### PR TITLE
Auto pickling 2

### DIFF
--- a/crds/__init__.py
+++ b/crds/__init__.py
@@ -31,7 +31,7 @@ from . import config   # module
 from .exceptions import *
 
 from crds.client import get_default_context
-from .heavy_client import getreferences, getrecommendations, get_symbolic_mapping
+from .heavy_client import getreferences, getrecommendations, get_symbolic_mapping, get_pickled_mapping
 from .rmap import get_cached_mapping, locate_mapping, locate_file, asmapping
 
 # ============================================================================

--- a/crds/bestrefs.py
+++ b/crds/bestrefs.py
@@ -620,8 +620,8 @@ and debug output.
         Returns { instrument: EXPTIME, ... }
         """
         datasets_since = {}
-        self.oldctx = rmap.get_cached_mapping(self.old_context)
-        self.newctx = rmap.get_cached_mapping(self.new_context)
+        self.oldctx = heavy_client.get_symbolic_mapping(self.old_context)
+        self.newctx = heavy_client.get_symbolic_mapping(self.new_context)
         for instrument in self.oldctx.selections:
             old_imap = self.oldctx.get_imap(instrument)
             new_imap = self.newctx.get_imap(instrument)

--- a/crds/bestrefs.py
+++ b/crds/bestrefs.py
@@ -620,8 +620,8 @@ and debug output.
         Returns { instrument: EXPTIME, ... }
         """
         datasets_since = {}
-        self.oldctx = heavy_client.get_symbolic_mapping(self.old_context)
-        self.newctx = heavy_client.get_symbolic_mapping(self.new_context)
+        self.oldctx = crds.get_pickled_mapping(self.old_context)
+        self.newctx = crds.get_pickled_mapping(self.new_context)
         for instrument in self.oldctx.selections:
             old_imap = self.oldctx.get_imap(instrument)
             new_imap = self.newctx.get_imap(instrument)

--- a/crds/certify.py
+++ b/crds/certify.py
@@ -534,7 +534,7 @@ class Certifier(object):
 
     def get_corresponding_rmap(self):
         """Return the rmap which corresponds to self.filename under self.context."""
-        pmap = rmap.get_cached_mapping(self.context, ignore_checksum="warn")
+        pmap = crds.get_pickled_mapping(self.context, ignore_checksum="warn")
         instrument, filekind = pmap.locate.get_file_properties(self.filename)
         return pmap.get_imap(instrument).get_rmap(filekind)
 
@@ -1018,7 +1018,7 @@ def find_old_mapping(comparison_context, new_mapping):
     trial mappings.
     """
     if comparison_context:
-        comparison_mapping = rmap.get_cached_mapping(comparison_context)
+        comparison_mapping = crds.get_pickled_mapping(comparison_context)
         old_mapping = comparison_mapping.get_equivalent_mapping(new_mapping)
         return old_mapping
     else:
@@ -1288,7 +1288,7 @@ For more information on the checks being performed,  use --verbose or --verbosit
             more_files = {file_}
             if rmap.is_mapping(file_):
                 with self.error_on_exception(file_, "Problem loading submappings of", repr(file_)):
-                    mapping = rmap.get_cached_mapping(file_, ignore_checksum="warn")
+                    mapping = crds.get_pickled_mapping(file_, ignore_checksum="warn")
                     more_files = {rmap.locate_mapping(name) for name in mapping.mapping_names()}
                     more_files = (more_files - {rmap.locate_mapping(mapping.basename)}) | {file_}
             closure_files |= more_files

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -18,6 +18,7 @@ from .proxy import CheckingProxy
 
 # heavy versions of core CRDS modules defined in one place, client minimally
 # dependent on core for configuration, logging, and  file path management.
+import crds
 from crds import utils, log, config
 from crds.client import proxy
 from crds.log import srepr
@@ -514,8 +515,7 @@ class FileCacher(object):
         elif "hst" in self.pipeline_context:
             observatory = "hst"
         else:
-            import crds.rmap
-            observatory = crds.rmap.get_cached_mapping(self.pipeline_context).observatory
+            observatory = crds.get_pickled_mapping(self.pipeline_context).observatory
         return observatory
 
     def locate(self, name):
@@ -807,8 +807,7 @@ def get_minimum_header(context, dataset, ignore_cache=False):
     """Given a `dataset` and a `context`,  extract relevant header 
     information from the `dataset`.
     """
-    import crds.rmap
     dump_mappings(context, ignore_cache=ignore_cache)
-    ctx = crds.get_cached_mapping(context)
+    ctx = crds.get_pickled_mapping(context)
     return ctx.get_minimum_header(dataset)
 

--- a/crds/cmdline.py
+++ b/crds/cmdline.py
@@ -684,13 +684,13 @@ class ContextsScript(Script):
                     self.dump_files(pmaps[-1], files)
             for context in self.contexts:
                 with log.warn_on_exception("Failed loading context", repr(context)):
-                    pmap = rmap.get_cached_mapping(context)
+                    pmap = crds.get_pickled_mapping(context)
                     useable_contexts.append(context)
         else:
             for context in self.contexts:
                 with log.warn_on_exception("Failed listing mappings for", repr(context)):
                     try:
-                        pmap = rmap.get_cached_mapping(context)
+                        pmap = crds.get_pickled_mapping(context)
                         files |= set(pmap.mapping_names())
                     except Exception:
                         files |= set(api.get_mapping_names(context))
@@ -712,7 +712,7 @@ class ContextsScript(Script):
         files = set()
         for context in self.contexts:
             try:
-                pmap = rmap.get_cached_mapping(context)
+                pmap = crds.get_pickled_mapping(context)
                 files |= set(pmap.reference_names())
                 log.verbose("Determined references from cached mapping", repr(context))
             except Exception:  # only ask the server if loading context fails

--- a/crds/config.py
+++ b/crds/config.py
@@ -932,7 +932,7 @@ def is_mapping(mapping):
     """Return True IFF `mapping` has an extension indicating a CRDS mapping file."""
     return isinstance(mapping, python23.string_types) and mapping.endswith((".pmap", ".imap", ".rmap"))
 
-def is_crds_mapping(mapping):
+def is_simple_crds_mapping(mapping):
     """Return True IFF `mapping` implicitly or explicitly exists in the CRDS cache.
 
     Return False for ad hoc mappings outside the CRDS Cache.   
