### PR TITLE
Removed .tpn value restrictions on JWST all_dark NFRAMES and GROUPGAP

### DIFF
--- a/crds/jwst/tpns/all_dark.tpn
+++ b/crds/jwst/tpns/all_dark.tpn
@@ -8,6 +8,6 @@
 # NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
 #----------------------------------------------------------
 META.SUBARRAY.NAME          H   C   R   NOT_GENERIC
-META.EXPOSURE.NFRAMES       H   I   R   1                
-META.EXPOSURE.GROUPGAP      H   I   R   0
+META.EXPOSURE.NFRAMES       H   I   R  
+META.EXPOSURE.GROUPGAP      H   I   R   
 META.EXPOSURE.NGROUPS       H   I   R                  


### PR DESCRIPTION
…with the caveat that

submitted references can only be applied to matching data.