### PR TITLE
Critical pickling bug-fix,  interior caching

### DIFF
--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -589,7 +589,7 @@ def get_symbolic_mapping(
 # ============================================================================
 
 @utils.cached
-def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, **keys):
+def get_pickled_mapping(mapping, cached=True, use_pickles=None, save_pickles=None, **keys):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
     system optimization to prevent 100+ file reads.   
     """
@@ -603,7 +603,7 @@ def get_pickled_mapping(mapping, use_pickles=None, save_pickles=None, **keys):
         try:
             loaded = load_pickled_mapping(mapping)
         except Exception:
-            loaded = rmap.asmapping(mapping, **keys)
+            loaded = rmap.asmapping(mapping, cached=cached, **keys)
             if save_pickles:
                 save_pickled_mapping(mapping, loaded)
     else:

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -607,7 +607,7 @@ def get_pickled_mapping(mapping, cached=True, use_pickles=None, save_pickles=Non
             if save_pickles:
                 save_pickled_mapping(mapping, loaded)
     else:
-        loaded = rmap.asmapping(mapping, **keys)
+        loaded = rmap.asmapping(mapping, cached=cached, **keys)
     return loaded
 
 def load_pickled_mapping(mapping):


### PR DESCRIPTION
Within the memory cached get_pickled_mapping() function,  the context load for the case with no pickle or failed pickles must use memory caching so that they're incremental during iterations over all contexts.  Unlike get_pickled_mapping() which memory caches only at the top level,  get_cached_mapping() (or asmapping with cached=True) caches each loaded sub-mapping as well;  this is critical to prevent re-loads when iterating over all contexts.