@@ -940,13 +940,49 @@ def is_crds_mapping(mapping):
     Nominally this function is one determinant of whether or not a mapping is
     picklable at the level of the overall CRDS runtime system.
 
-    >>> is_crds_mapping(locate_mapping("hst.pmap"))
+    >>> is_simple_crds_mapping(locate_mapping("hst.pmap"))
     True
 
-    >>> is_crds_mapping("tests/data/hst.pmap")
+    is_simple_crds_mapping() is not a full guarantee that a mapping actually exists in
+    CRDS,  merely a guarantee that if it did it would be located implicitly in
+    the CRDS cache and has a basic name format which is not a date based context
+    specifier.
+    
+    >>> is_simple_crds_mapping("hst_foo.pmap")
+    True
+
+    >>> is_simple_crds_mapping(locate_mapping("hst.fits"))
+    False
+
+    >>> is_simple_crds_mapping("tests/data/hst.pmap")
+    False
+
+    >>> is_simple_crds_mapping("hst-2040-01-29T12:00:00")
+    False
+
+    >>> is_simple_crds_mapping("hst-acs-2040-01-29T12:00:00")
+    False
+
+    >>> is_simple_crds_mapping("hst-acs-darkfile-2040-01-29T12:00:00")
+    False
+    
+    >>> is_simple_crds_mapping("2040-01-29T12:00:00")
+    False
+    
+    >>> is_simple_crds_mapping("hst-edit")
+    False
+    
+    >>> is_simple_crds_mapping("hst-cos-deadtab-edit")
+    False
+    
+    >>> is_simple_crds_mapping("jwst-operational")
+    False
+    
+    >>> is_simple_crds_mapping("hst-foo")
     False
     """
-    return (is_mapping(mapping) and (locate_mapping(mapping) == locate_mapping(os.path.basename(mapping))))
+    basename = os.path.basename(mapping)
+    return is_valid_mapping_name(basename) and (locate_mapping(mapping) == locate_mapping(basename))
 
 def is_valid_mapping_name(mapping):
     """Return True IFF `mapping` has a CRDS-style root name and a mapping extension."""
@@ -1134,3 +1170,5 @@ def test():
     from . import config
     return doctest.testmod(config)
 
+if __name__ ==  "__main__":
+    print(test())

--- a/crds/config.py
+++ b/crds/config.py
@@ -387,10 +387,29 @@ def get_crds_refpath(observatory):
     return _std_cache_path(observatory, "CRDS_REFPATH", "references")
 
 def locate_config(cfg, observatory):
-    """Return the absolute path where reference `ref` should be located."""
+    """Return the absolute path where reference `cfg` should be located."""
     if os.path.dirname(cfg):
         return cfg
     return os.path.join(get_crds_cfgpath(observatory), cfg)
+
+# -------------------------------------------------------------------------------------
+
+def get_crds_picklepath(observatory):
+    return _std_cache_path(observatory, "CRDS_PICKLEPATH", "pickles")
+
+def locate_pickle(mapping, observatory=None):
+    """Return the absolute path where reference `ref` should be located."""
+    if os.path.dirname(mapping):
+        return mapping
+    if observatory is None:
+        observatory = mapping_to_observatory(mapping)
+    return os.path.join(get_crds_picklepath(observatory), mapping)
+
+USE_PICKLED_CONTEXTS = BooleanConfigItem("CRDS_USE_PICKLED_CONTEXTS", True,
+    "When True,  CRDS contexts should be loaded from a pickled version if possible.")
+
+AUTO_PICKLE_CONTEXTS = BooleanConfigItem("CRDS_AUTO_PICKLE_CONTEXTS", True,
+    "When True, CRDS contexts should be automatically pickled and cached after loading.")
 
 # -------------------------------------------------------------------------------------
 
@@ -912,6 +931,12 @@ MAPPING_RE = re.compile(complete_re(MAPPING_RE_STR))
 def is_mapping(mapping):
     """Return True IFF `mapping` has an extension indicating a CRDS mapping file."""
     return isinstance(mapping, python23.string_types) and mapping.endswith((".pmap", ".imap", ".rmap"))
+
+def is_crds_mapping(mapping):
+    """Return True IFF `mapping` implicitly or explicitly exists in the CRDS cache.
+    Return False for ad hoc mappings outside the CRDS Cache.
+    """
+    return (is_mapping(mapping) and (locate_mapping(mapping) == locate_mapping(os.path.basename(mapping))))
 
 def is_valid_mapping_name(mapping):
     """Return True IFF `mapping` has a CRDS-style root name and a mapping extension."""

--- a/crds/config.py
+++ b/crds/config.py
@@ -405,10 +405,10 @@ def locate_pickle(mapping, observatory=None):
         observatory = mapping_to_observatory(mapping)
     return os.path.join(get_crds_picklepath(observatory), mapping)
 
-USE_PICKLED_CONTEXTS = BooleanConfigItem("CRDS_USE_PICKLED_CONTEXTS", True,
+USE_PICKLED_CONTEXTS = BooleanConfigItem("CRDS_USE_PICKLED_CONTEXTS", False,
     "When True,  CRDS contexts should be loaded from a pickled version if possible.")
 
-AUTO_PICKLE_CONTEXTS = BooleanConfigItem("CRDS_AUTO_PICKLE_CONTEXTS", True,
+AUTO_PICKLE_CONTEXTS = BooleanConfigItem("CRDS_AUTO_PICKLE_CONTEXTS", False,
     "When True, CRDS contexts should be automatically pickled and cached after loading.")
 
 # -------------------------------------------------------------------------------------

--- a/crds/config.py
+++ b/crds/config.py
@@ -934,7 +934,17 @@ def is_mapping(mapping):
 
 def is_crds_mapping(mapping):
     """Return True IFF `mapping` implicitly or explicitly exists in the CRDS cache.
