### PR TITLE
Fix for DR-003136 mixed case paths dont work

### DIFF
--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -313,7 +313,7 @@ def locate_dir(instrument, mode=None):
         config.check_crds_ref_subdir_mode(mode)
     crds_refpath = config.get_crds_refpath("jwst")
     if mode == "instrument":   # use simple names inside CRDS cache.
-        rootdir = os.path.join(crds_refpath, instrument)
+        rootdir = os.path.join(crds_refpath, instrument.lower())
         if not os.path.exists(rootdir):
             utils.ensure_dir_exists(rootdir + "/locate_dir.fits")
     elif mode == "flat":    # use original flat cache structure,  all instruments in same directory.


### PR DESCRIPTION
CRDS was generating files paths with uppercase instrument names for the default "instrument" organization for JWST.    Modified to squash instrument name to lower case.