### PR TITLE
More pickling memory consumption reversions

### DIFF
--- a/crds/bestrefs.py
+++ b/crds/bestrefs.py
@@ -620,8 +620,8 @@ and debug output.
         Returns { instrument: EXPTIME, ... }
         """
         datasets_since = {}
-        self.oldctx = crds.get_pickled_mapping(self.old_context)
-        self.newctx = crds.get_pickled_mapping(self.new_context)
+        self.oldctx = crds.get_pickled_mapping(self.old_context)   # reviewed
+        self.newctx = crds.get_pickled_mapping(self.new_context)   # reviewed
         for instrument in self.oldctx.selections:
             old_imap = self.oldctx.get_imap(instrument)
             new_imap = self.newctx.get_imap(instrument)

--- a/crds/certify.py
+++ b/crds/certify.py
@@ -534,7 +534,7 @@ class Certifier(object):
 
     def get_corresponding_rmap(self):
         """Return the rmap which corresponds to self.filename under self.context."""
-        pmap = crds.get_pickled_mapping(self.context, ignore_checksum="warn")
+        pmap = crds.get_pickled_mapping(self.context, ignore_checksum="warn")  # reviewed
         instrument, filekind = pmap.locate.get_file_properties(self.filename)
         return pmap.get_imap(instrument).get_rmap(filekind)
 
@@ -1018,7 +1018,7 @@ def find_old_mapping(comparison_context, new_mapping):
     trial mappings.
     """
     if comparison_context:
-        comparison_mapping = crds.get_pickled_mapping(comparison_context)
+        comparison_mapping = crds.get_pickled_mapping(comparison_context)  # reviewed
         old_mapping = comparison_mapping.get_equivalent_mapping(new_mapping)
         return old_mapping
     else:
@@ -1288,7 +1288,7 @@ For more information on the checks being performed,  use --verbose or --verbosit
             more_files = {file_}
             if rmap.is_mapping(file_):
                 with self.error_on_exception(file_, "Problem loading submappings of", repr(file_)):
-                    mapping = crds.get_pickled_mapping(file_, ignore_checksum="warn")
+                    mapping = crds.get_cached_mapping(file_, ignore_checksum="warn")
                     more_files = {rmap.locate_mapping(name) for name in mapping.mapping_names()}
                     more_files = (more_files - {rmap.locate_mapping(mapping.basename)}) | {file_}
             closure_files |= more_files

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -526,7 +526,7 @@ class FileCacher(object):
         elif "hst" in self.pipeline_context:
             observatory = "hst"
         else:
-            observatory = crds.get_pickled_mapping(self.pipeline_context).observatory
+            observatory = crds.get_pickled_mapping(self.pipeline_context).observatory  # reviewed
         return observatory
 
     def locate(self, name):
@@ -819,6 +819,6 @@ def get_minimum_header(context, dataset, ignore_cache=False):
     information from the `dataset`.
     """
     dump_mappings(context, ignore_cache=ignore_cache)
-    ctx = crds.get_pickled_mapping(context)
+    ctx = crds.get_pickled_mapping(context)   # reviewed
     return ctx.get_minimum_header(dataset)
 

--- a/crds/cmdline.py
+++ b/crds/cmdline.py
@@ -712,7 +712,7 @@ class ContextsScript(Script):
         files = set()
         for context in self.contexts:
             try:
-                pmap = crds.get_pickled_mapping(context)
+                pmap = crds.get_cached_mapping(context)
                 files |= set(pmap.reference_names())
                 log.verbose("Determined references from cached mapping", repr(context))
             except Exception:  # only ask the server if loading context fails

--- a/crds/diff.py
+++ b/crds/diff.py
@@ -57,7 +57,7 @@ def get_affected(old_pmap, new_pmap, *args, **keys):
     
     Returns { affected_instrument : { affected_type, ... } }
     """
-    observatory = keys.pop("observatory", crds.get_pickled_mapping(old_pmap).observatory)
+    observatory = keys.pop("observatory", crds.get_pickled_mapping(old_pmap).observatory)  # reviewed
     differ = MappingDifferencer(observatory, old_pmap, new_pmap, *args, **keys)
     return differ.get_affected()
 