-    Return False for ad hoc mappings outside the CRDS Cache.
+
+    Return False for ad hoc mappings outside the CRDS Cache.   
+
+    Nominally this function is one determinant of whether or not a mapping is
+    picklable at the level of the overall CRDS runtime system.
+
+    >>> is_crds_mapping(locate_mapping("hst.pmap"))
+    True
+
+    >>> is_crds_mapping("tests/data/hst.pmap")
+    False
     """
     return (is_mapping(mapping) and (locate_mapping(mapping) == locate_mapping(os.path.basename(mapping))))
 

--- a/crds/diff.py
+++ b/crds/diff.py
@@ -17,6 +17,7 @@ import json
 import pprint
 import re
 
+import crds
 from crds import rmap, log, pysh, cmdline, utils, rowdiff, config, sync
 from crds import naming
 
@@ -56,7 +57,7 @@ def get_affected(old_pmap, new_pmap, *args, **keys):
     
     Returns { affected_instrument : { affected_type, ... } }
     """
-    observatory = keys.pop("observatory", rmap.get_cached_mapping(old_pmap).observatory)
+    observatory = keys.pop("observatory", crds.get_pickled_mapping(old_pmap).observatory)
     differ = MappingDifferencer(observatory, old_pmap, new_pmap, *args, **keys)
     return differ.get_affected()
 
@@ -653,7 +654,7 @@ def get_updated_files(context1, context2):
     extension1 = os.path.splitext(context1)[1]
     extension2 = os.path.splitext(context2)[1]
     assert extension1 == extension2, "Only compare mappings of same type/extension."
-    old_map = rmap.get_cached_mapping(context1)
+    old_map = crds.get_pickled_mapping(context1)
     old_files = set(old_map.mapping_names() + old_map.reference_names())
     all_mappings = rmap.list_mappings("*"+extension1, old_map.observatory)
     updated = set()
@@ -661,7 +662,7 @@ def get_updated_files(context1, context2):
     for new in all_mappings:
         new = os.path.basename(new)
         if context1 < new <= context2:
-            new_map = rmap.get_cached_mapping(new)
+            new_map = crds.get_pickled_mapping(new)
             updated |= set(new_map.mapping_names() + new_map.reference_names())
     return sorted(list(updated - old_files))
 
@@ -870,8 +871,8 @@ Mutually Exclusive Modes
         if not rmap.is_mapping(self.old_file) or not rmap.is_mapping(self.new_file):
             log.error("--print-new-files really only works for mapping differences.")
             return -1
