### PR TITLE
Lightened import of crds.tests by removing "from test_config import *…

### DIFF
--- a/crds/tests/__init__.py
+++ b/crds/tests/__init__.py
@@ -2,5 +2,11 @@ from __future__ import division # confidence high
 from __future__ import print_function
 from __future__ import absolute_import
 
-from .test_config import *
+# ==============================================================================
+
+def tstmod(module):
+    """Wrap test_config.tstmod to configure standard options throughout CRDS test_config."""
+    import doctest
+    # doctest.ELLIPSIS_MARKER = '-etc-'
+    return doctest.testmod(module, optionflags=doctest.ELLIPSIS)
 

--- a/crds/tests/test_bad_files.py
+++ b/crds/tests/test_bad_files.py
@@ -165,7 +165,7 @@ def dt_bad_rules_jwst_getreferences_error():
     
     Do some setup to switch to a JWST serverless mode.
     
-    >>> old_state = test_config.setup(cache=tests.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
+    >>> old_state = test_config.setup(cache=test_config.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
     >>> config.ALLOW_BAD_RULES.reset()
     >>> config.ALLOW_BAD_REFERENCES.reset()
     
@@ -182,7 +182,7 @@ def dt_bad_rules_jwst_getreferences_warning():
     """
     Similarly,  the use of bad rules can be permitted:
     
-    >>> old_state = test_config.setup(cache=tests.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
+    >>> old_state = test_config.setup(cache=test_config.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
     >>> config.ALLOW_BAD_RULES.set("1")
     False
 
@@ -203,7 +203,7 @@ def dt_bad_rules_jwst_bestrefs_script_error():
     """
     Here try bad rules for a JWST dataset:
     
-    >>> old_state = test_config.setup(cache=tests.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
+    >>> old_state = test_config.setup(cache=test_config.CRDS_SHARED_GROUP_CACHE, url="https://jwst-serverless-mode.stsci.edu")    
     >>> config.ALLOW_BAD_RULES.reset()
     
     >>> hdr = {

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -7,7 +7,7 @@ import json
 import shutil
 
 from crds.bestrefs import BestrefsScript
-from crds.tests import CRDSTestCase, test_config, CRDS_TESTING_CACHE
+from crds.tests import test_config
 
 """
 Bestrefs has a number of command line parameters which make it operate in different modes. 
@@ -251,11 +251,11 @@ def dt_bestrefs_context_to_context():
     >>> test_config.cleanup(old_state)
     """
 
-class TestBestrefs(CRDSTestCase):
+class TestBestrefs(test_config.CRDSTestCase):
     
     script_class = BestrefsScript
     server_url = "https://hst-crds-dev.stsci.edu"
-    cache = CRDS_TESTING_CACHE
+    cache = test_config.CRDS_TESTING_CACHE
 
     def test_bestrefs_affected_datasets(self):
         self.run_script("crds.bestrefs --affected-datasets --old-context hst_0314.pmap --new-context hst_0315.pmap --datasets-since 2015-01-01",

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -10,7 +10,7 @@ import os
 from crds import certify, utils, log, client
 from crds.certify import CertifyScript
 
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -296,7 +296,7 @@ def certify_jwst_missing_optional_parkey():
 
 # ==================================================================================
 
-class TestHSTTpnInfoClass(CRDSTestCase):
+class TestHSTTpnInfoClass(test_config.CRDSTestCase):
 
     def setUp(self, *args, **keys):
         super(TestHSTTpnInfoClass, self).setUp(*args, **keys)
@@ -316,7 +316,7 @@ class TestHSTTpnInfoClass(CRDSTestCase):
 
 # ==================================================================================
 
-class TestCertify(CRDSTestCase):
+class TestCertify(test_config.CRDSTestCase):
 
     def setUp(self, *args, **keys):
         super(TestCertify, self).setUp(*args, **keys)

--- a/crds/tests/test_config.py
+++ b/crds/tests/test_config.py
@@ -99,14 +99,6 @@ def cleanup(old_state):
 
 # ==============================================================================
 
-def tstmod(module):
-    """Wrap tests.tstmod to configure standard options throughout CRDS tests."""
-    import doctest
-    # doctest.ELLIPSIS_MARKER = '-etc-'
-    return doctest.testmod(module, optionflags=doctest.ELLIPSIS)
-
-# ==============================================================================
-
 def run_and_profile(name, case, globs={}, locs={}):
     """Using `name` for a banner and divider,  execute code string `case` in the
     global namespace,  both evaled printing result and under the profiler.

--- a/crds/tests/test_diff.py
+++ b/crds/tests/test_diff.py
@@ -388,7 +388,7 @@ def dt_diff_print_affected_modes():
 
 def dt_diff_print_all_new_files():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
+    >>> old_state = test_config.setup(cache=test_config.CRDS_TESTING_CACHE)
     >>> DiffScript("crds.diff data/hst_0001.pmap data/hst_0008.pmap --print-all-new-files --sync-files --include-header-diffs --hide-boring")()
     CRDS - INFO - 0 errors
     CRDS - INFO - 0 warnings

--- a/crds/tests/test_heavy_client.py
+++ b/crds/tests/test_heavy_client.py
@@ -12,7 +12,7 @@ from pprint import pprint as pp
 
 from crds import rmap, log, config, tests, heavy_client
 from crds.exceptions import *
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -21,7 +21,7 @@ from nose.tools import assert_raises, assert_true
 def dt_getreferences_rmap_na():
     """
     >>> old_state = test_config.setup(cache=None, url="https://jwst-crds-dev.stsci.edu")
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> heavy_client.getreferences({"META.INSTRUMENT.NAME":"NIRISS", "META.INSTRUMENT.DETECTOR":"NIS", "META.INSTRUMENT.FILTER":"BOGUS2"},
     ...    observatory="jwst", context="jwst_na_omit.pmap", ignore_cache=False)
@@ -35,7 +35,7 @@ def dt_getreferences_rmap_na():
 def dt_getreferences_rmap_omit():
     """
     >>> old_state = test_config.setup(cache=None, url="https://jwst-crds-dev.stsci.edu")
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> heavy_client.getreferences({"META.INSTRUMENT.NAME":"NIRISS", "META.INSTRUMENT.DETECTOR":"NIS", "META.INSTRUMENT.FILTER":"BOGUS1"},
     ...    observatory="jwst", context="jwst_na_omit.pmap", ignore_cache=False)
@@ -49,7 +49,7 @@ def dt_getreferences_rmap_omit():
 def dt_getreferences_imap_na():
     """
     >>> old_state = test_config.setup(cache=None, url="https://jwst-crds-dev.stsci.edu")
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> heavy_client.getreferences({"META.INSTRUMENT.NAME":"FGS",},
     ...    observatory="jwst", context="jwst_na_omit.pmap", ignore_cache=False)
@@ -61,7 +61,7 @@ def dt_getreferences_imap_na():
 def dt_getreferences_imap_omit():
     """
     >>> old_state = test_config.setup(cache=None, url="https://jwst-crds-dev.stsci.edu")
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> heavy_client.getreferences({"META.INSTRUMENT.NAME":"MIRI",},
     ...    observatory="jwst", context="jwst_na_omit.pmap", ignore_cache=False)
@@ -72,7 +72,7 @@ def dt_getreferences_imap_omit():
 
 # ==================================================================================
 
-# class TestHeavyClient(CRDSTestCase):
+# class TestHeavyClient(test_config.CRDSTestCase):
 
     """
     def test_rmap_get_imap_except(self):

--- a/crds/tests/test_matches.py
+++ b/crds/tests/test_matches.py
@@ -11,7 +11,7 @@ import crds
 from crds import rmap, log, exceptions, config, tests
 from crds.matches import MatchesScript
 from crds.client import api
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 

--- a/crds/tests/test_newcontext.py
+++ b/crds/tests/test_newcontext.py
@@ -10,7 +10,7 @@ import os, os.path
 from pprint import pprint as pp
 
 from crds import rmap, log, exceptions, newcontext, diff, pysh, tests
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -21,7 +21,7 @@ def dt_fake_name():
     Fake names are only used by crds.newcontext when it is run from the command line.
 
     >>> old_state = test_config.setup()
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> newcontext.fake_name("data/hst.pmap")
     './hst_0003.pmap'
@@ -38,7 +38,7 @@ def dt_fake_name():
 def dt_new_context():
     """
     >>> old_state = test_config.setup()
-    >>> os.environ["CRDS_MAPPATH_SINGLE"] = tests.TEST_DATA
+    >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
     >>> newcontext.NewContextScript("newcontext.py hst.pmap data/hst_cos_deadtab_9999.rmap data/hst_acs_imphttab_9999.rmap")()
     CRDS - INFO - Replaced 'hst_acs_imphttab.rmap' with 'data/hst_acs_imphttab_9999.rmap' for 'imphttab' in 'data/hst_acs.imap' producing './hst_acs_10000.imap'
@@ -64,8 +64,7 @@ def dt_new_context():
     >>> test_config.cleanup(old_state)
     """
 
-class TestNewContext(CRDSTestCase):
-
+class TestNewContext(test_config.CRDSTestCase):
     '''
     def test_get_imap_except(self):
         r = rmap.get_cached_mapping("hst.pmap")

--- a/crds/tests/test_refactor.py
+++ b/crds/tests/test_refactor.py
@@ -12,7 +12,7 @@ from pprint import pprint as pp
 
 from crds import refactor, log, exceptions, diff
 from crds.refactor import RefactorScript
-from crds.tests import CRDSTestCase
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -138,7 +138,7 @@ def dt_refactor_bad_modify_count():
 
 # ==================================================================================
 
-class TestRefactor(CRDSTestCase):
+class TestRefactor(test_config.CRDSTestCase):
 
     '''
     example unit test code,  not for test_refactor

--- a/crds/tests/test_rmap.py
+++ b/crds/tests/test_rmap.py
@@ -13,7 +13,7 @@ from pprint import pprint as pp
 from crds import rmap, log, config, tests
 from crds.client import api
 from crds.exceptions import *
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -498,7 +498,7 @@ def dt_pickled_bestrefs():
 
 # ==================================================================================
 
-class TestRmap(CRDSTestCase):
+class TestRmap(test_config.CRDSTestCase):
 
     def test_rmap_get_imap_except(self):
         r = rmap.get_cached_mapping("hst.pmap")
@@ -768,7 +768,7 @@ selector = Match({
         p.todict()
 
     def test_rmap_match_tjson(self):
-        os.environ["CRDS_PATH"] = tests.CRDS_TESTING_CACHE
+        os.environ["CRDS_PATH"] = test_config.CRDS_TESTING_CACHE
         p = rmap.get_cached_mapping("jwst.pmap")
         p.tojson()
 

--- a/crds/tests/test_sync.py
+++ b/crds/tests/test_sync.py
@@ -11,11 +11,11 @@ import os
 import crds
 from crds import log, config, rmap
 from crds.sync import SyncScript
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 # ==================================================================================
 
-class TestSync(CRDSTestCase):
+class TestSync(test_config.CRDSTestCase):
     
     script_class = SyncScript
 

--- a/crds/tests/test_uses.py
+++ b/crds/tests/test_uses.py
@@ -11,7 +11,7 @@ import os, os.path
 from pprint import pprint as pp
 
 from crds import log, config, uses, tests
-from crds.tests import CRDSTestCase, test_config
+from crds.tests import test_config
 
 from nose.tools import assert_raises, assert_true
 
@@ -21,7 +21,7 @@ HERE = os.path.dirname(__file__) or "."
 
 def dt_uses_finaall_mappings_using_reference():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
+    >>> old_state = test_config.setup(cache=test_config.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files v2e20129l_flat.fits")()
     hst.pmap
     hst_0001.pmap
@@ -41,7 +41,7 @@ def dt_uses_finaall_mappings_using_reference():
 
 def dt_uses_rmaps():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
+    >>> old_state = test_config.setup(cache=test_config.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files hst_cos_flatfile.rmap hst_acs_darkfile.rmap --include-used")()
     hst_cos_flatfile.rmap hst.pmap
     hst_cos_flatfile.rmap hst_0001.pmap
@@ -73,7 +73,7 @@ def dt_uses_rmaps():
     
 def dt_uses_imap():
     """
-    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
+    >>> old_state = test_config.setup(cache=test_config.CRDS_TESTING_CACHE)
     >>> uses.UsesScript("crds.uses --files hst_cos.imap")()
     hst.pmap
     hst_0001.pmap
@@ -86,9 +86,9 @@ def dt_uses_imap():
 def dt_uses_print_datasets():
     """
     This test/function is quite slow since it surveys the catalog for recorded uses of the
-    specified file.  Too slow for routine unit tests.
+    specified file.  Too slow for routine unit test_config.
     
-    >>> old_state = test_config.setup(cache=tests.CRDS_TESTING_CACHE)
+    >>> old_state = test_config.setup(cache=test_config.CRDS_TESTING_CACHE)
 
     >> uses.UsesScript("crds.uses --files n3o1022ij_drk.fits --print-datasets --hst")()
     J8BA0HRPQ:J8BA0HRPQ
@@ -100,7 +100,7 @@ def dt_uses_print_datasets():
     >>> test_config.cleanup(old_state)
     """
 
-class TestUses(CRDSTestCase):
+class TestUses(test_config.CRDSTestCase):
     '''
     def test_get_imap_except(self):
         r = rmap.get_cached_mapping("hst.pmap")

--- a/crds/tobs/locate.py
+++ b/crds/tobs/locate.py
@@ -21,7 +21,7 @@ HERE = os.path.dirname(__file__) or "./"
 # =======================================================================
 
 def test():
-    """Run the module doctests."""
+    """Run the module doctest_config."""
     import doctest
     from . import locate
     return doctest.testmod(locate)

--- a/crds/tobs/tests.py
+++ b/crds/tobs/tests.py
@@ -9,13 +9,13 @@ import os
 import unittest
 
 from crds import rmap, log
-from crds import tests
+from crds.tests import test_config
 import crds
 
 # =============================================================================
 
-class TobsTestCase(tests.CRDSTestCase):
-    cache = tests.CRDS_TESTING_CACHE
+class TobsTestCase(test_config.CRDSTestCase):
+    cache = test_config.CRDS_TESTING_CACHE
     clear_existing = False
     server_url = "https://tobs-serverless-mode.stsci.edu"
 


### PR DESCRIPTION
…" after

hitting an issue with circular imports using test code in crds.client