### PR TITLE
Corrected CRDS unit test following formal USEAFTER format definition

### DIFF
--- a/crds/timestamp.py
+++ b/crds/timestamp.py
@@ -345,7 +345,9 @@ class Jwstdate(DateParser):
     datetime.datetime(2001, 3, 21, 0, 0)
 
     >>> Jwstdate.get_datetime("2001-03-21")
-    datetime.datetime(2001, 3, 21, 0, 0)
+    Traceback (most recent call last):
+    ...
+    ValueError: Invalid 'Jwstdate' format '2001-03-21'
 
     >>> Jwstdate.get_datetime("2001-03-21 12:00:00")
     Traceback (most recent call last):


### PR DESCRIPTION
and elimination of optional time.  (making full datetime required).