-        old = rmap.get_cached_mapping(self.old_file)
-        new = rmap.get_cached_mapping(self.new_file)
+        old = crds.get_pickled_mapping(self.old_file)
+        new = crds.get_pickled_mapping(self.new_file)
         old_mappings = set(old.mapping_names())
         new_mappings = set(new.mapping_names())
         old_references = set(old.reference_names())

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -631,7 +631,6 @@ def save_pickled_mapping(mapping, loaded):
     with log.verbose_warning_on_exception("Failed saving pickle for", repr(mapping), "to", repr(pickle_file)):
         pickled = python23.pickle.dumps(loaded)
         cache_atomic_write(pickle_file, pickled, "CONTEXT PICKLE")
-        log.verbose("Saved pickled context for", repr(mapping), "to", repr(pickle_file))
 
 # =============================================================================
 

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -590,15 +590,14 @@ def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=Non
 def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, cached=True):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
     system optimization to prevent 100+ file reads.   
-
-    `mapping` must be a literal CRDS mapping name, not a date-based context
-    specification.
     """
+    assert config.is_mapping(mapping), \
+        "`mapping` must be a literal CRDS mapping name, not a date-based context specification."
     if use_pickles is None:
         use_pickles = config.USE_PICKLED_CONTEXTS
     if save_pickles is None:
         save_pickles = config.AUTO_PICKLE_CONTEXTS
-    if use_pickles and config.is_crds_mapping(mapping):
+    if use_pickles and config.is_simple_crds_mapping(mapping):
         try:
             loaded = load_pickled_mapping(mapping)
         except Exception:

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -551,7 +551,6 @@ def list_mappings(observatory, glob_pattern):
     info = get_config_info(observatory)
     return sorted([mapping for mapping in info.mappings if fnmatch.fnmatch(mapping, glob_pattern)])
 
-@utils.cached
 def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=None, save_pickles=None):
     """Return a loaded mapping object,  first translating any date based or
     named contexts into a more primitive serial number only mapping name.
@@ -587,6 +586,7 @@ def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=Non
 
 # ============================================================================
 
+@utils.cached
 def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, cached=True):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
     system optimization to prevent 100+ file reads.   

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -551,7 +551,8 @@ def list_mappings(observatory, glob_pattern):
     info = get_config_info(observatory)
     return sorted([mapping for mapping in info.mappings if fnmatch.fnmatch(mapping, glob_pattern)])
 
-def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=None, save_pickles=None):
+def get_symbolic_mapping(
+    mapping, observatory=None, cached=True, use_pickles=None, save_pickles=None, **keys):
     """Return a loaded mapping object,  first translating any date based or
     named contexts into a more primitive serial number only mapping name.
 
@@ -582,12 +583,13 @@ def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=Non
     else:
         info = get_config_info(observatory)
         abs_mapping = translate_date_based_context(info, mapping)
-    return get_pickled_mapping(abs_mapping, cached=cached, use_pickles=use_pickles, save_pickles=save_pickles)
+    return get_pickled_mapping(
+        abs_mapping, cached=cached, use_pickles=use_pickles, save_pickles=save_pickles, **keys)
 
 # ============================================================================
 
 @utils.cached
-def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, cached=True):
+def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, **keys):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
     system optimization to prevent 100+ file reads.   
     """
@@ -601,11 +603,11 @@ def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, cached=Tru
         try:
             loaded = load_pickled_mapping(mapping)
         except Exception:
-            loaded = rmap.asmapping(mapping, cached=cached)
+            loaded = rmap.asmapping(mapping, **keys)
             if save_pickles:
                 save_pickled_mapping(mapping, loaded)
     else:
-        loaded = rmap.asmapping(mapping, cached=cached)
+        loaded = rmap.asmapping(mapping, **keys)
     return loaded
 
 def load_pickled_mapping(mapping):

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -627,6 +627,7 @@ def save_pickled_mapping(mapping, loaded):
     pickle_file = config.locate_pickle(mapping + ".pkl")
     if not utils.is_writable(pickle_file):  # Don't even bother pickling
         log.verbose("Pickle file", repr(pickle_file), "is not writable,  skipping pickle save.")
+        return
     with log.verbose_warning_on_exception("Failed saving pickle for", repr(mapping), "to", repr(pickle_file)):
         pickled = python23.pickle.dumps(loaded)
         cache_atomic_write(pickle_file, pickled, "CONTEXT PICKLE")

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -31,7 +31,6 @@ from __future__ import division
 from __future__ import absolute_import
 import os
 import pprint
-import glob
 import ast
 import traceback
 import uuid
@@ -42,6 +41,7 @@ from crds.client import api
 from crds.log import srepr
 from crds.exceptions import CrdsError, CrdsBadRulesError, CrdsBadReferenceError, CrdsNetworkError
 from crds import python23
