### PR TITLE
crds.certify changes to constrain SUBARRAY=GENERIC disallowed for all DARK types

### DIFF
--- a/crds/jwst/specs/all_dark.spec
+++ b/crds/jwst/specs/all_dark.spec
@@ -1,0 +1,10 @@
+{
+    'observatory' : 'JWST',
+    'instrument' : 'ALL',
+    'filekind' : 'DARK',
+    'filetype' : 'DARK',
+    'suffix' : 'DARK',
+    'text_descr' : 'Dark files for all instruments.',
+    'ld_tpn': 'all_dark_ld.tpn',  # identical
+    'tpn': 'all_dark.tpn',
+}

--- a/crds/jwst/tpns/all_dark.tpn
+++ b/crds/jwst/tpns/all_dark.tpn
@@ -1,0 +1,10 @@
+# Template file used by certify to check reference files
+# Some fields may be abbreviated to their first character:
+#
+# keytype = (Header|Group|Column)
+# datatype = (Integer|Real|Logical|Double|Character)
+# presence = (Optional|Required)
+#
+# NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
+#----------------------------------------------------------
+META.SUBARRAY.NAME          H   C   R                   NOT_GENERIC

--- a/crds/jwst/tpns/all_dark_ld.tpn
+++ b/crds/jwst/tpns/all_dark_ld.tpn
@@ -1,0 +1,10 @@
+# Template file used by certify to check reference files
+# Some fields may be abbreviated to their first character:
+#
+# keytype = (Header|Group|Column)
+# datatype = (Integer|Real|Logical|Double|Character)
+# presence = (Optional|Required)
+#
+# NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
+#----------------------------------------------------------
+META.SUBARRAY.NAME          H   C   R                   NOT_GENERIC

--- a/crds/reftypes.py
+++ b/crds/reftypes.py
@@ -218,6 +218,7 @@ class TypeParameters(object):
                 log.verbose_warning("Can't find TPN key for", (filename, instrument, filekind), ":", str(exc), verbosity=75)
         append_tpn_level(results, "all", "all")
         append_tpn_level(results, instrument, "all")
+        append_tpn_level(results, "all", filekind)
         append_tpn_level(results, instrument, filekind)
         return results
 


### PR DESCRIPTION
Added capability to define constraints across all instruments for a filekind via one .tpn
Added capability to define NOT_ values which are disallowed..
Defined JWST SUBARRAY=GENERIC as disallowed for all DARKs.