### PR TITLE
Update MIRI RSCD and SYSTEM CALVER specs for USEAFTER

### DIFF
--- a/crds/jwst/specs/miri_rscd.rmap
+++ b/crds/jwst/specs/miri_rscd.rmap
@@ -8,8 +8,8 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'jwst_miri_rscd.rmap',
     'observatory' : 'JWST',
-    'parkey' : (('META.INSTRUMENT.DETECTOR',),),
-    'sha1sum' : 'c153df7d3d93faee4b79fa9059bfc4b72e553fca',
+    'parkey' : (('META.INSTRUMENT.DETECTOR',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : 'ec43fcd3756a572d11405b7e683983c5d2fe51ff',
     'suffix' : 'rscd',
     'text_descr' : 'Reset Switch Charge Decay correction',
 }

--- a/crds/jwst/specs/system_calver.rmap
+++ b/crds/jwst/specs/system_calver.rmap
@@ -8,8 +8,8 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'jwst_system_calver_0000.rmap',
     'observatory' : 'JWST',
-    'parkey' : (('CAL_VER',),),
-    'sha1sum' : '43107e2879e5a9fcbc28ca83bccf7a20bde4ab67',
+    'parkey' : (('CAL_VER',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : 'f86296b13da8e7b6d5edefac1493391f837efab9',
     'suffix' : 'calver',
     'text_descr' : 'Calibration Software Component Versions',
 }


### PR DESCRIPTION
Added META.OBSERVATION.DATE + META.OBSERVATION.TIME keywords to MIRI RSCD and SYSTEM CALVER spec parkey header field corresponding to USEAFTER lookup.