+# import crds  forward
 
 __all__ = ["getreferences", "getrecommendations"]
 
@@ -232,7 +232,7 @@ def mapping_names(context):
     else consult server.
     """
     try:
-        mapping = get_pickled_mapping(context)
+        mapping = get_symbolic_mapping(context)
         contained_mappings = mapping.mapping_names()
     except IOError:
         contained_mappings = api.get_mapping_names(context)
@@ -296,7 +296,7 @@ def local_bestrefs(parameters, reftypes, context, ignore_cache=False):
         if ignore_cache:
             raise IOError("explicitly ignoring cache.")
         # Finally do the best refs computation using pmap methods from local code.
-        return rmap.get_best_references(context, parameters, reftypes)
+        return hv_best_references(context, parameters, reftypes)
     except IOError as exc:
         log.verbose("Caching mapping files for context", srepr(context))
         try:
@@ -304,7 +304,23 @@ def local_bestrefs(parameters, reftypes, context, ignore_cache=False):
         except CrdsError as exc:
             traceback.print_exc()
             raise CrdsNetworkError("Failed caching mapping files: " + str(exc))
-        return rmap.get_best_references(context, parameters, reftypes)
+        return hv_best_references(context, parameters, reftypes)
+
+# =============================================================================
+
+def hv_best_references(context_file, header, include=None, condition=True):
+    """Compute the best references for `header` for the given CRDS
+    `context_file`.   This is a local computation using local rmaps and
+    CPU resources.   If `include` is None,  return results for all
+    filekinds appropriate to `header`,  otherwise return only those
+    filekinds listed in `include`.
+    """
+    ctx = get_symbolic_mapping(context_file, cached=True)
+    minheader = ctx.minimize_header(header)
+    log.verbose("Bestrefs header:\n", log.PP(minheader))
+    if condition:
+        minheader = utils.condition_header(minheader)
+    return ctx.get_best_references(minheader, include=include)
 
 # ============================================================================
 
@@ -374,6 +390,11 @@ def translate_date_based_context(info, context):
 
 class ConfigInfo(utils.Struct):
     """Encapsulate CRDS cache config info."""
+    def __init__(self, *args, **keys):
+        self.status = None
+        self.connected = None
+        super(ConfigInfo, self).__init__(*args, **keys)
+
     @property
     def bad_files_set(self):
         """Return the set of references and mappings which are considered scientifically invalid."""
@@ -469,7 +490,8 @@ def cache_atomic_write(replace_path, contents, fail_warning):
             log.verbose("CACHE updating:", repr(replace_path))
             utils.ensure_dir_exists(replace_path)
             temp_path = os.path.join(os.path.dirname(replace_path), str(uuid.uuid4()))
-            with open(temp_path, "w+") as file_:
+            mode = "w+" if isinstance(contents, python23.string_types) else "wb+"
+            with open(temp_path, mode) as file_:
                 file_.write(contents)
             os.rename(temp_path, replace_path)
         except Exception as exc:
@@ -513,7 +535,7 @@ def get_context_parkeys(context, instrument):
     Returns [ matching_parameter, ... ]
     """
     try:
-        parkeys = get_pickled_mapping(context).get_required_parkeys()
+        parkeys = get_symbolic_mapping(context).get_required_parkeys()
     except Exception:
         parkeys = api.get_required_parkeys(context)
     if isinstance(parkeys, (list,tuple)):
@@ -529,11 +551,12 @@ def list_mappings(observatory, glob_pattern):
     info = get_config_info(observatory)
     return sorted([mapping for mapping in info.mappings if fnmatch.fnmatch(mapping, glob_pattern)])
 
+@utils.cached
 def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=None, save_pickles=None):
     """Return a loaded mapping object,  first translating any date based or
     named contexts into a more primitive serial number only mapping name.
 
-    This is basically the symbolic form of rmap.asmapping().  Since the default
+    This is basically the symbolic form of get_pickled_mapping().  Since the default
     setting of 'cached' is True,  it performs much like crds.get_cached_mapping()
     but also accepts abstract or date-based names.
     
@@ -552,24 +575,30 @@ def get_symbolic_mapping(mapping, observatory=None, cached=True, use_pickles=Non
     >> get_symbolic_mapping("jwst-miri-flat-2015-01-01T00:20:05")
     ReferenceMapping('jwst_miri_flat_0012.rmap')
 
-    WARNING:  this is a high level feature which *requires* a server connection
+    WARNING: this is a high level feature which *requires* a server connection
     to interpret the symbolic name into a primitive name.
     """
-    abs_mapping = api.get_context_by_date(mapping, observatory)
+    if observatory is None:
+        abs_mapping = mapping
+    else:
+        info = get_config_info(observatory)
+        abs_mapping = translate_date_based_context(info, mapping)
     return get_pickled_mapping(abs_mapping, cached=cached, use_pickles=use_pickles, save_pickles=save_pickles)
 
 # ============================================================================
 