@@ -654,7 +654,7 @@ def get_updated_files(context1, context2):
     extension1 = os.path.splitext(context1)[1]
     extension2 = os.path.splitext(context2)[1]
     assert extension1 == extension2, "Only compare mappings of same type/extension."
-    old_map = crds.get_pickled_mapping(context1)
+    old_map = crds.get_cached_mapping(context1)
     old_files = set(old_map.mapping_names() + old_map.reference_names())
     all_mappings = rmap.list_mappings("*"+extension1, old_map.observatory)
     updated = set()
@@ -662,7 +662,7 @@ def get_updated_files(context1, context2):
     for new in all_mappings:
         new = os.path.basename(new)
         if context1 < new <= context2:
-            new_map = crds.get_pickled_mapping(new)
+            new_map = crds.get_cached_mapping(new)
             updated |= set(new_map.mapping_names() + new_map.reference_names())
     return sorted(list(updated - old_files))
 
@@ -871,8 +871,8 @@ Mutually Exclusive Modes
         if not rmap.is_mapping(self.old_file) or not rmap.is_mapping(self.new_file):
             log.error("--print-new-files really only works for mapping differences.")
             return -1
-        old = crds.get_pickled_mapping(self.old_file)
-        new = crds.get_pickled_mapping(self.new_file)
+        old = crds.get_pickled_mapping(self.old_file)   # reviewed
+        new = crds.get_pickled_mapping(self.new_file)   # reviewed
         old_mappings = set(old.mapping_names())
         new_mappings = set(new.mapping_names())
         old_references = set(old.reference_names())

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -589,7 +589,7 @@ def get_symbolic_mapping(
     to interpret the symbolic name into a primitive name.
     """
     abs_mapping = translate_date_based_context(mapping, observatory)
-    return get_pickled_mapping(
+    return get_pickled_mapping(   # reviewed
         abs_mapping, cached=cached, use_pickles=use_pickles, save_pickles=save_pickles, **keys)
 
         

--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -253,7 +253,7 @@ def check_naming_consistency(checked_instrument=None, exhaustive_mapping_check=F
 
             for pmap_name in reversed(sorted(rmap.list_mappings("*.pmap", observatory="hst"))):
 
-                pmap = crds.get_pickled_mapping(pmap_name)
+                pmap = crds.get_cached_mapping(pmap_name)
 
                 r = certify.find_governing_rmap(pmap_name, ref)
 

--- a/crds/jwst/schema.py
+++ b/crds/jwst/schema.py
@@ -56,7 +56,7 @@ def tpninfos_key_to_parkeys(tpn):
         return []
     with log.verbose_warning_on_exception("Can't determine parkeys for", repr(tpn)):
         _mode, context  = heavy_client.get_processing_mode("jwst")
-        p = crds.get_pickled_mapping(context)
+        p = crds.get_pickled_mapping(context)   # reviewed
         instrument, suffix = tpn.split(".")[0].split("_")[:2]
         filekind = p.locate.suffix_to_filekind(instrument, suffix)
         keys = p.get_imap(instrument).get_rmap(filekind).get_required_parkeys()

--- a/crds/list.py
+++ b/crds/list.py
@@ -227,7 +227,7 @@ class ListScript(cmdline.ContextsScript):
             with log.error_on_exception("Failed fetching dataset parameters with repect to", repr(context), 
                                         "for", repr(self.args.datasets)):
                 pars = api.get_dataset_headers_by_id(context, self.args.datasets)
-                pmap = crds.get_pickled_mapping(context)
+                pmap = crds.get_cached_mapping(context)
                 for (dataset_id, header) in pars.items():
                     if isinstance(header, python23.string_types):
                         log.error("No header for", repr(dataset_id), ":", repr(header)) # header is reason

--- a/crds/matches.py
+++ b/crds/matches.py
@@ -65,7 +65,7 @@ def find_full_match_paths(context, reffile):
        ('CCDCHIP', 'N/A')),
       (('DATE-OBS', '2006-07-04'), ('TIME-OBS', '11:32:35')))]
     """
-    ctx = crds.get_pickled_mapping(context, cached=True)
+    ctx = crds.get_pickled_mapping(context, cached=True)  # reviewed
     return ctx.file_matches(reffile)
 
 def find_match_paths_as_dict(context, reffile):
@@ -282,7 +282,7 @@ jwst_niriss_throughput_0008.fits :  META.INSTRUMENT.FILTER='F480M'
                 if self.args.condition_values:
                     header = utils.condition_header(header)
                 if self.args.minimize_headers:
-                    header = crds.get_pickled_mapping(context).minimize_header(header)
+                    header = crds.get_cached_mapping(context).minimize_header(header)
                 if len(self.contexts) == 1:
                     print(dataset_id, ":", log.format_parameter_list(header))
                 else:
@@ -307,7 +307,7 @@ jwst_niriss_throughput_0008.fits :  META.INSTRUMENT.FILTER='F480M'
     def find_match_tuples(self, context, reffile):
         """Return the list of match representations for `reference` in `context`.   
         """
-        ctx = crds.get_pickled_mapping(context)
+        ctx = crds.get_cached_mapping(context)
         matches = ctx.file_matches(reffile)
         result = []
         for path in matches:

--- a/crds/newcontext.py
+++ b/crds/newcontext.py
@@ -22,7 +22,7 @@ def get_update_map(old_pipeline, updated_rmaps):
     of new rmap names, `updated_rmaps`,  return the mapping:
         { imap_name : [ updates_for_that_imap, ... ], ... }
     """
-    pctx = crds.get_pickled_mapping(old_pipeline)
+    pctx = crds.get_pickled_mapping(old_pipeline)   # reviewed
     updates = {}
     for update in sorted(updated_rmaps):
         instrument, _filekind = utils.get_file_properties(pctx.observatory, update)

--- a/crds/refactor2.py
+++ b/crds/refactor2.py
@@ -642,7 +642,7 @@ class RefactorScript(cmdline.Script):
         """Insert files specified by --references into the appropriate rmaps identified by --source-context."""
         self._setup_source_context()
         categorized = self.categorize_files(self.args.references)
-        pmap = crds.get_pickled_mapping(self.source_context)
+        pmap = crds.get_pickled_mapping(self.source_context)  # reviewed
         self.args.rmaps = []
         for (instrument, filekind) in categorized:
             try:

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -325,7 +325,7 @@ class SyncScript(cmdline.ContextsScript):
         """
         for context in contexts:
             with log.error_on_exception("Failed pickling", repr(context)):
-                crds.get_pickled_mapping(context, use_pickles=True, save_pickles=True)
+                crds.get_pickled_mapping(context, use_pickles=True, save_pickles=True)  # reviewed
     
     # ------------------------------------------------------------------------------------------
 

--- a/crds/uses.py
+++ b/crds/uses.py
@@ -90,7 +90,7 @@ def uses(files, observatory="hst"):
             mappings.extend(findall_mappings_using_reference(file_, observatory))
     return sorted(list(set(mappings)))
 
-def datasets_using(references, context):
+def datasets_using(references, context):    # XXXX rip out,  DADSOPS is stale.
     """Print out the DADSOPS dataset ids which historically used the specified reference files.
     Return [(reference, dataset_id), ...]
     """
@@ -100,7 +100,7 @@ def datasets_using(references, context):
         if config.is_mapping(reference):
             log.error("Used file", repr(reference), "is a mapping file.  Must be a reference file.")
             continue
-        pmap = crds.get_pickled_mapping(context)
+        pmap = crds.get_pickled_mapping(context)   # reviewed
         instrument, filekind = utils.get_file_properties(pmap.observatory, reference)
         if instrument not in datasets:
             log.verbose("Dumping dataset info for", repr(instrument), "from", repr(api.get_crds_server()))


### PR DESCRIPTION
Reverted instances of get_pickled_mapping() inside loops over context to get_cached_mapping() because the latter is more memory efficient and roughly equivalent once the bulk of the mappings network is loaded.   Marked those instances of get_pickled_mapping() which appeared loop-free as "reviewed".
