### PR TITLE
Testing consolidation

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -23,7 +23,7 @@ rules, reference files, and datasets for testing CRDS.
 Now,  setting up CRDS to run the built-in unit tests can be accomplished as follows:
 
 % git checkout https://github.com/spacetelescope.git CRDS
-% svn co https://aeon.stsci.edu/ssb/svn/crds/branches/crds_testing_cache crds_testing_cache
+% svn co https://aeon.stsci.edu/ssb/svn/crds/branches/crds_testing_cache crds-testing-cache
 % cd CRDS
 % source envs/hst-crds-dev.csh
 % ./runtests

--- a/TESTING
+++ b/TESTING
@@ -22,8 +22,8 @@ rules, reference files, and datasets for testing CRDS.
 
 Now,  setting up CRDS to run the built-in unit tests can be accomplished as follows:
 
-% svn co https://aeon.stsci.edu/ssb/svn/crds/trunk  CRDS
-% svn co https://aeon.stsci.edu/ssb/svn/crds/branches/crds_cache_test crds_cache_test
+% git checkout https://github.com/spacetelescope.git CRDS
+% svn co https://aeon.stsci.edu/ssb/svn/crds/branches/crds_testing_cache crds_testing_cache
 % cd CRDS
 % source envs/hst-crds-dev.csh
 % ./runtests
@@ -35,7 +35,7 @@ present in the subversion checkout and installable by adding
 
 The above configures CRDS to run the built-in unit tests using 3 file sources:
 
-- ^/branches/crds_cache_test
+- ^/branches/crds_testing_cache
 - ^/trunk/crds/test/data
 - /grp/crds/cache
 
@@ -45,7 +45,7 @@ both JWST and HST.
 
 CRDS/crds/test/data is normally omitted from source code distributions.
 
-^/branches/crds_cache_test is a modified version of
+^/branches/crds_testing_cache is a modified version of
 ^/branches/crds_cache_archive altered to support unit testing requirements.
 
 Unit tests requiring a server are run against https://hst-crds-dev.stsci.edu

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -7,7 +7,7 @@ import json
 import shutil
 
 from crds.bestrefs import BestrefsScript