-@utils.cached
-def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, observatory=None, cached=True):
+def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, cached=True):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
-    system optimization to prevent 100+ file reads.
+    system optimization to prevent 100+ file reads.   
+
+    `mapping` must be a literal CRDS mapping name, not a date-based context
+    specification.
     """
     if use_pickles is None:
         use_pickles = config.USE_PICKLED_CONTEXTS
     if save_pickles is None:
         save_pickles = config.AUTO_PICKLE_CONTEXTS
-    if use_pickles:
+    if use_pickles and config.is_crds_mapping(mapping):
         try:
             loaded = load_pickled_mapping(mapping)
         except Exception:
@@ -598,8 +627,7 @@ def save_pickled_mapping(mapping, loaded):
     """Save live mapping `loaded` as a pickle under named based on `mapping` name."""
     pickle_file = config.locate_pickle(mapping + ".pkl")
     if not utils.is_writable(pickle_file):  # Don't even bother pickling
-        cache_atomic_write(pickle_file, None, "CONTEXT PICKLE")  # Issue warning from null contents
-        return
+        log.verbose("Pickle file", repr(pickle_file), "is not writable,  skipping pickle save.")
     with log.verbose_warning_on_exception("Failed saving pickle for", repr(mapping), "to", repr(pickle_file)):
         pickled = python23.pickle.dumps(loaded)
         cache_atomic_write(pickle_file, pickled, "CONTEXT PICKLE")

--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -20,6 +20,7 @@ import datetime
 import time
 
 # import crds.pysh as pysh
+import crds
 from crds import (log, rmap, data_file, config, utils, timestamp)
 from crds.exceptions import CrdsError
 from crds.hst import siname
@@ -252,7 +253,7 @@ def check_naming_consistency(checked_instrument=None, exhaustive_mapping_check=F
 
             for pmap_name in reversed(sorted(rmap.list_mappings("*.pmap", observatory="hst"))):
 
-                pmap = rmap.get_cached_mapping(pmap_name)
+                pmap = crds.get_pickled_mapping(pmap_name)
 
                 r = certify.find_governing_rmap(pmap_name, ref)
 

--- a/crds/jwst/schema.py
+++ b/crds/jwst/schema.py
@@ -17,6 +17,7 @@ import pprint
 
 # from jwst import datamodels   # deferred
 
+import crds
 from crds import rmap, log, utils, heavy_client
 from crds.certify import TpnInfo
 
@@ -55,7 +56,7 @@ def tpninfos_key_to_parkeys(tpn):
         return []
     with log.verbose_warning_on_exception("Can't determine parkeys for", repr(tpn)):
         _mode, context  = heavy_client.get_processing_mode("jwst")
-        p = rmap.get_cached_mapping(context)
+        p = crds.get_pickled_mapping(context)
         instrument, suffix = tpn.split(".")[0].split("_")[:2]
         filekind = p.locate.suffix_to_filekind(instrument, suffix)
         keys = p.get_imap(instrument).get_rmap(filekind).get_required_parkeys()

--- a/crds/list.py
+++ b/crds/list.py
@@ -227,7 +227,7 @@ class ListScript(cmdline.ContextsScript):
             with log.error_on_exception("Failed fetching dataset parameters with repect to", repr(context), 
                                         "for", repr(self.args.datasets)):
                 pars = api.get_dataset_headers_by_id(context, self.args.datasets)
-                pmap = rmap.get_cached_mapping(context)
+                pmap = crds.get_pickled_mapping(context)
                 for (dataset_id, header) in pars.items():
                     if isinstance(header, python23.string_types):
                         log.error("No header for", repr(dataset_id), ":", repr(header)) # header is reason

--- a/crds/matches.py
+++ b/crds/matches.py
@@ -17,7 +17,8 @@ import os.path
 from collections import defaultdict
 from pprint import pprint as pp
 
-from crds import rmap, log, cmdline, utils, config
+import crds
+from crds import log, cmdline, utils, config
 from crds.client import api
 from crds import python23
 
@@ -64,7 +65,7 @@ def find_full_match_paths(context, reffile):
        ('CCDCHIP', 'N/A')),
       (('DATE-OBS', '2006-07-04'), ('TIME-OBS', '11:32:35')))]
     """
-    ctx = rmap.asmapping(context, cached=True)
+    ctx = crds.get_pickled_mapping(context, cached=True)
     return ctx.file_matches(reffile)
 
 def find_match_paths_as_dict(context, reffile):
@@ -281,7 +282,7 @@ jwst_niriss_throughput_0008.fits :  META.INSTRUMENT.FILTER='F480M'
                 if self.args.condition_values:
                     header = utils.condition_header(header)
                 if self.args.minimize_headers:
-                    header = rmap.get_cached_mapping(context).minimize_header(header)
+                    header = crds.get_pickled_mapping(context).minimize_header(header)
                 if len(self.contexts) == 1:
                     print(dataset_id, ":", log.format_parameter_list(header))
                 else:
@@ -306,7 +307,7 @@ jwst_niriss_throughput_0008.fits :  META.INSTRUMENT.FILTER='F480M'
     def find_match_tuples(self, context, reffile):
         """Return the list of match representations for `reference` in `context`.   
         """
-        ctx = rmap.get_cached_mapping(context)
+        ctx = crds.get_pickled_mapping(context)
         matches = ctx.file_matches(reffile)
         result = []
         for path in matches:

--- a/crds/newcontext.py
+++ b/crds/newcontext.py
@@ -10,6 +10,7 @@ import shutil
 import re
 import glob
 
+import crds
 from crds import (rmap, utils, log, cmdline, refactor, config)
 
 # =============================================================================
@@ -21,7 +22,7 @@ def get_update_map(old_pipeline, updated_rmaps):
     of new rmap names, `updated_rmaps`,  return the mapping:
         { imap_name : [ updates_for_that_imap, ... ], ... }
     """
-    pctx = rmap.get_cached_mapping(old_pipeline)
+    pctx = crds.get_pickled_mapping(old_pipeline)
     updates = {}
     for update in sorted(updated_rmaps):
         instrument, _filekind = utils.get_file_properties(pctx.observatory, update)

--- a/crds/refactor2.py
+++ b/crds/refactor2.py
@@ -628,7 +628,7 @@ class RefactorScript(cmdline.Script):
         """Insert files specified by --references into the appropriate rmaps identified by --source-context."""
         self._setup_source_context()
         categorized = self.categorize_files(self.args.references)
-        pmap = crds.get_cached_mapping(self.source_context)
+        pmap = crds.get_pickled_mapping(self.source_context)
         self.args.rmaps = []
         for (instrument, filekind) in categorized:
             try:

--- a/crds/rmap.py
+++ b/crds/rmap.py
@@ -365,7 +365,7 @@ class Mapping(object):
     """Mapping is the abstract baseclass for PipelineContext,
     InstrumentContext, and ReferenceMapping.
     """
-    required_attrs = []
+    required_attrs = ["mapping", "parkey", "name", "derived_from"]
     
     # no precursor file if derived_from contains any of these.
     null_derivation_substrings = ("generated", "cloning", "by hand")
@@ -382,6 +382,7 @@ class Mapping(object):
             if name not in self.header:
                 raise crexc.MissingHeaderKeyError(
                     "Required header key " + repr(name) + " is missing.")
+
         self.mapping = self.header["mapping"]
         self.parkey = self.header["parkey"]
         self.extra_keys = tuple(self.header.get("extra_keys", ()))
@@ -846,8 +847,7 @@ class PipelineContext(ContextMapping):
     of a pipeline.
     """
     # Last required attribute is "difference type".
-    required_attrs = ["observatory", "mapping", "parkey",
-                      "name", "derived_from"]
+    required_attrs = ContextMapping.required_attrs + ["observatory"]
 
     def __init__(self, filename, header, selector, **keys):
         super(PipelineContext, self).__init__(filename, header, selector, **keys)

--- a/crds/rmap.py
+++ b/crds/rmap.py
@@ -407,12 +407,6 @@ class Mapping(object):
         """Return the source text of the Mapping."""
         return self.format()
 
-    def list_tree(self):
-        """Recursively print out the repr's() of all loaded mappings from `self` down."""
-        print(repr(self))
-        for mapping in self.selections.values():
-            mapping.list_tree()
-
     def __getattr__(self, attr):
         """Enable access to required header parameters as 'self.<parameter>'"""
         if "header" in self.__dict__ and attr in self.header:
@@ -1642,10 +1636,6 @@ class ReferenceMapping(Mapping):
             log.warning("Invalid comparison context", repr(self.name), "for", repr(mapping))
             return None
         return self
-
-    def list_tree(self):
-        """Print repr() of ReferenceMapping,  assumed to be terminal."""
-        print(repr(self))
 
 # ===================================================================
 

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -238,9 +238,13 @@ class SyncScript(cmdline.ContextsScript):
         self.add_argument("--organize-delete-junk", action="store_true",
                           help="When --organize'ing, delete obstructing files or directories CRDS discovers.")
         self.add_argument("--verify-context-change", action="store_true",
-                          help="When specified,  it's an error if the context does not update to something new.")
+                          help="Make it an error if the context does not update to something new.")
         self.add_argument("--push-context", metavar="KEY", type=str,
-                          help="When specified, push the name of the final cached context to the server for the pipeline identified by KEY.")
+                          help="Push the name of the final cached context to the server for the pipeline identified by KEY.")
+        self.add_argument("--clear-pickles", action="store_true",
+                          help="Remove the pickles for the sync'ed contexts from the CRDS cache. Can precede --save-pickles.")
+        self.add_argument("--save-pickles", action="store_true",
+                          help="Save pre-compiled versions of the sync'ed contexts in the CRDS cache.  Keep pre-existing pickles.")
 
     # ------------------------------------------------------------------------------------------
     