-from crds.tests import CRDSTestCase, test_config, CRDS_CACHE_TEST
+from crds.tests import CRDSTestCase, test_config, CRDS_TESTING_CACHE
 
 """
 Bestrefs has a number of command line parameters which make it operate in different modes. 
@@ -255,7 +255,7 @@ class TestBestrefs(CRDSTestCase):
     
     script_class = BestrefsScript
     server_url = "https://hst-crds-dev.stsci.edu"
-    cache = CRDS_CACHE_TEST
+    cache = CRDS_TESTING_CACHE
 
     def test_bestrefs_affected_datasets(self):
         self.run_script("crds.bestrefs --affected-datasets --old-context hst_0314.pmap --new-context hst_0315.pmap --datasets-since 2015-01-01",

--- a/crds/tests/test_config.py
+++ b/crds/tests/test_config.py
@@ -19,11 +19,11 @@ from crds import log, utils, client, config
 HERE = os.path.abspath(os.path.dirname(__file__) or ".")
 
 CRDS_DIR = os.path.abspath(os.path.dirname(crds.__file__))
-CRDS_CACHE_TEST = os.environ.get("CRDS_CACHE_TEST", "no-test-cache-defined-see-TESTING")
+CRDS_TESTING_CACHE = os.environ.get("CRDS_TESTING_CACHE", "no-test-cache-defined-see-TESTING")
 CRDS_SHARED_GROUP_CACHE = "/grp/crds/cache"
 CRDS_FORWARDED_URL = "https://localhost:8001/"
 TEST_DATA = os.path.join(HERE, 'data')
-TEST_MAPPATH = os.path.join(CRDS_CACHE_TEST, "mappings")
+TEST_MAPPATH = os.path.join(CRDS_TESTING_CACHE, "mappings")
 TEST_TEMP_DIR = tempfile.mkdtemp(prefix='crds-test-')
 
 # ==============================================================================

--- a/crds/tests/test_diff.py
+++ b/crds/tests/test_diff.py
@@ -388,7 +388,7 @@ def dt_diff_print_affected_modes():
 
 def dt_diff_print_all_new_files():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_CACHE_TEST)
+    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
     >>> DiffScript("crds.diff data/hst_0001.pmap data/hst_0008.pmap --print-all-new-files --sync-files --include-header-diffs --hide-boring")()
     CRDS - INFO - 0 errors
     CRDS - INFO - 0 warnings

--- a/crds/tests/test_rmap.py
+++ b/crds/tests/test_rmap.py
@@ -768,7 +768,7 @@ selector = Match({
         p.todict()
 
     def test_rmap_match_tjson(self):
-        os.environ["CRDS_PATH"] = tests.CRDS_CACHE_TEST
+        os.environ["CRDS_PATH"] = tests.CRDS_TESTING_CACHE
         p = rmap.get_cached_mapping("jwst.pmap")
         p.tojson()
 

--- a/crds/tests/test_uses.py
+++ b/crds/tests/test_uses.py
@@ -21,7 +21,7 @@ HERE = os.path.dirname(__file__) or "."
 
 def dt_uses_finaall_mappings_using_reference():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_CACHE_TEST)
+    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files v2e20129l_flat.fits")()
     hst.pmap
     hst_0001.pmap
@@ -41,7 +41,7 @@ def dt_uses_finaall_mappings_using_reference():
 
 def dt_uses_rmaps():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_CACHE_TEST)
+    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files hst_cos_flatfile.rmap hst_acs_darkfile.rmap --include-used")()
     hst_cos_flatfile.rmap hst.pmap
     hst_cos_flatfile.rmap hst_0001.pmap
@@ -73,7 +73,7 @@ def dt_uses_rmaps():
     
 def dt_uses_imap():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_CACHE_TEST)
+    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files hst_cos.imap")()
     hst.pmap
     hst_0001.pmap
@@ -88,7 +88,7 @@ def dt_uses_print_datasets():
     This test/function is quite slow since it surveys the catalog for recorded uses of the
     specified file.  Too slow for routine unit tests.
     
-    >>> old_state = test_config.setup(cache=tests.CRDS_CACHE_TEST)
+    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
 
     >> uses.UsesScript("crds.uses --files n3o1022ij_drk.fits --print-datasets --hst")()
     J8BA0HRPQ:J8BA0HRPQ

--- a/crds/tobs/tests.py
+++ b/crds/tobs/tests.py
@@ -15,7 +15,7 @@ import crds
 # =============================================================================
 
 class TobsTestCase(tests.CRDSTestCase):
-    cache = tests.CRDS_CACHE_TEST
+    cache = tests.CRDS_TESTING_CACHE
     clear_existing = False
     server_url = "https://tobs-serverless-mode.stsci.edu"
 

--- a/runtests
+++ b/runtests
@@ -8,10 +8,10 @@ from crds import config, log
 os.chdir(os.path.dirname(sys.argv[0]) or ".")
 topdir = os.getcwd()
 
-# Unlike historical CRDS with builtin cache,  test cache is now a separate 
-# subversion checkout from ^/branches/crds_cache_test to ../crds_cache_test.
+# Unlike historical CRDS with builtin cache,  test cache is now a separate dedicated entity
+# which contains mutated but otherwise same named mutated files.
 # os.environ["CRDS_MAPPATH"] = os.path.join(os.getcwd(), "..", "crds_cache_archive", "mappings")
-os.environ["CRDS_CACHE_TEST"] = os.path.join(os.getcwd(), "..", "crds_cache_test")
+os.environ["CRDS_TESTING_CACHE"] = os.path.join(os.getcwd(), "..", "crds-testing-cache")
 
 os.system("python -m crds.sync --all --stats --log-time")
 os.system("./install")


### PR DESCRIPTION
This is the beginning of testing consolidation that will attempt to reduce custom test caches and dependence on /grp/crds/cache for unit testing with the hope of using Travis CI for the CRDS client library. This change set merely renames the custom testing support cache so that it doesn't have an identical name to the user cache nominally used with the TEST servers.