@@ -279,8 +283,15 @@ class SyncScript(cmdline.ContextsScript):
         else:
             log.error("Define --all, --contexts, --last, --range, --files, or --fetch-sqlite-db to sync.")
             sys.exit(-1)
+
         if self.args.check_files or self.args.check_sha1sum or self.args.repair_files:
             self.verify_files(verify_file_list)
+            
+        if self.args.clear_pickles or self.args.ignore_cache:
+            self.clear_pickles(self.contexts)
+        if self.args.save_pickles:
+            self.pickle_contexts(self.contexts)
+
         if self.args.verify_context_change:
             old_context = heavy_client.load_server_info(self.observatory).operational_context
         heavy_client.update_config_info(self.observatory)
@@ -288,11 +299,30 @@ class SyncScript(cmdline.ContextsScript):
             self.verify_context_change(old_context)
         if self.args.push_context:
             self.push_context()
+            
         self.report_stats()
         log.standard_status()
         return log.errors()
     # ------------------------------------------------------------------------------------------
+
+    def clear_pickles(self, contexts):
+        """Remove pickles specified by `contexts`."""
+        for context in contexts:
+            path = config.locate_pickle(context + ".pkl")
+            if os.path.exists(path):
+                utils.remove(path, self.observatory)
+
+    def pickle_contexts(self, contexts):
+        """Save pickled versions of `contexts` in the CRDS cache.
+
+        By default this will by-pass existing pickles if they successfully load.
+        """
+        for context in contexts:
+            with log.error_on_exception("Failed pickling", repr(context)):
+                heavy_client.get_pickled_mapping(context, use_pickles=True, save_pickles=True)
     
+    # ------------------------------------------------------------------------------------------
+
     @property
     def server_info(self):
         """Return the server_info dict from the CRDS server.  Do not call update_config_info() until sync complete."""

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -32,10 +32,10 @@ import re
 import shutil
 import glob
 
+import crds
 import crds.client.api as api
 from crds import (rmap, log, data_file, cmdline, utils, config, heavy_client)
 from crds.log import srepr
-import crds
 
 # ============================================================================
 
@@ -319,7 +319,7 @@ class SyncScript(cmdline.ContextsScript):
         """
         for context in contexts:
             with log.error_on_exception("Failed pickling", repr(context)):
-                heavy_client.get_pickled_mapping(context, use_pickles=True, save_pickles=True)
+                crds.get_pickled_mapping(context, use_pickles=True, save_pickles=True)
     
     # ------------------------------------------------------------------------------------------
 

--- a/crds/uses.py
+++ b/crds/uses.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import
 import sys
 import os.path
 
-from . import rmap, pysh, config, cmdline, utils, log
+import crds
+from . import pysh, config, cmdline, utils, log
 from crds.client import api
 
 def _clean_file_lines(files):
@@ -99,7 +100,7 @@ def datasets_using(references, context):
         if config.is_mapping(reference):
             log.error("Used file", repr(reference), "is a mapping file.  Must be a reference file.")
             continue
-        pmap = rmap.get_cached_mapping(context)
+        pmap = crds.get_pickled_mapping(context)
         instrument, filekind = utils.get_file_properties(pmap.observatory, reference)
         if instrument not in datasets:
             log.verbose("Dumping dataset info for", repr(instrument), "from", repr(api.get_crds_server()))

--- a/crds/utils.py
+++ b/crds/utils.py
@@ -569,9 +569,10 @@ def remove(rmpath, observatory):
             abs_config = os.path.abspath(config.get_crds_cfgpath(observatory))
             abs_references = os.path.abspath(config.get_crds_refpath(observatory))
             abs_mappings = os.path.abspath(config.get_crds_mappath(observatory))
-            assert abs_path.startswith((abs_cache, abs_config, abs_references, abs_mappings)), \
+            abs_pickles = os.path.abspath(config.get_crds_picklepath(observatory))
+            assert abs_path.startswith((abs_cache, abs_config, abs_references, abs_mappings, abs_pickles)), \
                 "remove() only works on files in CRDS cache. not: " + repr(rmpath)
-            log.verbose("Removing: ", repr(rmpath))
+            log.verbose("CACHE removing:", repr(rmpath))
             if os.path.isfile(rmpath):
                 os.remove(rmpath)
             else:


### PR DESCRIPTION
Added features for optionally using pickled CRDS contexts rather than loading .pmaps and all their descendant mappings.   Currently these default "off" but can be enabled by setting environment variables (as-is done on the CRDS servers).   Potentially these can benefit the archive pipeline client bestrefs as well by avoiding concurrent context loads from multiple processes of context trees.