### PR TITLE
Added explicit separators to combined spec .json dump 

### DIFF
--- a/crds/hst/specs/combined_specs.json
+++ b/crds/hst/specs/combined_specs.json
@@ -1,2788 +1,2788 @@
 {
-    "acs": {
-        "atodtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "analog-to-digital", 
-            "ld_tpn": "acs_a2d_ld.tpn", 
-            "parkey": [
+    "acs":{
+        "atodtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"analog-to-digital",
+            "ld_tpn":"acs_a2d_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "atodcorr", 
-            "rmap_relevance": "((DETECTOR != \"SBC\") and (ATODCORR != \"OMIT\"))", 
-            "suffix": "a2d", 
-            "text_descr": "Analog To Digital Lookup Table", 
-            "tpn": "acs_a2d.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "REF_KEY", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"atodcorr",
+            "rmap_relevance":"((DETECTOR != \"SBC\") and (ATODCORR != \"OMIT\"))",
+            "suffix":"a2d",
+            "text_descr":"Analog To Digital Lookup Table",
+            "tpn":"acs_a2d.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CCDAMP",
+                "CCDGAIN",
+                "REF_KEY",
                 "REF_KEY_VALUE"
             ]
-        }, 
-        "biasfile": {
-            "extra_keys": [
-                "xcorner", 
-                "ycorner", 
+        },
+        "biasfile":{
+            "extra_keys":[
+                "xcorner",
+                "ycorner",
                 "ccdchip"
-            ], 
-            "file_ext": ".fits", 
-            "filetype": "bias", 
-            "ld_tpn": "acs_bia_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "APERTURE", 
-                "NAXIS1", 
-                "NAXIS2", 
-                "LTV1", 
+            ],
+            "file_ext":".fits",
+            "filetype":"bias",
+            "ld_tpn":"acs_bia_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "CCDGAIN",
+                "APERTURE",
+                "NAXIS1",
+                "NAXIS2",
+                "LTV1",
                 "LTV2"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "biascorr", 
-            "rmap_relevance": "((DETECTOR != \"SBC\") and (BIASCORR != \"OMIT\"))", 
-            "suffix": "bia", 
-            "text_descr": "Bias Frame", 
-            "tpn": "acs_bia.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "bpixtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "bad pixels", 
-            "ld_tpn": "acs_bpx_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"biascorr",
+            "rmap_relevance":"((DETECTOR != \"SBC\") and (BIASCORR != \"OMIT\"))",
+            "suffix":"bia",
+            "text_descr":"Bias Frame",
+            "tpn":"acs_bia.tpn",
+            "unique_rowkeys":null
+        },
+        "bpixtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"bad pixels",
+            "ld_tpn":"acs_bpx_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "dqicorr", 
-            "rmap_relevance": "(DQICORR != \"OMIT\")", 
-            "suffix": "bpx", 
-            "text_descr": "Data Quality (Bad Pixel) Initialization Table", 
-            "tpn": "acs_bpx.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "ccdtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ccd parameters", 
-            "ld_tpn": "acs_ccd_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"dqicorr",
+            "rmap_relevance":"(DQICORR != \"OMIT\")",
+            "suffix":"bpx",
+            "text_descr":"Data Quality (Bad Pixel) Initialization Table",
+            "tpn":"acs_bpx.tpn",
+            "unique_rowkeys":[]
+        },
+        "ccdtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ccd parameters",
+            "ld_tpn":"acs_ccd_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"SBC\")", 
-            "suffix": "ccd", 
-            "text_descr": "Ccd Parameters Table", 
-            "tpn": "acs_ccd.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "BINAXIS1", 
-                "BINAXIS2", 
-                "CCDOFSTA", 
-                "CCDOFSTB", 
-                "CCDOFSTC", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"SBC\")",
+            "suffix":"ccd",
+            "text_descr":"Ccd Parameters Table",
+            "tpn":"acs_ccd.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CCDAMP",
+                "CCDGAIN",
+                "BINAXIS1",
+                "BINAXIS2",
+                "CCDOFSTA",
+                "CCDOFSTB",
+                "CCDOFSTC",
                 "CCDOFSTD"
             ]
-        }, 
-        "cfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "spot flat", 
-            "ld_tpn": "acs_cfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "FILTER1", 
-                "FILTER2", 
+        },
+        "cfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"spot flat",
+            "ld_tpn":"acs_cfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "FILTER1",
+                "FILTER2",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"HRC\" and OBSTYPE == \"CORONAGRAPHIC\")", 
-            "suffix": "cfl", 
-            "text_descr": "Coronagraphic Spot Flat Image", 
-            "tpn": "acs_cfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "crrejtab": {
-            "extra_keys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"HRC\" and OBSTYPE == \"CORONAGRAPHIC\")",
+            "suffix":"cfl",
+            "text_descr":"Coronagraphic Spot Flat Image",
+            "tpn":"acs_cfl.tpn",
+            "unique_rowkeys":null
+        },
+        "crrejtab":{
+            "extra_keys":[
                 "RPTCORR"
-            ], 
-            "file_ext": ".fits", 
-            "filetype": "cosmic ray rejection", 
-            "ld_tpn": "acs_crr_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "file_ext":".fits",
+            "filetype":"cosmic ray rejection",
+            "ld_tpn":"acs_crr_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "RPTCORR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "crcorr", 
-            "rmap_relevance": "((DETECTOR != \"SBC\") and ((CRCORR != \"OMIT\") or (RPTCORR != \"OMIT\")))", 
-            "suffix": "crr", 
-            "text_descr": "Cosmic Ray Rejection Parameter Table", 
-            "tpn": "acs_crr.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CRSPLIT", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"crcorr",
+            "rmap_relevance":"((DETECTOR != \"SBC\") and ((CRCORR != \"OMIT\") or (RPTCORR != \"OMIT\")))",
+            "suffix":"crr",
+            "text_descr":"Cosmic Ray Rejection Parameter Table",
+            "tpn":"acs_crr.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CRSPLIT",
                 "MEANEXP"
             ]
-        }, 
-        "d2imfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "wfc d2i file", 
-            "ld_tpn": "acs_d2i_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "((DETECTOR == \"WFC\") and (DRIZCORR != \"OMIT\"))", 
-            "suffix": "d2i", 
-            "text_descr": "Column Correction File", 
-            "tpn": "acs_d2i.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "darkfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dark", 
-            "ld_tpn": "acs_drk_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
+        },
+        "d2imfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"wfc d2i file",
+            "ld_tpn":"acs_d2i_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"((DETECTOR == \"WFC\") and (DRIZCORR != \"OMIT\"))",
+            "suffix":"d2i",
+            "text_descr":"Column Correction File",
+            "tpn":"acs_d2i.tpn",
+            "unique_rowkeys":null
+        },
+        "darkfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dark",
+            "ld_tpn":"acs_drk_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
                 "CCDGAIN"
-            ], 
-            "parkey_relevance": {
-                "ccdamp": "(DETECTOR != \"SBC\")", 
-                "ccdgain": "(DETECTOR != \"SBC\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "darkcorr", 
-            "rmap_relevance": "(DARKCORR != \"OMIT\")", 
-            "suffix": "drk", 
-            "text_descr": "Dark Frame", 
-            "tpn": "acs_drk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dfltfile": {
-            "derived_from": "Initial hand made version 2015-01-16.", 
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filekind": "DFLTFILE", 
-            "filetype": "DELTA FLAT", 
-            "instrument": "ACS", 
-            "ld_tpn": "acs_dfl_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "acs_dfltfile.rmap", 
-            "observatory": "HST", 
-            "parkey": [
+            ],
+            "parkey_relevance":{
+                "ccdamp":"(DETECTOR != \"SBC\")",
+                "ccdgain":"(DETECTOR != \"SBC\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"darkcorr",
+            "rmap_relevance":"(DARKCORR != \"OMIT\")",
+            "suffix":"drk",
+            "text_descr":"Dark Frame",
+            "tpn":"acs_drk.tpn",
+            "unique_rowkeys":null
+        },
+        "dfltfile":{
+            "derived_from":"Initial hand made version 2015-01-16.",
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filekind":"DFLTFILE",
+            "filetype":"DELTA FLAT",
+            "instrument":"ACS",
+            "ld_tpn":"acs_dfl_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"acs_dfltfile.rmap",
+            "observatory":"HST",
+            "parkey":[
                 [
-                    "DETECTOR", 
-                    "LRFWAVE", 
-                    "FILTER1", 
+                    "DETECTOR",
+                    "LRFWAVE",
+                    "FILTER1",
                     "FILTER2"
-                ], 
+                ],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "IMAGE", 
-            "reffile_required": "NO", 
-            "reffile_switch": "FLATCORR", 
-            "rmap_relevance": "(DETECTOR == \"WFC\")", 
-            "sha1sum": "5238170ec90c9117f90879c62788964949b654bf", 
-            "suffix": "dfl", 
-            "text_descr": "Delta Flat Field Image", 
-            "tpn": "acs_dfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dgeofile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "distortion correction", 
-            "ld_tpn": "acs_dxy_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "FILTER1", 
+            ],
+            "reffile_format":"IMAGE",
+            "reffile_required":"NO",
+            "reffile_switch":"FLATCORR",
+            "rmap_relevance":"(DETECTOR == \"WFC\")",
+            "sha1sum":"5238170ec90c9117f90879c62788964949b654bf",
+            "suffix":"dfl",
+            "text_descr":"Delta Flat Field Image",
+            "tpn":"acs_dfl.tpn",
+            "unique_rowkeys":null
+        },
+        "dgeofile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"distortion correction",
+            "ld_tpn":"acs_dxy_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "FILTER1",
                 "FILTER2"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "dxy", 
-            "text_descr": "Geometric Distortion Correction File", 
-            "tpn": "acs_dxy.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "drkcfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ctedark", 
-            "ld_tpn": "acs_dkc_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"dxy",
+            "text_descr":"Geometric Distortion Correction File",
+            "tpn":"acs_dxy.tpn",
+            "unique_rowkeys":null
+        },
+        "drkcfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ctedark",
+            "ld_tpn":"acs_dkc_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
                 "CCDGAIN"
-            ], 
-            "parkey_relevance": {
-                "ccdamp": "(DETECTOR != \"SBC\")", 
-                "ccdgain": "(DETECTOR != \"SBC\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "pctecorr", 
-            "rmap_relevance": "((DETECTOR == \"WFC\") and (PCTECORR != \"OMIT\"))", 
-            "suffix": "dkc", 
-            "text_descr": "Cte Corrected Dark", 
-            "tpn": "acs_dkc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flshfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "post flash", 
-            "ld_tpn": "acs_fls_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "FLASHCUR", 
+            ],
+            "parkey_relevance":{
+                "ccdamp":"(DETECTOR != \"SBC\")",
+                "ccdgain":"(DETECTOR != \"SBC\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"pctecorr",
+            "rmap_relevance":"((DETECTOR == \"WFC\") and (PCTECORR != \"OMIT\"))",
+            "suffix":"dkc",
+            "text_descr":"Cte Corrected Dark",
+            "tpn":"acs_dkc.tpn",
+            "unique_rowkeys":null
+        },
+        "flshfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"post flash",
+            "ld_tpn":"acs_fls_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "CCDGAIN",
+                "FLASHCUR",
                 "SHUTRPOS"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "flshcorr", 
-            "rmap_relevance": "((DETECTOR != \"SBC\" and FLASHCUR != \"OFF\") and (FLSHCORR != \"OMIT\"))", 
-            "suffix": "fls", 
-            "text_descr": "Post-flash Image", 
-            "tpn": "acs_fls.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "idctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "distortion coefficients", 
-            "ld_tpn": "acs_idc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"flshcorr",
+            "rmap_relevance":"((DETECTOR != \"SBC\" and FLASHCUR != \"OFF\") and (FLSHCORR != \"OMIT\"))",
+            "suffix":"fls",
+            "text_descr":"Post-flash Image",
+            "tpn":"acs_fls.tpn",
+            "unique_rowkeys":null
+        },
+        "idctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"distortion coefficients",
+            "ld_tpn":"acs_idc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "idc", 
-            "text_descr": "Image Distortion Correction File", 
-            "tpn": "acs_idc.tpn", 
-            "unique_rowkeys": [
-                "DETCHIP", 
-                "WAVELENGTH", 
-                "DIRECTION", 
-                "FILTER1", 
-                "FILTER2", 
-                "V2REF", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"idc",
+            "text_descr":"Image Distortion Correction File",
+            "tpn":"acs_idc.tpn",
+            "unique_rowkeys":[
+                "DETCHIP",
+                "WAVELENGTH",
+                "DIRECTION",
+                "FILTER1",
+                "FILTER2",
+                "V2REF",
                 "V3REF"
             ]
-        }, 
-        "imphttab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "image photometry table", 
-            "ld_tpn": "acs_imp_ld.tpn", 
-            "parkey": [
+        },
+        "imphttab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"image photometry table",
+            "ld_tpn":"acs_imp_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "photcorr", 
-            "rmap_relevance": "(PHOTCORR != \"OMIT\")", 
-            "suffix": "imp", 
-            "text_descr": "Photometry Keyword Table", 
-            "tpn": "acs_imp.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"photcorr",
+            "rmap_relevance":"(PHOTCORR != \"OMIT\")",
+            "suffix":"imp",
+            "text_descr":"Photometry Keyword Table",
+            "tpn":"acs_imp.tpn",
+            "unique_rowkeys":[
                 "OBSMODE"
             ]
-        }, 
-        "lfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "large scale flat", 
-            "ld_tpn": "acs_lfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "FILTER1", 
+        },
+        "lfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"large scale flat",
+            "ld_tpn":"acs_lfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "CCDGAIN",
+                "FILTER1",
                 "FILTER2"
-            ], 
-            "parkey_relevance": {
-                "ccdamp": "(DETECTOR != \"SBC\")", 
-                "ccdgain": "(DETECTOR != \"SBC\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "lfl", 
-            "text_descr": "Low-order Flat Field Image", 
-            "tpn": "acs_lfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mdriztab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "multidrizzle parameters", 
-            "ld_tpn": "acs_mdz_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{
+                "ccdamp":"(DETECTOR != \"SBC\")",
+                "ccdgain":"(DETECTOR != \"SBC\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"lfl",
+            "text_descr":"Low-order Flat Field Image",
+            "tpn":"acs_lfl.tpn",
+            "unique_rowkeys":null
+        },
+        "mdriztab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"multidrizzle parameters",
+            "ld_tpn":"acs_mdz_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "(DRIZCORR != \"OMIT\")", 
-            "suffix": "mdz", 
-            "text_descr": "Multidrizzle Parameter Table", 
-            "tpn": "acs_mdz.tpn", 
-            "unique_rowkeys": [
-                "FILTER", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"(DRIZCORR != \"OMIT\")",
+            "suffix":"mdz",
+            "text_descr":"Multidrizzle Parameter Table",
+            "tpn":"acs_mdz.tpn",
+            "unique_rowkeys":[
+                "FILTER",
                 "NUMIMAGES"
             ]
-        }, 
-        "mlintab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "linearity", 
-            "ld_tpn": "acs_lin_ld.tpn", 
-            "parkey": [
+        },
+        "mlintab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"linearity",
+            "ld_tpn":"acs_lin_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "glincorr", 
-            "rmap_relevance": "((DETECTOR == \"SBC\") and (GLINCORR != \"OMIT\"))", 
-            "suffix": "lin", 
-            "text_descr": "Mama Linearity Table", 
-            "tpn": "acs_lin.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"glincorr",
+            "rmap_relevance":"((DETECTOR == \"SBC\") and (GLINCORR != \"OMIT\"))",
+            "suffix":"lin",
+            "text_descr":"Mama Linearity Table",
+            "tpn":"acs_lin.tpn",
+            "unique_rowkeys":[
                 "DETECTOR"
             ]
-        }, 
-        "npolfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dxy grid", 
-            "ld_tpn": "acs_npl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "FILTER1", 
+        },
+        "npolfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dxy grid",
+            "ld_tpn":"acs_npl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "FILTER1",
                 "FILTER2"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "(DRIZCORR != \"OMIT\")", 
-            "suffix": "npl", 
-            "text_descr": "Non-polynomial Offset", 
-            "tpn": "acs_npl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "oscntab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "overscan", 
-            "ld_tpn": "acs_osc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"(DRIZCORR != \"OMIT\")",
+            "suffix":"npl",
+            "text_descr":"Non-polynomial Offset",
+            "tpn":"acs_npl.tpn",
+            "unique_rowkeys":null
+        },
+        "oscntab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"overscan",
+            "ld_tpn":"acs_osc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"SBC\")", 
-            "suffix": "osc", 
-            "text_descr": "Overscan Region Table", 
-            "tpn": "acs_osc.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"SBC\")",
+            "suffix":"osc",
+            "text_descr":"Overscan Region Table",
+            "tpn":"acs_osc.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
                 "CCDAMP"
             ]
-        }, 
-        "pctetab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pixcte", 
-            "ld_tpn": "acs_cte_ld.tpn", 
-            "parkey": [
+        },
+        "pctetab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pixcte",
+            "ld_tpn":"acs_cte_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "pctecorr", 
-            "rmap_relevance": "((DETECTOR == \"WFC\") and (PCTECORR != \"OMIT\"))", 
-            "suffix": "cte", 
-            "text_descr": "Pixel CTE Correction Table", 
-            "tpn": "acs_cte.tpn", 
-            "unique_rowkeys": [
-                "LEVEL", 
-                "COLUMN", 
-                "NODE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"pctecorr",
+            "rmap_relevance":"((DETECTOR == \"WFC\") and (PCTECORR != \"OMIT\"))",
+            "suffix":"cte",
+            "text_descr":"Pixel CTE Correction Table",
+            "tpn":"acs_cte.tpn",
+            "unique_rowkeys":[
+                "LEVEL",
+                "COLUMN",
+                "NODE",
                 "MJD"
             ]
-        }, 
-        "pfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pixel-to-pixel flat", 
-            "ld_tpn": "acs_pfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "FILTER1", 
-                "FILTER2", 
-                "OBSTYPE", 
-                "FW1OFFST", 
-                "FW2OFFST", 
+        },
+        "pfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pixel-to-pixel flat",
+            "ld_tpn":"acs_pfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "FILTER1",
+                "FILTER2",
+                "OBSTYPE",
+                "FW1OFFST",
+                "FW2OFFST",
                 "FWSOFFST"
-            ], 
-            "parkey_relevance": {
-                "ccdamp": "(DETECTOR != \"SBC\")", 
-                "fw1offst": "(FW1OFFST == \"-1.0\" or FW1OFFST == \"1.0\")", 
-                "fw2offst": "(FW2OFFST == \"-1.0\" or FW2OFFST == \"1.0\")", 
-                "fwsoffst": "(FWSOFFST == \"-1.0\" or FWSOFFST == \"1.0\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "flatcorr", 
-            "rmap_relevance": "((OBSTYPE != \"INTERNAL\") and (FLATCORR != \"OMIT\"))", 
-            "suffix": "pfl", 
-            "text_descr": "Pixel To Pixel Flat Field Image", 
-            "tpn": "acs_pfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "shadfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "shutter shading", 
-            "ld_tpn": "acs_shd_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{
+                "ccdamp":"(DETECTOR != \"SBC\")",
+                "fw1offst":"(FW1OFFST == \"-1.0\" or FW1OFFST == \"1.0\")",
+                "fw2offst":"(FW2OFFST == \"-1.0\" or FW2OFFST == \"1.0\")",
+                "fwsoffst":"(FWSOFFST == \"-1.0\" or FWSOFFST == \"1.0\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"flatcorr",
+            "rmap_relevance":"((OBSTYPE != \"INTERNAL\") and (FLATCORR != \"OMIT\"))",
+            "suffix":"pfl",
+            "text_descr":"Pixel To Pixel Flat Field Image",
+            "tpn":"acs_pfl.tpn",
+            "unique_rowkeys":null
+        },
+        "shadfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"shutter shading",
+            "ld_tpn":"acs_shd_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "shadcorr", 
-            "rmap_relevance": "((DETECTOR != \"SBC\") and (SHADCORR != \"OMIT\"))", 
-            "suffix": "shd", 
-            "text_descr": "Shutter Shading Correction Image", 
-            "tpn": "acs_shd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "spottab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "spot position table", 
-            "ld_tpn": "acs_csp_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"shadcorr",
+            "rmap_relevance":"((DETECTOR != \"SBC\") and (SHADCORR != \"OMIT\"))",
+            "suffix":"shd",
+            "text_descr":"Shutter Shading Correction Image",
+            "tpn":"acs_shd.tpn",
+            "unique_rowkeys":null
+        },
+        "spottab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"spot position table",
+            "ld_tpn":"acs_csp_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"HRC\" and OBSTYPE == \"CORONAGRAPHIC\")", 
-            "suffix": "csp", 
-            "text_descr": "Spot Position Table", 
-            "tpn": "acs_csp.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"HRC\" and OBSTYPE == \"CORONAGRAPHIC\")",
+            "suffix":"csp",
+            "text_descr":"Spot Position Table",
+            "tpn":"acs_csp.tpn",
+            "unique_rowkeys":[
                 "DATE"
             ]
         }
-    }, 
-    "cos": {
-        "badttab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "bad time intervals table", 
-            "ld_tpn": "cos_badt_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+    },
+    "cos":{
+        "badttab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"bad time intervals table",
+            "ld_tpn":"cos_badt_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSMODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "badtcorr", 
-            "rmap_relevance": "((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (BADTCORR != \"OMIT\"))", 
-            "suffix": "badt", 
-            "text_descr": "Bad Time Interval Table", 
-            "tpn": "cos_badt.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "bpixtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "data quality initialization table", 
-            "ld_tpn": "cos_bpix_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"badtcorr",
+            "rmap_relevance":"((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (BADTCORR != \"OMIT\"))",
+            "suffix":"badt",
+            "text_descr":"Bad Time Interval Table",
+            "tpn":"cos_badt.tpn",
+            "unique_rowkeys":[]
+        },
+        "bpixtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"data quality initialization table",
+            "ld_tpn":"cos_bpix_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "bpix", 
-            "text_descr": "Data Quality (Bad Pixel) Initialization Table", 
-            "tpn": "cos_bpix.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "brftab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "baseline reference frame table", 
-            "ld_tpn": "cos_brf_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"bpix",
+            "text_descr":"Data Quality (Bad Pixel) Initialization Table",
+            "tpn":"cos_bpix.tpn",
+            "unique_rowkeys":[]
+        },
+        "brftab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"baseline reference frame table",
+            "ld_tpn":"cos_brf_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"FUV\")", 
-            "suffix": "brf", 
-            "text_descr": "Baseline Reference Frame Table", 
-            "tpn": "cos_brf.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"FUV\")",
+            "suffix":"brf",
+            "text_descr":"Baseline Reference Frame Table",
+            "tpn":"cos_brf.tpn",
+            "unique_rowkeys":[
                 "SEGMENT"
             ]
-        }, 
-        "brsttab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "burst parameters table", 
-            "ld_tpn": "cos_burst_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+        },
+        "brsttab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"burst parameters table",
+            "ld_tpn":"cos_burst_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSMODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "brstcorr", 
-            "rmap_relevance": "((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (BRSTCORR != \"OMIT\"))", 
-            "suffix": "burst", 
-            "text_descr": "Burst Parameters Table", 
-            "tpn": "cos_burst.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"brstcorr",
+            "rmap_relevance":"((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (BRSTCORR != \"OMIT\"))",
+            "suffix":"burst",
+            "text_descr":"Burst Parameters Table",
+            "tpn":"cos_burst.tpn",
+            "unique_rowkeys":[
                 "SEGMENT"
             ]
-        }, 
-        "deadtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "deadtime reference table", 
-            "ld_tpn": "cos_dead_ld.tpn", 
-            "parkey": [
+        },
+        "deadtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"deadtime reference table",
+            "ld_tpn":"cos_dead_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "deadcorr", 
-            "rmap_relevance": "(DEADCORR != \"OMIT\")", 
-            "suffix": "dead", 
-            "text_descr": "Deadtime Reference Table", 
-            "tpn": "cos_dead.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "disptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dispersion relation reference table", 
-            "ld_tpn": "cos_disp_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"deadcorr",
+            "rmap_relevance":"(DEADCORR != \"OMIT\")",
+            "suffix":"dead",
+            "text_descr":"Deadtime Reference Table",
+            "tpn":"cos_dead.tpn",
+            "unique_rowkeys":[]
+        },
+        "disptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dispersion relation reference table",
+            "ld_tpn":"cos_disp_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "disp", 
-            "text_descr": "Dispersion Relation Table", 
-            "tpn": "cos_disp.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"disp",
+            "text_descr":"Dispersion Relation Table",
+            "tpn":"cos_disp.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SEGMENT"
             ]
-        }, 
-        "flatfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "flat field reference image", 
-            "ld_tpn": "cos_flat_ld.tpn", 
-            "parkey": [
+        },
+        "flatfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"flat field reference image",
+            "ld_tpn":"cos_flat_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "flatcorr", 
-            "rmap_relevance": "(FLATCORR != \"OMIT\")", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "cos_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "fluxtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "photometric sensitivity reference table", 
-            "ld_tpn": "cos_phot_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"flatcorr",
+            "rmap_relevance":"(FLATCORR != \"OMIT\")",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"cos_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "fluxtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"photometric sensitivity reference table",
+            "ld_tpn":"cos_phot_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "LIFE_ADJ"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "fluxcorr", 
-            "rmap_relevance": "((OBSTYPE == \"SPECTROSCOPIC\") and (FLUXCORR != \"OMIT\"))", 
-            "suffix": "phot", 
-            "text_descr": "Sensitivity Reference Files", 
-            "tpn": "cos_phot.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"fluxcorr",
+            "rmap_relevance":"((OBSTYPE == \"SPECTROSCOPIC\") and (FLUXCORR != \"OMIT\"))",
+            "suffix":"phot",
+            "text_descr":"Sensitivity Reference Files",
+            "tpn":"cos_phot.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SEGMENT"
             ]
-        }, 
-        "geofile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "geometric distortion reference image", 
-            "ld_tpn": "cos_geo_ld.tpn", 
-            "parkey": [
+        },
+        "geofile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"geometric distortion reference image",
+            "ld_tpn":"cos_geo_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"FUV\")", 
-            "suffix": "geo", 
-            "text_descr": "Geometric Distortion Correction", 
-            "tpn": "cos_geo.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gsagtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "gain sag reference table", 
-            "ld_tpn": "cos_gsag_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"FUV\")",
+            "suffix":"geo",
+            "text_descr":"Geometric Distortion Correction",
+            "tpn":"cos_geo.tpn",
+            "unique_rowkeys":null
+        },
+        "gsagtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"gain sag reference table",
+            "ld_tpn":"cos_gsag_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"FUV\")", 
-            "suffix": "gsag", 
-            "text_descr": "Gain Sag Reference Table", 
-            "tpn": "cos_gsag.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "hvtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "fuv high voltage history", 
-            "ld_tpn": "cos_hv_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"FUV\")",
+            "suffix":"gsag",
+            "text_descr":"Gain Sag Reference Table",
+            "tpn":"cos_gsag.tpn",
+            "unique_rowkeys":[]
+        },
+        "hvtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"fuv high voltage history",
+            "ld_tpn":"cos_hv_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"FUV\")", 
-            "suffix": "hv", 
-            "text_descr": "High Voltage Reference Table", 
-            "tpn": "cos_hv.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"FUV\")",
+            "suffix":"hv",
+            "text_descr":"High Voltage Reference Table",
+            "tpn":"cos_hv.tpn",
+            "unique_rowkeys":[
                 "DATE"
             ]
-        }, 
-        "lamptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "template cal lamp spectra table", 
-            "ld_tpn": "cos_lamp_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+        },
+        "lamptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"template cal lamp spectra table",
+            "ld_tpn":"cos_lamp_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "lamp", 
-            "text_descr": "Template Calibration Lamp Spectra Table", 
-            "tpn": "cos_lamp.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "CENWAVE", 
-                "SEGMENT", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"lamp",
+            "text_descr":"Template Calibration Lamp Spectra Table",
+            "tpn":"cos_lamp.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "CENWAVE",
+                "SEGMENT",
                 "FPOFFSET"
             ]
-        }, 
-        "phatab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pulse height parameters reference table", 
-            "ld_tpn": "cos_pha_ld.tpn", 
-            "parkey": [
+        },
+        "phatab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pulse height parameters reference table",
+            "ld_tpn":"cos_pha_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"FUV\")", 
-            "suffix": "pha", 
-            "text_descr": "Pulse Height Parameters Table", 
-            "tpn": "cos_pha.tpn", 
-            "unique_rowkeys": [
-                "SEGMENT", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"FUV\")",
+            "suffix":"pha",
+            "text_descr":"Pulse Height Parameters Table",
+            "tpn":"cos_pha.tpn",
+            "unique_rowkeys":[
+                "SEGMENT",
                 "OPT_ELEM"
             ]
-        }, 
-        "proftab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "2d spectrum profile table", 
-            "ld_tpn": "cos_profile_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+        },
+        "proftab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"2d spectrum profile table",
+            "ld_tpn":"cos_profile_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "LIFE_ADJ"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "algncorr", 
-            "rmap_relevance": "(LIFE_ADJ == \"3.0\")", 
-            "suffix": "profile", 
-            "text_descr": "2D Spectrum Profile Table", 
-            "tpn": "cos_profile.tpn", 
-            "unique_rowkeys": [
-                "SEGMENT", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"algncorr",
+            "rmap_relevance":"(LIFE_ADJ == \"3.0\")",
+            "suffix":"profile",
+            "text_descr":"2D Spectrum Profile Table",
+            "tpn":"cos_profile.tpn",
+            "unique_rowkeys":[
+                "SEGMENT",
+                "OPT_ELEM",
+                "CENWAVE",
                 "APERTURE"
             ]
-        }, 
-        "spottab": {
-            "derived_from": "Initial hand made version 2015-10-19.", 
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filekind": "SPOTTAB", 
-            "filetype": "TRANSIENT BAD PIXEL REFERENCE TABLE", 
-            "instrument": "COS", 
-            "ld_tpn": "cos_spot_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "hst_cos_spottab_0000.rmap", 
-            "observatory": "HST", 
-            "parkey": [
+        },
+        "spottab":{
+            "derived_from":"Initial hand made version 2015-10-19.",
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filekind":"SPOTTAB",
+            "filetype":"TRANSIENT BAD PIXEL REFERENCE TABLE",
+            "instrument":"COS",
+            "ld_tpn":"cos_spot_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"hst_cos_spottab_0000.rmap",
+            "observatory":"HST",
+            "parkey":[
                 [
                     "DETECTOR"
-                ], 
+                ],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "TABLE", 
-            "reffile_required": "NO", 
-            "sha1sum": "f9da0314e944b4e2afa1ececb8b2c24f8459a4ab", 
-            "suffix": "spot", 
-            "text_descr": "Spot Position Table", 
-            "tpn": "cos_spot.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "spwcstab": {
-            "extra_keys": [
+            ],
+            "reffile_format":"TABLE",
+            "reffile_required":"NO",
+            "sha1sum":"f9da0314e944b4e2afa1ececb8b2c24f8459a4ab",
+            "suffix":"spot",
+            "text_descr":"Spot Position Table",
+            "tpn":"cos_spot.tpn",
+            "unique_rowkeys":null
+        },
+        "spwcstab":{
+            "extra_keys":[
                 "exptype"
-            ], 
-            "file_ext": ".fits", 
-            "filetype": "spectroscopic wcs parameters table", 
-            "ld_tpn": "cos_spwcs_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "file_ext":".fits",
+            "filetype":"spectroscopic wcs parameters table",
+            "ld_tpn":"cos_spwcs_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\") and (EXPTYPE == \"EXTERNAL/SCI\")", 
-            "suffix": "spwcs", 
-            "text_descr": "Spectroscopic WCS Parameters Table", 
-            "tpn": "cos_spwcs.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\") and (EXPTYPE == \"EXTERNAL/SCI\")",
+            "suffix":"spwcs",
+            "text_descr":"Spectroscopic WCS Parameters Table",
+            "tpn":"cos_spwcs.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SEGMENT"
             ]
-        }, 
-        "tdstab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "time dependent sensitivity table", 
-            "ld_tpn": "cos_tds_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+        },
+        "tdstab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"time dependent sensitivity table",
+            "ld_tpn":"cos_tds_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "tdscorr", 
-            "rmap_relevance": "((OBSTYPE == \"SPECTROSCOPIC\") and (TDSCORR != \"OMIT\"))", 
-            "suffix": "tds", 
-            "text_descr": "Time Dependent Sensitivity Table", 
-            "tpn": "cos_tds.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"tdscorr",
+            "rmap_relevance":"((OBSTYPE == \"SPECTROSCOPIC\") and (TDSCORR != \"OMIT\"))",
+            "suffix":"tds",
+            "text_descr":"Time Dependent Sensitivity Table",
+            "tpn":"cos_tds.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
                 "SEGMENT"
             ]
-        }, 
-        "tracetab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "1d spectral trace table", 
-            "ld_tpn": "cos_trace_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+        },
+        "tracetab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"1d spectral trace table",
+            "ld_tpn":"cos_trace_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "LIFE_ADJ"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "trcecorr", 
-            "rmap_relevance": "(LIFE_ADJ == \"3.0\")", 
-            "suffix": "trace", 
-            "text_descr": "1D Spectral Trace Table", 
-            "tpn": "cos_trace.tpn", 
-            "unique_rowkeys": [
-                "SEGMENT", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"trcecorr",
+            "rmap_relevance":"(LIFE_ADJ == \"3.0\")",
+            "suffix":"trace",
+            "text_descr":"1D Spectral Trace Table",
+            "tpn":"cos_trace.tpn",
+            "unique_rowkeys":[
+                "SEGMENT",
+                "OPT_ELEM",
+                "CENWAVE",
                 "APERTURE"
             ]
-        }, 
-        "twozxtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "two-zone spectral extraction parameters table", 
-            "ld_tpn": "cos_2zx_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+        },
+        "twozxtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"two-zone spectral extraction parameters table",
+            "ld_tpn":"cos_2zx_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "LIFE_ADJ"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "algncorr", 
-            "rmap_relevance": "(LIFE_ADJ == \"3.0\")", 
-            "suffix": "2zx", 
-            "text_descr": "Two-Zone Spectral Extraction Parameters Table", 
-            "tpn": "cos_2zx.tpn", 
-            "unique_rowkeys": [
-                "SEGMENT", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"algncorr",
+            "rmap_relevance":"(LIFE_ADJ == \"3.0\")",
+            "suffix":"2zx",
+            "text_descr":"Two-Zone Spectral Extraction Parameters Table",
+            "tpn":"cos_2zx.tpn",
+            "unique_rowkeys":[
+                "SEGMENT",
+                "OPT_ELEM",
+                "CENWAVE",
                 "APERTURE"
             ]
-        }, 
-        "walktab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "walk correction table", 
-            "ld_tpn": "cos_walk_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+        },
+        "walktab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"walk correction table",
+            "ld_tpn":"cos_walk_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSMODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "walkcorr", 
-            "rmap_relevance": "((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (WALKCORR != \"OMIT\"))", 
-            "suffix": "walk", 
-            "text_descr": "Walk Correction Reference Table", 
-            "tpn": "cos_walk.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"walkcorr",
+            "rmap_relevance":"((DETECTOR == \"FUV\" and OBSMODE == \"TIME-TAG\") and (WALKCORR != \"OMIT\"))",
+            "suffix":"walk",
+            "text_descr":"Walk Correction Reference Table",
+            "tpn":"cos_walk.tpn",
+            "unique_rowkeys":[
                 "SEGMENT"
             ]
-        }, 
-        "wcptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "wavecal parameters reference table", 
-            "ld_tpn": "cos_wcp_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+        },
+        "wcptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"wavecal parameters reference table",
+            "ld_tpn":"cos_wcp_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "wcp", 
-            "text_descr": "Wavecal Parameters Reference Table", 
-            "tpn": "cos_wcp.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"wcp",
+            "text_descr":"Wavecal Parameters Reference Table",
+            "tpn":"cos_wcp.tpn",
+            "unique_rowkeys":[
                 "OPT_ELEM"
             ]
-        }, 
-        "xtractab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "1-d extraction parameters table", 
-            "ld_tpn": "cos_1dx_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+        },
+        "xtractab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"1-d extraction parameters table",
+            "ld_tpn":"cos_1dx_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "LIFE_ADJ"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "1dx", 
-            "text_descr": "1-d Extraction Parameters Table", 
-            "tpn": "cos_1dx.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"1dx",
+            "text_descr":"1-d Extraction Parameters Table",
+            "tpn":"cos_1dx.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SEGMENT"
             ]
         }
-    }, 
-    "nicmos": {
-        "backtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "bkg", 
-            "ld_tpn": "nic_bkg_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "bkg", 
-            "text_descr": "Background Model Table", 
-            "tpn": "nic_bkg.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "darkfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "drk", 
-            "ld_tpn": "nic_drk_ld.tpn", 
-            "parkey": [
-                "CAMERA", 
-                "READOUT", 
-                "NREAD", 
-                "SAMP_SEQ", 
+    },
+    "nicmos":{
+        "backtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"bkg",
+            "ld_tpn":"nic_bkg_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"bkg",
+            "text_descr":"Background Model Table",
+            "tpn":"nic_bkg.tpn",
+            "unique_rowkeys":null
+        },
+        "darkfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"drk",
+            "ld_tpn":"nic_drk_ld.tpn",
+            "parkey":[
+                "CAMERA",
+                "READOUT",
+                "NREAD",
+                "SAMP_SEQ",
                 "OBSMODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(SAMP_SEQ not in [\"SPARS4\",\"SPARS16\",\"SPARS32\",\"SPARS128\"])", 
-            "suffix": "drk", 
-            "text_descr": "Dark Frame", 
-            "tpn": "nic_drk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flatfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "flt", 
-            "ld_tpn": "nic_flt_ld.tpn", 
-            "parkey": [
-                "CAMERA", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(SAMP_SEQ not in [\"SPARS4\",\"SPARS16\",\"SPARS32\",\"SPARS128\"])",
+            "suffix":"drk",
+            "text_descr":"Dark Frame",
+            "tpn":"nic_drk.tpn",
+            "unique_rowkeys":null
+        },
+        "flatfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"flt",
+            "ld_tpn":"nic_flt_ld.tpn",
+            "parkey":[
+                "CAMERA",
                 "FILTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(FILTER != \"BLANK\")", 
-            "suffix": "flt", 
-            "text_descr": "Flat Field", 
-            "tpn": "nic_flt.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "idctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "idc", 
-            "ld_tpn": "nic_idc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(FILTER != \"BLANK\")",
+            "suffix":"flt",
+            "text_descr":"Flat Field",
+            "tpn":"nic_flt.tpn",
+            "unique_rowkeys":null
+        },
+        "idctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"idc",
+            "ld_tpn":"nic_idc_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "idc", 
-            "text_descr": "Image Distortion Correction File", 
-            "tpn": "nic_idc.tpn", 
-            "unique_rowkeys": [
-                "DETCHIP", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"idc",
+            "text_descr":"Image Distortion Correction File",
+            "tpn":"nic_idc.tpn",
+            "unique_rowkeys":[
+                "DETCHIP",
                 "FILTER"
             ]
-        }, 
-        "illmfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ilm", 
-            "ld_tpn": "nic_ilm_ld.tpn", 
-            "parkey": [
-                "CAMERA", 
+        },
+        "illmfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ilm",
+            "ld_tpn":"nic_ilm_ld.tpn",
+            "parkey":[
+                "CAMERA",
                 "FILTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(FILTER != \"BLANK\")", 
-            "suffix": "ilm", 
-            "text_descr": "Illumination Pattern File", 
-            "tpn": "nic_ilm.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "maskfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "msk", 
-            "ld_tpn": "nic_msk_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(FILTER != \"BLANK\")",
+            "suffix":"ilm",
+            "text_descr":"Illumination Pattern File",
+            "tpn":"nic_ilm.tpn",
+            "unique_rowkeys":null
+        },
+        "maskfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"msk",
+            "ld_tpn":"nic_msk_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "msk", 
-            "text_descr": "Static Mask File", 
-            "tpn": "nic_msk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "nlinfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "lin", 
-            "ld_tpn": "nic_lin_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"msk",
+            "text_descr":"Static Mask File",
+            "tpn":"nic_msk.tpn",
+            "unique_rowkeys":null
+        },
+        "nlinfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"lin",
+            "ld_tpn":"nic_lin_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "lin", 
-            "text_descr": "Detector Linearity Correction File", 
-            "tpn": "nic_lin.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "noisfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "noi", 
-            "ld_tpn": "nic_noi_ld.tpn", 
-            "parkey": [
-                "CAMERA", 
-                "READOUT", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"lin",
+            "text_descr":"Detector Linearity Correction File",
+            "tpn":"nic_lin.tpn",
+            "unique_rowkeys":null
+        },
+        "noisfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"noi",
+            "ld_tpn":"nic_noi_ld.tpn",
+            "parkey":[
+                "CAMERA",
+                "READOUT",
                 "NREAD"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "noi", 
-            "text_descr": "Detector Read-noise File", 
-            "tpn": "nic_noi.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "pedsbtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "psb", 
-            "ld_tpn": "nic_psb_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "psb", 
-            "text_descr": "pedsbtab", 
-            "tpn": "nic_psb.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"noi",
+            "text_descr":"Detector Read-noise File",
+            "tpn":"nic_noi.tpn",
+            "unique_rowkeys":null
+        },
+        "pedsbtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"psb",
+            "ld_tpn":"nic_psb_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"psb",
+            "text_descr":"pedsbtab",
+            "tpn":"nic_psb.tpn",
+            "unique_rowkeys":[
                 "CAMERA"
             ]
-        }, 
-        "phottab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pht", 
-            "ld_tpn": "nic_pht_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "pht", 
-            "text_descr": "Phototmetric Calibration Table", 
-            "tpn": "nic_pht.tpn", 
-            "unique_rowkeys": [
+        },
+        "phottab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pht",
+            "ld_tpn":"nic_pht_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"pht",
+            "text_descr":"Phototmetric Calibration Table",
+            "tpn":"nic_pht.tpn",
+            "unique_rowkeys":[
                 "PHOTMODE"
             ]
-        }, 
-        "pmodfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pmd", 
-            "ld_tpn": "nic_pmd_ld.tpn", 
-            "parkey": [
+        },
+        "pmodfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pmd",
+            "ld_tpn":"nic_pmd_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "pmd", 
-            "text_descr": "Persistence Model Files", 
-            "tpn": "nic_pmd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "pmskfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pmk", 
-            "ld_tpn": "nic_pmk_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"pmd",
+            "text_descr":"Persistence Model Files",
+            "tpn":"nic_pmd.tpn",
+            "unique_rowkeys":null
+        },
+        "pmskfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pmk",
+            "ld_tpn":"nic_pmk_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "pmk", 
-            "text_descr": "Persistence Mask Files", 
-            "tpn": "nic_pmk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "rnlcortb": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "nlc", 
-            "ld_tpn": "nic_nlc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"pmk",
+            "text_descr":"Persistence Mask Files",
+            "tpn":"nic_pmk.tpn",
+            "unique_rowkeys":null
+        },
+        "rnlcortb":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"nlc",
+            "ld_tpn":"nic_nlc_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "nlc", 
-            "text_descr": "Nonlinearity Power Law Table", 
-            "tpn": "nic_nlc.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"nlc",
+            "text_descr":"Nonlinearity Power Law Table",
+            "tpn":"nic_nlc.tpn",
+            "unique_rowkeys":[
                 "WAVELENGTH"
             ]
-        }, 
-        "saacntab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "scn", 
-            "ld_tpn": "nic_scn_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "scn", 
-            "text_descr": "SAACLEAN Task Parameters", 
-            "tpn": "nic_scn.tpn", 
-            "unique_rowkeys": [
+        },
+        "saacntab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"scn",
+            "ld_tpn":"nic_scn_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"scn",
+            "text_descr":"SAACLEAN Task Parameters",
+            "tpn":"nic_scn.tpn",
+            "unique_rowkeys":[
                 "CAMERA"
             ]
-        }, 
-        "saadfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "sdk", 
-            "ld_tpn": "nic_sdk_ld.tpn", 
-            "parkey": [
+        },
+        "saadfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"sdk",
+            "ld_tpn":"nic_sdk_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "sdk", 
-            "text_descr": "Post Saa Dark Assoc.", 
-            "tpn": "nic_sdk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "tdffile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "tdf", 
-            "ld_tpn": "nic_tdf_ld.tpn", 
-            "parkey": [
-                "CAMERA", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"sdk",
+            "text_descr":"Post Saa Dark Assoc.",
+            "tpn":"nic_sdk.tpn",
+            "unique_rowkeys":null
+        },
+        "tdffile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"tdf",
+            "ld_tpn":"nic_tdf_ld.tpn",
+            "parkey":[
+                "CAMERA",
                 "FILTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(FILTER != \"BLANK\")", 
-            "suffix": "tdf", 
-            "text_descr": "Temperature Dependent Flat Fields", 
-            "tpn": "nic_tdf.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "tempfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "tdd", 
-            "ld_tpn": "nic_tdd_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(FILTER != \"BLANK\")",
+            "suffix":"tdf",
+            "text_descr":"Temperature Dependent Flat Fields",
+            "tpn":"nic_tdf.tpn",
+            "unique_rowkeys":null
+        },
+        "tempfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"tdd",
+            "ld_tpn":"nic_tdd_ld.tpn",
+            "parkey":[
                 "CAMERA"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "tdd", 
-            "text_descr": "Temperature-dependent Dark Reference File", 
-            "tpn": "nic_tdd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "zprattab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "zpr", 
-            "ld_tpn": "nic_zpr_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "zpr", 
-            "text_descr": "Nonlincor Zeropoint Scaling Table", 
-            "tpn": "nic_zpr.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"tdd",
+            "text_descr":"Temperature-dependent Dark Reference File",
+            "tpn":"nic_tdd.tpn",
+            "unique_rowkeys":null
+        },
+        "zprattab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"zpr",
+            "ld_tpn":"nic_zpr_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"zpr",
+            "text_descr":"Nonlincor Zeropoint Scaling Table",
+            "tpn":"nic_zpr.tpn",
+            "unique_rowkeys":[
                 "PHOTMODE"
             ]
         }
-    }, 
-    "stis": {
-        "apdestab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "aperture description table", 
-            "ld_tpn": "stis_apd_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "apd", 
-            "text_descr": "Aperture Description Table", 
-            "tpn": "stis_apd.tpn", 
-            "unique_rowkeys": [
+    },
+    "stis":{
+        "apdestab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"aperture description table",
+            "ld_tpn":"stis_apd_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"apd",
+            "text_descr":"Aperture Description Table",
+            "tpn":"stis_apd.tpn",
+            "unique_rowkeys":[
                 "APERTURE"
             ]
-        }, 
-        "apertab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "aperture throughput table", 
-            "ld_tpn": "stis_apt_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "apt", 
-            "text_descr": "Aperture Throughput Table", 
-            "tpn": "stis_apt.tpn", 
-            "unique_rowkeys": [
+        },
+        "apertab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"aperture throughput table",
+            "ld_tpn":"stis_apt_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"apt",
+            "text_descr":"Aperture Throughput Table",
+            "tpn":"stis_apt.tpn",
+            "unique_rowkeys":[
                 "APERTURE"
             ]
-        }, 
-        "biasfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ccd bias image", 
-            "ld_tpn": "stis_bia_ld.tpn", 
-            "parkey": [
-                "CCDAMP", 
-                "CCDGAIN", 
-                "CCDOFFST", 
-                "BINAXIS1", 
+        },
+        "biasfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ccd bias image",
+            "ld_tpn":"stis_bia_ld.tpn",
+            "parkey":[
+                "CCDAMP",
+                "CCDGAIN",
+                "CCDOFFST",
+                "BINAXIS1",
                 "BINAXIS2"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"CCD\")", 
-            "suffix": "bia", 
-            "text_descr": "Bias Frame", 
-            "tpn": "stis_bia.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "bpixtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "bad pixel table", 
-            "ld_tpn": "stis_bpx_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"CCD\")",
+            "suffix":"bia",
+            "text_descr":"Bias Frame",
+            "tpn":"stis_bia.tpn",
+            "unique_rowkeys":null
+        },
+        "bpixtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"bad pixel table",
+            "ld_tpn":"stis_bpx_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "bpx", 
-            "text_descr": "Data Quality (Bad Pixel) Initialization Table", 
-            "tpn": "stis_bpx.tpn", 
-            "unique_rowkeys": [
-                "PIX1", 
-                "PIX2", 
-                "LENGTH", 
-                "AXIS", 
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"bpx",
+            "text_descr":"Data Quality (Bad Pixel) Initialization Table",
+            "tpn":"stis_bpx.tpn",
+            "unique_rowkeys":[
+                "PIX1",
+                "PIX2",
+                "LENGTH",
+                "AXIS",
+                "OPT_ELEM",
                 "VALUE"
             ]
-        }, 
-        "ccdtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ccd parameters table", 
-            "ld_tpn": "stis_ccd_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"CCD\")", 
-            "suffix": "ccd", 
-            "text_descr": "Ccd Parameters Table", 
-            "tpn": "stis_ccd.tpn", 
-            "unique_rowkeys": [
-                "CCDAMP", 
-                "CCDGAIN", 
-                "CCDOFFST", 
-                "BINAXIS1", 
+        },
+        "ccdtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ccd parameters table",
+            "ld_tpn":"stis_ccd_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"CCD\")",
+            "suffix":"ccd",
+            "text_descr":"Ccd Parameters Table",
+            "tpn":"stis_ccd.tpn",
+            "unique_rowkeys":[
+                "CCDAMP",
+                "CCDGAIN",
+                "CCDOFFST",
+                "BINAXIS1",
                 "BINAXIS2"
             ]
-        }, 
-        "cdstab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "cross-disperser scattering table", 
-            "ld_tpn": "stis_cds_ld.tpn", 
-            "parkey": [
+        },
+        "cdstab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"cross-disperser scattering table",
+            "ld_tpn":"stis_cds_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "cds", 
-            "text_descr": "Cross-disperser Scattering Table", 
-            "tpn": "stis_cds.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"cds",
+            "text_descr":"Cross-disperser Scattering Table",
+            "tpn":"stis_cds.tpn",
+            "unique_rowkeys":[
                 "OPT_ELEM"
             ]
-        }, 
-        "crrejtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "cosmic ray rejection table", 
-            "ld_tpn": "stis_crr_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"CCD\")", 
-            "suffix": "crr", 
-            "text_descr": "Cosmic Ray Rejection Parameter Table", 
-            "tpn": "stis_crr.tpn", 
-            "unique_rowkeys": [
-                "CRSPLIT", 
+        },
+        "crrejtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"cosmic ray rejection table",
+            "ld_tpn":"stis_crr_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"CCD\")",
+            "suffix":"crr",
+            "text_descr":"Cosmic Ray Rejection Parameter Table",
+            "tpn":"stis_crr.tpn",
+            "unique_rowkeys":[
+                "CRSPLIT",
                 "MEANEXP"
             ]
-        }, 
-        "darkfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dark image", 
-            "ld_tpn": "stis_drk_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
+        },
+        "darkfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dark image",
+            "ld_tpn":"stis_drk_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
                 "CCDGAIN"
-            ], 
-            "parkey_relevance": {
-                "ccdamp": "(DETECTOR == \"CCD\")", 
-                "ccdgain": "(DETECTOR == \"CCD\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "drk", 
-            "text_descr": "Dark Frame", 
-            "tpn": "stis_drk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "disptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dispersion coefficients table", 
-            "ld_tpn": "stis_dsp_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{
+                "ccdamp":"(DETECTOR == \"CCD\")",
+                "ccdgain":"(DETECTOR == \"CCD\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"drk",
+            "text_descr":"Dark Frame",
+            "tpn":"stis_drk.tpn",
+            "unique_rowkeys":null
+        },
+        "disptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dispersion coefficients table",
+            "ld_tpn":"stis_dsp_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "dsp", 
-            "text_descr": "Dispersion Relation Table", 
-            "tpn": "stis_dsp.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"dsp",
+            "text_descr":"Dispersion Relation Table",
+            "tpn":"stis_dsp.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "CENWAVE",
                 "A2CENTER"
             ]
-        }, 
-        "echsctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "echelle grating scattering table", 
-            "ld_tpn": "stis_ech_ld.tpn", 
-            "parkey": [
+        },
+        "echsctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"echelle grating scattering table",
+            "ld_tpn":"stis_ech_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "ech", 
-            "text_descr": "Echelle Scattering Table", 
-            "tpn": "stis_ech.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"ech",
+            "text_descr":"Echelle Scattering Table",
+            "tpn":"stis_ech.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
                 "SPORDER"
             ]
-        }, 
-        "exstab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "echelle cross-dispersion scattering table", 
-            "ld_tpn": "stis_exs_ld.tpn", 
-            "parkey": [
+        },
+        "exstab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"echelle cross-dispersion scattering table",
+            "ld_tpn":"stis_exs_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "exs", 
-            "text_descr": "Echelle Cross-Dispersion Scattering Table", 
-            "tpn": "stis_exs.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"exs",
+            "text_descr":"Echelle Cross-Dispersion Scattering Table",
+            "tpn":"stis_exs.tpn",
+            "unique_rowkeys":[
                 "OPT_ELEM"
             ]
-        }, 
-        "gactab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "grating-aperture correction table", 
-            "ld_tpn": "stis_gac_ld.tpn", 
-            "parkey": [
+        },
+        "gactab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"grating-aperture correction table",
+            "ld_tpn":"stis_gac_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "((OBSTYPE == \"SPECTROSCOPIC\") and (DETECTOR == \"CCD\"))", 
-            "suffix": "gac", 
-            "text_descr": "Grating-Aperture Correction Table", 
-            "tpn": "stis_gac.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"((OBSTYPE == \"SPECTROSCOPIC\") and (DETECTOR == \"CCD\"))",
+            "suffix":"gac",
+            "text_descr":"Grating-Aperture Correction Table",
+            "tpn":"stis_gac.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
                 "CENWAVE"
             ]
-        }, 
-        "halotab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "detector halo table", 
-            "ld_tpn": "stis_hal_ld.tpn", 
-            "parkey": [
+        },
+        "halotab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"detector halo table",
+            "ld_tpn":"stis_hal_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "hal", 
-            "text_descr": "Detectore Halo Table", 
-            "tpn": "stis_hal.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"hal",
+            "text_descr":"Detectore Halo Table",
+            "tpn":"stis_hal.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
                 "HALOWAVE"
             ]
-        }, 
-        "idctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "image distortion correction table", 
-            "ld_tpn": "stis_idc_ld.tpn", 
-            "parkey": [
+        },
+        "idctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"image distortion correction table",
+            "ld_tpn":"stis_idc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"IMAGING\")", 
-            "suffix": "idc", 
-            "text_descr": "Image Distortion Correction File", 
-            "tpn": "stis_idc.tpn", 
-            "unique_rowkeys": [
-                "FILTER", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"IMAGING\")",
+            "suffix":"idc",
+            "text_descr":"Image Distortion Correction File",
+            "tpn":"stis_idc.tpn",
+            "unique_rowkeys":[
+                "FILTER",
                 "DIRECTION"
             ]
-        }, 
-        "imphttab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "image photometry table", 
-            "ld_tpn": "stis_imp_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "yes", 
-            "reffile_switch": "photcorr", 
-            "rmap_relevance": "(PHOTCORR != \"OMIT\")", 
-            "suffix": "imp", 
-            "text_descr": "Photometry Keyword Table", 
-            "tpn": "stis_imp.tpn", 
-            "unique_rowkeys": [
+        },
+        "imphttab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"image photometry table",
+            "ld_tpn":"stis_imp_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"yes",
+            "reffile_switch":"photcorr",
+            "rmap_relevance":"(PHOTCORR != \"OMIT\")",
+            "suffix":"imp",
+            "text_descr":"Photometry Keyword Table",
+            "tpn":"stis_imp.tpn",
+            "unique_rowkeys":[
                 "OBSMODE"
             ]
-        }, 
-        "inangtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "incidence angle correction table", 
-            "ld_tpn": "stis_iac_ld.tpn", 
-            "parkey": [
+        },
+        "inangtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"incidence angle correction table",
+            "ld_tpn":"stis_iac_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "iac", 
-            "text_descr": "Incidence Angle Correction Table", 
-            "tpn": "stis_iac.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "SPORDER", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"iac",
+            "text_descr":"Incidence Angle Correction Table",
+            "tpn":"stis_iac.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "SPORDER",
                 "CENWAVE"
             ]
-        }, 
-        "lamptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "template cal lamp spectra table", 
-            "ld_tpn": "stis_lmp_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "lmp", 
-            "text_descr": "Template Calibration Lamp Spectra Table", 
-            "tpn": "stis_lmp.tpn", 
-            "unique_rowkeys": [
-                "LAMPSET", 
-                "OPT_ELEM", 
+        },
+        "lamptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"template cal lamp spectra table",
+            "ld_tpn":"stis_lmp_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"lmp",
+            "text_descr":"Template Calibration Lamp Spectra Table",
+            "tpn":"stis_lmp.tpn",
+            "unique_rowkeys":[
+                "LAMPSET",
+                "OPT_ELEM",
                 "SCLAMP"
             ]
-        }, 
-        "lfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "low-order flatfield image", 
-            "ld_tpn": "stis_lfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OPT_ELEM", 
-                "OBSTYPE", 
-                "CENWAVE", 
+        },
+        "lfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"low-order flatfield image",
+            "ld_tpn":"stis_lfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OPT_ELEM",
+                "OBSTYPE",
+                "CENWAVE",
                 "APERTURE"
-            ], 
-            "parkey_relevance": {
-                "aperture": "(OBSTYPE == \"IMAGING\")", 
-                "cenwave": "(OBSTYPE == \"SPECTROSCOPIC\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "lfl", 
-            "text_descr": "Low-order Flat Field Image", 
-            "tpn": [
+            ],
+            "parkey_relevance":{
+                "aperture":"(OBSTYPE == \"IMAGING\")",
+                "cenwave":"(OBSTYPE == \"SPECTROSCOPIC\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"lfl",
+            "text_descr":"Low-order Flat Field Image",
+            "tpn":[
                 [
-                    "OBSTYPE == 'IMAGING'", 
+                    "OBSTYPE == 'IMAGING'",
                     "stis_ilfl.tpn"
-                ], 
+                ],
                 [
-                    "OBSTYPE == 'SPECTROSCOPIC'", 
+                    "OBSTYPE == 'SPECTROSCOPIC'",
                     "stis_slfl.tpn"
                 ]
-            ], 
-            "unique_rowkeys": null
-        }, 
-        "mlintab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "mama linearity table", 
-            "ld_tpn": "stis_lin_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\")", 
-            "suffix": "lin", 
-            "text_descr": "Mama Linearity Table", 
-            "tpn": "stis_lin.tpn", 
-            "unique_rowkeys": [
+            ],
+            "unique_rowkeys":null
+        },
+        "mlintab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"mama linearity table",
+            "ld_tpn":"stis_lin_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\")",
+            "suffix":"lin",
+            "text_descr":"Mama Linearity Table",
+            "tpn":"stis_lin.tpn",
+            "unique_rowkeys":[
                 "DETECTOR"
             ]
-        }, 
-        "mofftab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "mama offset correction table", 
-            "ld_tpn": "stis_moc_ld.tpn", 
-            "parkey": [
+        },
+        "mofftab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"mama offset correction table",
+            "ld_tpn":"stis_moc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "moc", 
-            "text_descr": "Mama Offset Correction Table", 
-            "tpn": "stis_moc.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"moc",
+            "text_descr":"Mama Offset Correction Table",
+            "tpn":"stis_moc.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "CENWAVE",
                 "SPORDER"
             ]
-        }, 
-        "pctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "photometric correction table", 
-            "ld_tpn": "stis_pct_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OBSTYPE", 
+        },
+        "pctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"photometric correction table",
+            "ld_tpn":"stis_pct_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OBSTYPE",
                 "OPT_ELEM"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "pct", 
-            "text_descr": "Photometric Correction Table", 
-            "tpn": "stis_pct.tpn", 
-            "unique_rowkeys": [
-                "CENWAVE", 
-                "APERTURE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"pct",
+            "text_descr":"Photometric Correction Table",
+            "tpn":"stis_pct.tpn",
+            "unique_rowkeys":[
+                "CENWAVE",
+                "APERTURE",
                 "EXTRHEIGHT"
             ]
-        }, 
-        "pfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pixel-to-pixel flatfield image", 
-            "ld_tpn": "stis_pfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "OPT_ELEM", 
-                "OBSTYPE", 
-                "CENWAVE", 
+        },
+        "pfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pixel-to-pixel flatfield image",
+            "ld_tpn":"stis_pfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "OPT_ELEM",
+                "OBSTYPE",
+                "CENWAVE",
                 "APERTURE"
-            ], 
-            "parkey_relevance": {
-                "aperture": "(OBSTYPE == \"IMAGING\")", 
-                "cenwave": "(OBSTYPE == \"SPECTROSCOPIC\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "pfl", 
-            "text_descr": "Pixel To Pixel Flat Field Image", 
-            "tpn": [
+            ],
+            "parkey_relevance":{
+                "aperture":"(OBSTYPE == \"IMAGING\")",
+                "cenwave":"(OBSTYPE == \"SPECTROSCOPIC\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"pfl",
+            "text_descr":"Pixel To Pixel Flat Field Image",
+            "tpn":[
                 [
-                    "OBSTYPE == 'IMAGING'", 
+                    "OBSTYPE == 'IMAGING'",
                     "stis_ipfl.tpn"
-                ], 
+                ],
                 [
-                    "OBSTYPE == 'SPECTROSCOPIC'", 
+                    "OBSTYPE == 'SPECTROSCOPIC'",
                     "stis_spfl.tpn"
                 ]
-            ], 
-            "unique_rowkeys": null
-        }, 
-        "phottab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "photometric conversion table", 
-            "ld_tpn": "stis_pht_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "unique_rowkeys":null
+        },
+        "phottab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"photometric conversion table",
+            "ld_tpn":"stis_pht_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "OBSTYPE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "pht", 
-            "text_descr": "Phototmetric Calibration Table", 
-            "tpn": "stis_pht.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"pht",
+            "text_descr":"Phototmetric Calibration Table",
+            "tpn":"stis_pht.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "CENWAVE",
                 "SPORDER"
             ]
-        }, 
-        "riptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "echelle ripple table", 
-            "ld_tpn": "stis_rip_ld.tpn", 
-            "parkey": [
+        },
+        "riptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"echelle ripple table",
+            "ld_tpn":"stis_rip_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "rip", 
-            "text_descr": "Echelle Ripple Table", 
-            "tpn": "stis_rip.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "SPORDER", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"rip",
+            "text_descr":"Echelle Ripple Table",
+            "tpn":"stis_rip.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "SPORDER",
                 "CENWAVE"
             ]
-        }, 
-        "sdctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "2-d spectrum distortion correction table", 
-            "ld_tpn": "stis_sdc_ld.tpn", 
-            "parkey": [
+        },
+        "sdctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"2-d spectrum distortion correction table",
+            "ld_tpn":"stis_sdc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "sdc", 
-            "text_descr": "2-d Spectrum Distortion Corrections", 
-            "tpn": "stis_sdc.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"sdc",
+            "text_descr":"2-d Spectrum Distortion Corrections",
+            "tpn":"stis_sdc.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SPORDER"
             ]
-        }, 
-        "sptrctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "1-d spectrum trace table", 
-            "ld_tpn": "stis_1dt_ld.tpn", 
-            "parkey": [
+        },
+        "sptrctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"1-d spectrum trace table",
+            "ld_tpn":"stis_1dt_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "1dt", 
-            "text_descr": "1-d Spectrum Trace Table", 
-            "tpn": "stis_1dt.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"1dt",
+            "text_descr":"1-d Spectrum Trace Table",
+            "tpn":"stis_1dt.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
+                "CENWAVE",
                 "A2CENTER"
             ]
-        }, 
-        "srwtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "scattering reference wavelengths table", 
-            "ld_tpn": "stis_srw_ld.tpn", 
-            "parkey": [
+        },
+        "srwtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"scattering reference wavelengths table",
+            "ld_tpn":"stis_srw_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "srw", 
-            "text_descr": "Scattering Reference Wavelength Table", 
-            "tpn": "stis_srw.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"srw",
+            "text_descr":"Scattering Reference Wavelength Table",
+            "tpn":"stis_srw.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
                 "CENWAVE"
             ]
-        }, 
-        "tdctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dark correction table", 
-            "ld_tpn": "stis_tdc_ld.tpn", 
-            "parkey": [
+        },
+        "tdctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dark correction table",
+            "ld_tpn":"stis_tdc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"NUV-MAMA\")", 
-            "suffix": "tdc", 
-            "text_descr": "Nuv Dark Correction Table", 
-            "tpn": "stis_tdc.tpn", 
-            "unique_rowkeys": []
-        }, 
-        "tdstab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "time dependent sensitivity table", 
-            "ld_tpn": "stis_tds_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"NUV-MAMA\")",
+            "suffix":"tdc",
+            "text_descr":"Nuv Dark Correction Table",
+            "tpn":"stis_tdc.tpn",
+            "unique_rowkeys":[]
+        },
+        "tdstab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"time dependent sensitivity table",
+            "ld_tpn":"stis_tds_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "tds", 
-            "text_descr": "Time Dependent Sensitivity Table", 
-            "tpn": "stis_tds.tpn", 
-            "unique_rowkeys": [
-                "OPT_ELEM", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"tds",
+            "text_descr":"Time Dependent Sensitivity Table",
+            "tpn":"stis_tds.tpn",
+            "unique_rowkeys":[
+                "OPT_ELEM",
                 "REF_TEMP"
             ]
-        }, 
-        "teltab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "telescope psf table", 
-            "ld_tpn": "stis_tel_ld.tpn", 
-            "parkey": [
+        },
+        "teltab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"telescope psf table",
+            "ld_tpn":"stis_tel_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "tel", 
-            "text_descr": "Telescope Point Spread Function Table", 
-            "tpn": "stis_tel.tpn", 
-            "unique_rowkeys": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"tel",
+            "text_descr":"Telescope Point Spread Function Table",
+            "tpn":"stis_tel.tpn",
+            "unique_rowkeys":[
                 "PSFWAVE"
             ]
-        }, 
-        "wcptab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "wavecal parameters table", 
-            "ld_tpn": "stis_wcp_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "wcp", 
-            "text_descr": "Wavecal Parameters Reference Table", 
-            "tpn": "stis_wcp.tpn", 
-            "unique_rowkeys": [
-                "DETECTOR", 
+        },
+        "wcptab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"wavecal parameters table",
+            "ld_tpn":"stis_wcp_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"wcp",
+            "text_descr":"Wavecal Parameters Reference Table",
+            "tpn":"stis_wcp.tpn",
+            "unique_rowkeys":[
+                "DETECTOR",
                 "OPT_ELEM"
             ]
-        }, 
-        "xtractab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "1-d extraction parameter table", 
-            "ld_tpn": "stis_1dx_ld.tpn", 
-            "parkey": [
+        },
+        "xtractab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"1-d extraction parameter table",
+            "ld_tpn":"stis_1dx_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(OBSTYPE == \"SPECTROSCOPIC\")", 
-            "suffix": "1dx", 
-            "text_descr": "1-d Extraction Parameters Table", 
-            "tpn": "stis_1dx.tpn", 
-            "unique_rowkeys": [
-                "APERTURE", 
-                "OPT_ELEM", 
-                "CENWAVE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(OBSTYPE == \"SPECTROSCOPIC\")",
+            "suffix":"1dx",
+            "text_descr":"1-d Extraction Parameters Table",
+            "tpn":"stis_1dx.tpn",
+            "unique_rowkeys":[
+                "APERTURE",
+                "OPT_ELEM",
+                "CENWAVE",
                 "SPORDER"
             ]
         }
-    }, 
-    "wfc3": {
-        "atodtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "analog-to-digital", 
-            "ld_tpn": "wfc3_a2d_ld.tpn", 
-            "parkey": [
+    },
+    "wfc3":{
+        "atodtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"analog-to-digital",
+            "ld_tpn":"wfc3_a2d_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "atodcorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\") and (ATODCORR != \"OMIT\"))", 
-            "suffix": "a2d", 
-            "text_descr": "Analog To Digital Lookup Table", 
-            "tpn": "wfc3_a2d.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "REF_KEY", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"atodcorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\") and (ATODCORR != \"OMIT\"))",
+            "suffix":"a2d",
+            "text_descr":"Analog To Digital Lookup Table",
+            "tpn":"wfc3_a2d.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CCDAMP",
+                "CCDGAIN",
+                "REF_KEY",
                 "REF_KEY_VALUE"
             ]
-        }, 
-        "biacfile": {
-            "derived_from": "Derived from TEST hst_wfc3_biacfile_0004.rmap on 2016-01-22", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "BIACFILE", 
-            "filetype": "CTEBIAS", 
-            "instrument": "WFC3", 
-            "ld_tpn": "wfc3_bic_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "hst_wfc3_biacfile_0004.rmap", 
-            "observatory": "HST", 
-            "parkey": [
-                [], 
+        },
+        "biacfile":{
+            "derived_from":"Derived from TEST hst_wfc3_biacfile_0004.rmap on 2016-01-22",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"BIACFILE",
+            "filetype":"CTEBIAS",
+            "instrument":"WFC3",
+            "ld_tpn":"wfc3_bic_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"hst_wfc3_biacfile_0004.rmap",
+            "observatory":"HST",
+            "parkey":[
+                [],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "IMAGE", 
-            "reffile_required": "YES", 
-            "reffile_switch": "PCTECORR", 
-            "rmap_relevance": "(DETECTOR == \"UVIS\" and PCTECORR == \"PERFORM\")", 
-            "sha1sum": "74052c1bda830cc94c8940c0215a0f8497838a39", 
-            "suffix": "bic", 
-            "text_descr": "CTE Bias Frame", 
-            "tpn": "wfc3_bic.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "biasfile": {
-            "extra_keys": [
+            ],
+            "reffile_format":"IMAGE",
+            "reffile_required":"YES",
+            "reffile_switch":"PCTECORR",
+            "rmap_relevance":"(DETECTOR == \"UVIS\" and PCTECORR == \"PERFORM\")",
+            "sha1sum":"74052c1bda830cc94c8940c0215a0f8497838a39",
+            "suffix":"bic",
+            "text_descr":"CTE Bias Frame",
+            "tpn":"wfc3_bic.tpn",
+            "unique_rowkeys":null
+        },
+        "biasfile":{
+            "extra_keys":[
                 "subarray"
-            ], 
-            "file_ext": ".fits", 
-            "filetype": "bias", 
-            "ld_tpn": "wfc3_bia_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "BINAXIS1", 
-                "BINAXIS2", 
-                "APERTURE", 
+            ],
+            "file_ext":".fits",
+            "filetype":"bias",
+            "ld_tpn":"wfc3_bia_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "CCDGAIN",
+                "BINAXIS1",
+                "BINAXIS2",
+                "APERTURE",
                 "CHINJECT"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "yes", 
-            "reffile_switch": "biascorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\") and (BIASCORR != \"OMIT\"))", 
-            "suffix": "bia", 
-            "text_descr": "Bias Frame", 
-            "tpn": "wfc3_bia.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "bpixtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "bad pixels", 
-            "ld_tpn": "wfc3_bpx_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"yes",
+            "reffile_switch":"biascorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\") and (BIASCORR != \"OMIT\"))",
+            "suffix":"bia",
+            "text_descr":"Bias Frame",
+            "tpn":"wfc3_bia.tpn",
+            "unique_rowkeys":null
+        },
+        "bpixtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"bad pixels",
+            "ld_tpn":"wfc3_bpx_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "dqicorr", 
-            "rmap_relevance": "(DQICORR != \"OMIT\")", 
-            "suffix": "bpx", 
-            "text_descr": "Data Quality (Bad Pixel) Initialization Table", 
-            "tpn": "wfc3_bpx.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "PIX1", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"dqicorr",
+            "rmap_relevance":"(DQICORR != \"OMIT\")",
+            "suffix":"bpx",
+            "text_descr":"Data Quality (Bad Pixel) Initialization Table",
+            "tpn":"wfc3_bpx.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "PIX1",
                 "PIX2"
             ]
-        }, 
-        "ccdtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "ccd parameters", 
-            "ld_tpn": "wfc3_ccd_ld.tpn", 
-            "parkey": [
+        },
+        "ccdtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"ccd parameters",
+            "ld_tpn":"wfc3_ccd_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "ccd", 
-            "text_descr": "Ccd Parameters Table", 
-            "tpn": "wfc3_ccd.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CCDAMP", 
-                "CCDGAIN", 
-                "CCDOFSTA", 
-                "CCDOFSTB", 
-                "CCDOFSTC", 
-                "CCDOFSTD", 
-                "BINAXIS1", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"ccd",
+            "text_descr":"Ccd Parameters Table",
+            "tpn":"wfc3_ccd.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CCDAMP",
+                "CCDGAIN",
+                "CCDOFSTA",
+                "CCDOFSTB",
+                "CCDOFSTC",
+                "CCDOFSTD",
+                "BINAXIS1",
                 "BINAXIS2"
             ]
-        }, 
-        "crrejtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "cosmic ray rejection", 
-            "ld_tpn": "wfc3_crr_ld.tpn", 
-            "parkey": [
+        },
+        "crrejtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"cosmic ray rejection",
+            "ld_tpn":"wfc3_crr_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "crr", 
-            "text_descr": "Cosmic Ray Rejection Parameter Table", 
-            "tpn": "wfc3_crr.tpn", 
-            "unique_rowkeys": [
-                "CRSPLIT", 
-                "MEANEXP", 
-                "CCDCHIP", 
-                "SCALENSE", 
-                "INITGUES", 
-                "SKYSUB", 
-                "CRSIGMAS", 
-                "CRRADIUS", 
-                "CRTHRESH", 
-                "BADINPDQ", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"crr",
+            "text_descr":"Cosmic Ray Rejection Parameter Table",
+            "tpn":"wfc3_crr.tpn",
+            "unique_rowkeys":[
+                "CRSPLIT",
+                "MEANEXP",
+                "CCDCHIP",
+                "SCALENSE",
+                "INITGUES",
+                "SKYSUB",
+                "CRSIGMAS",
+                "CRRADIUS",
+                "CRTHRESH",
+                "BADINPDQ",
                 "CRMASK"
             ]
-        }, 
-        "d2imfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "uvis d2i file", 
-            "ld_tpn": "wfc3_d2i_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\") and (DRIZCORR != \"OMIT\"))", 
-            "suffix": "d2i", 
-            "text_descr": "Column Correction File", 
-            "tpn": "wfc3_d2i.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "darkfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dark", 
-            "ld_tpn": "wfc3_drk_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "BINAXIS1", 
-                "BINAXIS2", 
-                "CCDGAIN", 
-                "SAMP_SEQ", 
+        },
+        "d2imfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"uvis d2i file",
+            "ld_tpn":"wfc3_d2i_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\") and (DRIZCORR != \"OMIT\"))",
+            "suffix":"d2i",
+            "text_descr":"Column Correction File",
+            "tpn":"wfc3_d2i.tpn",
+            "unique_rowkeys":null
+        },
+        "darkfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dark",
+            "ld_tpn":"wfc3_drk_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "BINAXIS1",
+                "BINAXIS2",
+                "CCDGAIN",
+                "SAMP_SEQ",
                 "SUBTYPE"
-            ], 
-            "parkey_relevance": {
-                "binaxis1": "(DETECTOR == \"UVIS\")", 
-                "binaxis2": "(DETECTOR == \"UVIS\")", 
-                "ccdgain": "(DETECTOR == \"IR\")", 
-                "samp_seq": "(DETECTOR == \"IR\")", 
-                "subtype": "(DETECTOR == \"IR\")"
-            }, 
-            "reffile_format": "IMAGE", 
-            "reffile_required": "none", 
-            "reffile_switch": "darkcorr", 
-            "rmap_relevance": "(DARKCORR != \"OMIT\")", 
-            "suffix": "drk", 
-            "text_descr": "Dark Frame", 
-            "tpn": "wfc3_drk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "delta flat", 
-            "ld_tpn": "wfc3_dfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "FILTER", 
-                "BINAXIS1", 
+            ],
+            "parkey_relevance":{
+                "binaxis1":"(DETECTOR == \"UVIS\")",
+                "binaxis2":"(DETECTOR == \"UVIS\")",
+                "ccdgain":"(DETECTOR == \"IR\")",
+                "samp_seq":"(DETECTOR == \"IR\")",
+                "subtype":"(DETECTOR == \"IR\")"
+            },
+            "reffile_format":"IMAGE",
+            "reffile_required":"none",
+            "reffile_switch":"darkcorr",
+            "rmap_relevance":"(DARKCORR != \"OMIT\")",
+            "suffix":"drk",
+            "text_descr":"Dark Frame",
+            "tpn":"wfc3_drk.tpn",
+            "unique_rowkeys":null
+        },
+        "dfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"delta flat",
+            "ld_tpn":"wfc3_dfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "FILTER",
+                "BINAXIS1",
                 "BINAXIS2"
-            ], 
-            "parkey_relevance": {
-                "binaxis1": "(DETECTOR == \"UVIS\")", 
-                "binaxis2": "(DETECTOR == \"UVIS\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "flatcorr", 
-            "rmap_relevance": "(FLATCORR != \"OMIT\")", 
-            "suffix": "dfl", 
-            "text_descr": "Delta Flat Field Image", 
-            "tpn": "wfc3_dfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "drkcfile": {
-            "derived_from": "Derived from TEST hst_wfc3_drkcfile_0005.rmap on 2016-01-22", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DRKCFILE", 
-            "filetype": "CTEDARK", 
-            "instrument": "WFC3", 
-            "ld_tpn": "wfc3_dkc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "hst_wfc3_drkcfile_0005.rmap", 
-            "observatory": "HST", 
-            "parkey": [
-                [], 
+            ],
+            "parkey_relevance":{
+                "binaxis1":"(DETECTOR == \"UVIS\")",
+                "binaxis2":"(DETECTOR == \"UVIS\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"flatcorr",
+            "rmap_relevance":"(FLATCORR != \"OMIT\")",
+            "suffix":"dfl",
+            "text_descr":"Delta Flat Field Image",
+            "tpn":"wfc3_dfl.tpn",
+            "unique_rowkeys":null
+        },
+        "drkcfile":{
+            "derived_from":"Derived from TEST hst_wfc3_drkcfile_0005.rmap on 2016-01-22",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DRKCFILE",
+            "filetype":"CTEDARK",
+            "instrument":"WFC3",
+            "ld_tpn":"wfc3_dkc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"hst_wfc3_drkcfile_0005.rmap",
+            "observatory":"HST",
+            "parkey":[
+                [],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "IMAGE", 
-            "reffile_required": "YES", 
-            "reffile_switch": "PCTECORR", 
-            "rmap_relevance": "(DETECTOR == \"UVIS\" and PCTECORR == \"PERFORM\")", 
-            "sha1sum": "0eb49a689cbe7d31d82fba3bc47bc07d340fb144", 
-            "suffix": "dkc", 
-            "text_descr": "Cte Corrected Dark", 
-            "tpn": "wfc3_dkc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flshfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "post flash", 
-            "ld_tpn": "wfc3_fls_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "BINAXIS1", 
-                "BINAXIS2", 
-                "FLASHCUR", 
+            ],
+            "reffile_format":"IMAGE",
+            "reffile_required":"YES",
+            "reffile_switch":"PCTECORR",
+            "rmap_relevance":"(DETECTOR == \"UVIS\" and PCTECORR == \"PERFORM\")",
+            "sha1sum":"0eb49a689cbe7d31d82fba3bc47bc07d340fb144",
+            "suffix":"dkc",
+            "text_descr":"Cte Corrected Dark",
+            "tpn":"wfc3_dkc.tpn",
+            "unique_rowkeys":null
+        },
+        "flshfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"post flash",
+            "ld_tpn":"wfc3_fls_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "BINAXIS1",
+                "BINAXIS2",
+                "FLASHCUR",
                 "SHUTRPOS"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "flshcorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\" and FLASHCUR != \"ZERO\") and (FLSHCORR != \"OMIT\"))", 
-            "suffix": "fls", 
-            "text_descr": "Post-flash Image", 
-            "tpn": "wfc3_fls.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "idctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "distortion coefficients", 
-            "ld_tpn": "wfc3_idc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"flshcorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\" and FLASHCUR != \"ZERO\") and (FLSHCORR != \"OMIT\"))",
+            "suffix":"fls",
+            "text_descr":"Post-flash Image",
+            "tpn":"wfc3_fls.tpn",
+            "unique_rowkeys":null
+        },
+        "idctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"distortion coefficients",
+            "ld_tpn":"wfc3_idc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "idc", 
-            "text_descr": "Image Distortion Correction File", 
-            "tpn": "wfc3_idc.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "FILTER", 
-                "V2REF", 
-                "V3REF", 
-                "XSIZE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"idc",
+            "text_descr":"Image Distortion Correction File",
+            "tpn":"wfc3_idc.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "FILTER",
+                "V2REF",
+                "V3REF",
+                "XSIZE",
                 "YSIZE"
             ]
-        }, 
-        "imphttab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "image photometry table", 
-            "ld_tpn": "wfc3_imp_ld.tpn", 
-            "parkey": [
+        },
+        "imphttab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"image photometry table",
+            "ld_tpn":"wfc3_imp_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "photcorr", 
-            "rmap_relevance": "(PHOTCORR != \"OMIT\")", 
-            "suffix": "imp", 
-            "text_descr": "Photometry Keyword Table", 
-            "tpn": "wfc3_imp.tpn", 
-            "unique_rowkeys": [
-                "OBSMODE", 
-                "DATACOL", 
-                "PHOTFLAM1", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"photcorr",
+            "rmap_relevance":"(PHOTCORR != \"OMIT\")",
+            "suffix":"imp",
+            "text_descr":"Photometry Keyword Table",
+            "tpn":"wfc3_imp.tpn",
+            "unique_rowkeys":[
+                "OBSMODE",
+                "DATACOL",
+                "PHOTFLAM1",
                 "PHOTFLAM2"
             ]
-        }, 
-        "lfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "large scale flat", 
-            "ld_tpn": "wfc3_lfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
+        },
+        "lfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"large scale flat",
+            "ld_tpn":"wfc3_lfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
                 "FILTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "flatcorr", 
-            "rmap_relevance": "(FLATCORR != \"OMIT\")", 
-            "suffix": "lfl", 
-            "text_descr": "Low-order Flat Field Image", 
-            "tpn": "wfc3_lfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mdriztab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "multidrizzle parameters", 
-            "ld_tpn": "wfc3_mdz_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"flatcorr",
+            "rmap_relevance":"(FLATCORR != \"OMIT\")",
+            "suffix":"lfl",
+            "text_descr":"Low-order Flat Field Image",
+            "tpn":"wfc3_lfl.tpn",
+            "unique_rowkeys":null
+        },
+        "mdriztab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"multidrizzle parameters",
+            "ld_tpn":"wfc3_mdz_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "no", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "(DRIZCORR != \"OMIT\")", 
-            "suffix": "mdz", 
-            "text_descr": "Multidrizzle Parameter Table", 
-            "tpn": "wfc3_mdz.tpn", 
-            "unique_rowkeys": [
-                "FILTER", 
-                "NUMIMAGES", 
-                "XSIZE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"no",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"(DRIZCORR != \"OMIT\")",
+            "suffix":"mdz",
+            "text_descr":"Multidrizzle Parameter Table",
+            "tpn":"wfc3_mdz.tpn",
+            "unique_rowkeys":[
+                "FILTER",
+                "NUMIMAGES",
+                "XSIZE",
                 "YSIZE"
             ]
-        }, 
-        "nlinfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "linearity coefficients", 
-            "ld_tpn": "wfc3_lin_ld.tpn", 
-            "parkey": [
+        },
+        "nlinfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"linearity coefficients",
+            "ld_tpn":"wfc3_lin_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "(DETECTOR == \"IR\")", 
-            "suffix": "lin", 
-            "text_descr": "Detector Linearity Correction File", 
-            "tpn": "wfc3_lin.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "npolfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "dxy grid", 
-            "ld_tpn": "wfc3_npl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"(DETECTOR == \"IR\")",
+            "suffix":"lin",
+            "text_descr":"Detector Linearity Correction File",
+            "tpn":"wfc3_lin.tpn",
+            "unique_rowkeys":null
+        },
+        "npolfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"dxy grid",
+            "ld_tpn":"wfc3_npl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
                 "FILTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "drizcorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\") and (DRIZCORR != \"OMIT\"))", 
-            "suffix": "npl", 
-            "text_descr": "Non-polynomial Offset", 
-            "tpn": "wfc3_npl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "oscntab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "overscan", 
-            "ld_tpn": "wfc3_osc_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"drizcorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\") and (DRIZCORR != \"OMIT\"))",
+            "suffix":"npl",
+            "text_descr":"Non-polynomial Offset",
+            "tpn":"wfc3_npl.tpn",
+            "unique_rowkeys":null
+        },
+        "oscntab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"overscan",
+            "ld_tpn":"wfc3_osc_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "osc", 
-            "text_descr": "Overscan Region Table", 
-            "tpn": "wfc3_osc.tpn", 
-            "unique_rowkeys": [
-                "CCDCHIP", 
-                "CCDAMP", 
-                "BINX", 
-                "BINY", 
-                "NX", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"osc",
+            "text_descr":"Overscan Region Table",
+            "tpn":"wfc3_osc.tpn",
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "CCDAMP",
+                "BINX",
+                "BINY",
+                "NX",
                 "NY"
             ]
-        }, 
-        "pctetab": {
-            "derived_from": "Derived from TEST hst_wfc3_pctetab_0004.rmap 2016-01-22", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "PCTETAB", 
-            "filetype": "PIXCTE", 
-            "instrument": "WFC3", 
-            "ld_tpn": "wfc3_cte_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "hst_wfc3_pctetab_0004.rmap", 
-            "observatory": "HST", 
-            "parkey": [
-                [], 
+        },
+        "pctetab":{
+            "derived_from":"Derived from TEST hst_wfc3_pctetab_0004.rmap 2016-01-22",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PCTETAB",
+            "filetype":"PIXCTE",
+            "instrument":"WFC3",
+            "ld_tpn":"wfc3_cte_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"hst_wfc3_pctetab_0004.rmap",
+            "observatory":"HST",
+            "parkey":[
+                [],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "TABLE", 
-            "reffile_required": "YES", 
-            "reffile_switch": "PCTECORR", 
-            "rmap_relevance": "(DETECTOR==\"UVIS\" and PCTECORR == \"PERFORM\")", 
-            "sha1sum": "01fb551f5a911bc0bb1c00d4149e1625ec101d59", 
-            "suffix": "cte", 
-            "text_descr": "Pixel CTE Correction Table", 
-            "tpn": "wfc3_cte.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "pfltfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "pixel-to-pixel flat", 
-            "ld_tpn": "wfc3_pfl_ld.tpn", 
-            "parkey": [
-                "DETECTOR", 
-                "CCDAMP", 
-                "FILTER", 
-                "BINAXIS1", 
+            ],
+            "reffile_format":"TABLE",
+            "reffile_required":"YES",
+            "reffile_switch":"PCTECORR",
+            "rmap_relevance":"(DETECTOR==\"UVIS\" and PCTECORR == \"PERFORM\")",
+            "sha1sum":"01fb551f5a911bc0bb1c00d4149e1625ec101d59",
+            "suffix":"cte",
+            "text_descr":"Pixel CTE Correction Table",
+            "tpn":"wfc3_cte.tpn",
+            "unique_rowkeys":null
+        },
+        "pfltfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"pixel-to-pixel flat",
+            "ld_tpn":"wfc3_pfl_ld.tpn",
+            "parkey":[
+                "DETECTOR",
+                "CCDAMP",
+                "FILTER",
+                "BINAXIS1",
                 "BINAXIS2"
-            ], 
-            "parkey_relevance": {
-                "binaxis1": "(DETECTOR == \"UVIS\")", 
-                "binaxis2": "(DETECTOR == \"UVIS\")"
-            }, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "flatcorr", 
-            "rmap_relevance": "((FILTER != \"BLANK\") and (FLATCORR != \"OMIT\"))", 
-            "suffix": "pfl", 
-            "text_descr": "Pixel To Pixel Flat Field Image", 
-            "tpn": "wfc3_pfl.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "shadfile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "shutter shading", 
-            "ld_tpn": "wfc3_shd_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{
+                "binaxis1":"(DETECTOR == \"UVIS\")",
+                "binaxis2":"(DETECTOR == \"UVIS\")"
+            },
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"flatcorr",
+            "rmap_relevance":"((FILTER != \"BLANK\") and (FLATCORR != \"OMIT\"))",
+            "suffix":"pfl",
+            "text_descr":"Pixel To Pixel Flat Field Image",
+            "tpn":"wfc3_pfl.tpn",
+            "unique_rowkeys":null
+        },
+        "shadfile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"shutter shading",
+            "ld_tpn":"wfc3_shd_ld.tpn",
+            "parkey":[
                 "DETECTOR"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "shadcorr", 
-            "rmap_relevance": "((DETECTOR == \"UVIS\") and (SHADCORR != \"OMIT\"))", 
-            "suffix": "shd", 
-            "text_descr": "Shutter Shading Correction Image", 
-            "tpn": "wfc3_shd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "snkcfile": {
-            "derived_from": "Derived from TEST hst_wfc3_snkcfile_0005.rmap on 2016-01-22", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SNKCFILE", 
-            "filetype": "SINK PIXELS", 
-            "instrument": "WFC3", 
-            "ld_tpn": "wfc3_snk_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "hst_wfc3_snkcfile_0005.rmap", 
-            "observatory": "HST", 
-            "parkey": [
-                [], 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"shadcorr",
+            "rmap_relevance":"((DETECTOR == \"UVIS\") and (SHADCORR != \"OMIT\"))",
+            "suffix":"shd",
+            "text_descr":"Shutter Shading Correction Image",
+            "tpn":"wfc3_shd.tpn",
+            "unique_rowkeys":null
+        },
+        "snkcfile":{
+            "derived_from":"Derived from TEST hst_wfc3_snkcfile_0005.rmap on 2016-01-22",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SNKCFILE",
+            "filetype":"SINK PIXELS",
+            "instrument":"WFC3",
+            "ld_tpn":"wfc3_snk_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"hst_wfc3_snkcfile_0005.rmap",
+            "observatory":"HST",
+            "parkey":[
+                [],
                 [
-                    "DATE-OBS", 
+                    "DATE-OBS",
                     "TIME-OBS"
                 ]
-            ], 
-            "reffile_format": "IMAGE", 
-            "reffile_required": "YES", 
-            "reffile_switch": "PCTECORR", 
-            "rmap_relevance": "(DETECTOR==\"UVIS\")", 
-            "sha1sum": "2abeb2c8d7a85d514cdeefd22bd5d48693b8c3ce", 
-            "suffix": "snk", 
-            "text_descr": "Sink Pixel Correction Image", 
-            "tpn": "wfc3_snk.tpn", 
-            "unique_rowkeys": null
+            ],
+            "reffile_format":"IMAGE",
+            "reffile_required":"YES",
+            "reffile_switch":"PCTECORR",
+            "rmap_relevance":"(DETECTOR==\"UVIS\")",
+            "sha1sum":"2abeb2c8d7a85d514cdeefd22bd5d48693b8c3ce",
+            "suffix":"snk",
+            "text_descr":"Sink Pixel Correction Image",
+            "tpn":"wfc3_snk.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "wfpc2": {
-        "atodfile": {
-            "extra_keys": [], 
-            "file_ext": ".r1h", 
-            "filetype": "a2d", 
-            "ld_tpn": "wp2_a2d_ld.tpn", 
-            "parkey": [
-                "MODE", 
+    },
+    "wfpc2":{
+        "atodfile":{
+            "extra_keys":[],
+            "file_ext":".r1h",
+            "filetype":"a2d",
+            "ld_tpn":"wp2_a2d_ld.tpn",
+            "parkey":[
+                "MODE",
                 "ATODGAIN"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "a2d", 
-            "text_descr": "Analog To Digital Converter Lookup Table", 
-            "tpn": "wp2_a2d.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "biasfile": {
-            "extra_keys": [], 
-            "file_ext": ".r2h", 
-            "filetype": "bas", 
-            "ld_tpn": "wp2_bas_ld.tpn", 
-            "parkey": [
-                "MODE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"a2d",
+            "text_descr":"Analog To Digital Converter Lookup Table",
+            "tpn":"wp2_a2d.tpn",
+            "unique_rowkeys":null
+        },
+        "biasfile":{
+            "extra_keys":[],
+            "file_ext":".r2h",
+            "filetype":"bas",
+            "ld_tpn":"wp2_bas_ld.tpn",
+            "parkey":[
+                "MODE",
                 "ATODGAIN"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "bas", 
-            "text_descr": "Bias Frame", 
-            "tpn": "wp2_bas.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "darkfile": {
-            "extra_keys": [], 
-            "file_ext": ".r3h", 
-            "filetype": "drk", 
-            "ld_tpn": "wp2_drk_ld.tpn", 
-            "parkey": [
-                "MODE", 
-                "ATODGAIN", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"bas",
+            "text_descr":"Bias Frame",
+            "tpn":"wp2_bas.tpn",
+            "unique_rowkeys":null
+        },
+        "darkfile":{
+            "extra_keys":[],
+            "file_ext":".r3h",
+            "filetype":"drk",
+            "ld_tpn":"wp2_drk_ld.tpn",
+            "parkey":[
+                "MODE",
+                "ATODGAIN",
                 "SERIALS"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "drk", 
-            "text_descr": "Dark Frame", 
-            "tpn": "wp2_drk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dgeofile": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "distortion correction", 
-            "ld_tpn": "wp2_dxy_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"drk",
+            "text_descr":"Dark Frame",
+            "tpn":"wp2_drk.tpn",
+            "unique_rowkeys":null
+        },
+        "dgeofile":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"distortion correction",
+            "ld_tpn":"wp2_dxy_ld.tpn",
+            "parkey":[
                 "MODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "dxy", 
-            "text_descr": "Geometric Distortion Correction File", 
-            "tpn": "wp2_dxy.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flatfile": {
-            "extra_keys": [
-                "imagetyp", 
-                "filtnam1", 
-                "filtnam2", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"dxy",
+            "text_descr":"Geometric Distortion Correction File",
+            "tpn":"wp2_dxy.tpn",
+            "unique_rowkeys":null
+        },
+        "flatfile":{
+            "extra_keys":[
+                "imagetyp",
+                "filtnam1",
+                "filtnam2",
                 "lrfwave"
-            ], 
-            "file_ext": ".r4h", 
-            "filetype": "flt", 
-            "ld_tpn": "wp2_flt_ld.tpn", 
-            "parkey": [
-                "MODE", 
-                "FILTER1", 
+            ],
+            "file_ext":".r4h",
+            "filetype":"flt",
+            "ld_tpn":"wp2_flt_ld.tpn",
+            "parkey":[
+                "MODE",
+                "FILTER1",
                 "FILTER2"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "flt", 
-            "text_descr": "Flat Field", 
-            "tpn": "wp2_flt.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "idctab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "distortion coefficients", 
-            "ld_tpn": "wp2_idc_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "idc", 
-            "text_descr": "Image Distortion Correction File", 
-            "tpn": "wp2_idc.tpn", 
-            "unique_rowkeys": [
-                "DETCHIP", 
-                "DIRECTION", 
-                "FILTER", 
-                "FILTER1", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"flt",
+            "text_descr":"Flat Field",
+            "tpn":"wp2_flt.tpn",
+            "unique_rowkeys":null
+        },
+        "idctab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"distortion coefficients",
+            "ld_tpn":"wp2_idc_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"idc",
+            "text_descr":"Image Distortion Correction File",
+            "tpn":"wp2_idc.tpn",
+            "unique_rowkeys":[
+                "DETCHIP",
+                "DIRECTION",
+                "FILTER",
+                "FILTER1",
                 "FILTER2"
             ]
-        }, 
-        "maskfile": {
-            "extra_keys": [], 
-            "file_ext": ".r0h", 
-            "filetype": "msk", 
-            "ld_tpn": "wp2_msk_ld.tpn", 
-            "parkey": [
+        },
+        "maskfile":{
+            "extra_keys":[],
+            "file_ext":".r0h",
+            "filetype":"msk",
+            "ld_tpn":"wp2_msk_ld.tpn",
+            "parkey":[
                 "MODE"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "msk", 
-            "text_descr": "Static Mask File", 
-            "tpn": "wp2_msk.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "offtab": {
-            "extra_keys": [], 
-            "file_ext": ".fits", 
-            "filetype": "chip offset", 
-            "ld_tpn": "wp2_off_ld.tpn", 
-            "parkey": [], 
-            "parkey_relevance": {}, 
-            "reffile_format": "table", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "off", 
-            "text_descr": "Inter-chip Offsets Table", 
-            "tpn": "wp2_off.tpn", 
-            "unique_rowkeys": [
-                "DETECTOR", 
-                "OBSDATE", 
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"msk",
+            "text_descr":"Static Mask File",
+            "tpn":"wp2_msk.tpn",
+            "unique_rowkeys":null
+        },
+        "offtab":{
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filetype":"chip offset",
+            "ld_tpn":"wp2_off_ld.tpn",
+            "parkey":[],
+            "parkey_relevance":{},
+            "reffile_format":"table",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"off",
+            "text_descr":"Inter-chip Offsets Table",
+            "tpn":"wp2_off.tpn",
+            "unique_rowkeys":[
+                "DETECTOR",
+                "OBSDATE",
                 "THETA"
             ]
-        }, 
-        "shadfile": {
-            "extra_keys": [], 
-            "file_ext": ".r5h", 
-            "filetype": "shd", 
-            "ld_tpn": "wp2_shd_ld.tpn", 
-            "parkey": [
-                "MODE", 
+        },
+        "shadfile":{
+            "extra_keys":[],
+            "file_ext":".r5h",
+            "filetype":"shd",
+            "ld_tpn":"wp2_shd_ld.tpn",
+            "parkey":[
+                "MODE",
                 "SHUTTER"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "none", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "shd", 
-            "text_descr": "Shutter Shading Correction Image", 
-            "tpn": "wp2_shd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wf4tfile": {
-            "extra_keys": [], 
-            "file_ext": ".r7h", 
-            "filetype": "w4t", 
-            "ld_tpn": "wp2_w4t_ld.tpn", 
-            "parkey": [
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"none",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"shd",
+            "text_descr":"Shutter Shading Correction Image",
+            "tpn":"wp2_shd.tpn",
+            "unique_rowkeys":null
+        },
+        "wf4tfile":{
+            "extra_keys":[],
+            "file_ext":".r7h",
+            "filetype":"w4t",
+            "ld_tpn":"wp2_w4t_ld.tpn",
+            "parkey":[
                 "ATODGAIN"
-            ], 
-            "parkey_relevance": {}, 
-            "reffile_format": "image", 
-            "reffile_required": "no", 
-            "reffile_switch": "none", 
-            "rmap_relevance": "ALWAYS", 
-            "suffix": "w4t", 
-            "text_descr": "WF4 Correction Table", 
-            "tpn": "wp2_w4t.tpn", 
-            "unique_rowkeys": null
+            ],
+            "parkey_relevance":{},
+            "reffile_format":"image",
+            "reffile_required":"no",
+            "reffile_switch":"none",
+            "rmap_relevance":"ALWAYS",
+            "suffix":"w4t",
+            "text_descr":"WF4 Correction Table",
+            "tpn":"wp2_w4t.tpn",
+            "unique_rowkeys":null
         }
     }
 }

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1,2630 +1,2630 @@
 {
-    "all": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filetype": "xxx", 
-            "instrument": "all", 
-            "ld_tpn": "all_all_ld.tpn", 
-            "suffix": "xxx", 
-            "text_descr": "All instruments and reference file types.", 
-            "tpn": "all_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "ALL", 
-            "ld_tpn": "all_dark_ld.tpn", 
-            "observatory": "JWST", 
-            "suffix": "DARK", 
-            "text_descr": "Dark files for all instruments.", 
-            "tpn": "all_dark.tpn", 
-            "unique_rowkeys": null
+    "all":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filetype":"xxx",
+            "instrument":"all",
+            "ld_tpn":"all_all_ld.tpn",
+            "suffix":"xxx",
+            "text_descr":"All instruments and reference file types.",
+            "tpn":"all_all.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"ALL",
+            "ld_tpn":"all_dark_ld.tpn",
+            "observatory":"JWST",
+            "suffix":"DARK",
+            "text_descr":"Dark files for all instruments.",
+            "tpn":"all_dark.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "fgs": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "all", 
-            "filetype": "all", 
-            "instrument": "fgs", 
-            "ld_tpn": "fgs_all.tpn", 
-            "suffix": "all", 
-            "text_descr": "All FGS reference file types.", 
-            "tpn": "fgs_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "amplifier": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AMPLIFIER", 
-            "filetype": "DETECTOR PARAMETERS", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_amplifier_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_amplifier_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+    },
+    "fgs":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"all",
+            "filetype":"all",
+            "instrument":"fgs",
+            "ld_tpn":"fgs_all.tpn",
+            "suffix":"all",
+            "text_descr":"All FGS reference file types.",
+            "tpn":"fgs_all.tpn",
+            "unique_rowkeys":null
+        },
+        "amplifier":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AMPLIFIER",
+            "filetype":"DETECTOR PARAMETERS",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_amplifier_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_amplifier_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "1052a84ac061fe2ce3dd013231e46814d48fc06d", 
-            "suffix": "amplifier", 
-            "text_descr": "Detector Amplifier Readout Parameters", 
-            "tpn": "fgs_amplifier.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "area": {
-            "derived_from": "Hand made 2016-02-18", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AREA", 
-            "filetype": "AREA", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_area_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_area_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"1052a84ac061fe2ce3dd013231e46814d48fc06d",
+            "suffix":"amplifier",
+            "text_descr":"Detector Amplifier Readout Parameters",
+            "tpn":"fgs_amplifier.tpn",
+            "unique_rowkeys":null
+        },
+        "area":{
+            "derived_from":"Hand made 2016-02-18",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AREA",
+            "filetype":"AREA",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_area_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_area_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "5d120d9441bd9f90bc16dacd462fad664a0158bc", 
-            "suffix": "area", 
-            "text_descr": "Pixel-Area Map", 
-            "tpn": "fgs_area.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "derived_from": "Hand derived 2016-02-19", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_dark_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "fgs_dark.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"5d120d9441bd9f90bc16dacd462fad664a0158bc",
+            "suffix":"area",
+            "text_descr":"Pixel-Area Map",
+            "tpn":"fgs_area.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "derived_from":"Hand derived 2016-02-19",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_dark_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"fgs_dark.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "372d7f23aa3b38f44ebfd0aadd534788bcbc7e9f", 
-            "suffix": "dark", 
-            "text_descr": "Dark Frame", 
-            "tpn": "fgs_dark.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "distortion": {
-            "derived_from": "Hand made 2016-03-10", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DISTORTION", 
-            "filetype": "DISTORTION", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_distortion_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "fgs_distortion.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"372d7f23aa3b38f44ebfd0aadd534788bcbc7e9f",
+            "suffix":"dark",
+            "text_descr":"Dark Frame",
+            "tpn":"fgs_dark.tpn",
+            "unique_rowkeys":null
+        },
+        "distortion":{
+            "derived_from":"Hand made 2016-03-10",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DISTORTION",
+            "filetype":"DISTORTION",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_distortion_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"fgs_distortion.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.EXPOSURE.TYPE", 
+                    "META.EXPOSURE.TYPE",
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "9327201ce1de6d8dcce569fb1b34472cb3a146c8", 
-            "suffix": "distortion", 
-            "text_descr": "Distortion", 
-            "tpn": "fgs_distortion.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flat": {
-            "derived_from": "Hand created 2016-02-19", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FLAT", 
-            "filetype": "PIXEL-TO-PIXEL FLAT", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_flat_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "fgs_flat.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
-                [
-                    "META.INSTRUMENT.DETECTOR"
-                ]
-            ], 
-            "sha1sum": "384b9ebba29831f7b84a21dd492e495657e04afe", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "fgs_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gain": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "GAIN", 
-            "filetype": "GAIN", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_gain_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_gain_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
-                [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER"
-                ]
-            ], 
-            "sha1sum": "0c8b22671495e338ee8d223ec0116109ef6d9f93", 
-            "suffix": "gain", 
-            "text_descr": "Gain", 
-            "tpn": "fgs_gain.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ipc": {
-            "derived_from": "generated as stub rmap on 2014-03-24 15:03:37.039709", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "IPC", 
-            "filetype": "INTERPIXEL CAPACITANCE", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_ipc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_ipc_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"9327201ce1de6d8dcce569fb1b34472cb3a146c8",
+            "suffix":"distortion",
+            "text_descr":"Distortion",
+            "tpn":"fgs_distortion.tpn",
+            "unique_rowkeys":null
+        },
+        "flat":{
+            "derived_from":"Hand created 2016-02-19",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FLAT",
+            "filetype":"PIXEL-TO-PIXEL FLAT",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_flat_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"fgs_flat.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "2ee487e0ad08a1c957842c684b07b5e9835a7c62", 
-            "suffix": "ipc", 
-            "text_descr": "Interpixel Capacitance", 
-            "tpn": "fgs_ipc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "linearity": {
-            "derived_from": "jwst_fgs_linearity_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LINEARITY", 
-            "filetype": "LINEARITY", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_linearity_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_linearity_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"384b9ebba29831f7b84a21dd492e495657e04afe",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"fgs_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_gain_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "2011b7b58f2111177feef71af2adcde0ff3d8d95", 
-            "suffix": "linearity", 
-            "text_descr": "Detector Linearity Correction Coefficients", 
-            "tpn": "fgs_linearity.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mask": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-07-31", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "MASK", 
-            "filetype": "MASK", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_mask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_mask_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
-                [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER"
-                ]
-            ], 
-            "sha1sum": "d694b2074e597d1f0593ef993a7022f2f099b36e", 
-            "suffix": "mask", 
-            "text_descr": "Bad Pixel Mask", 
-            "tpn": "fgs_mask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "photom": {
-            "derived_from": "Hand derived 2016-02-19", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "PHOTOM", 
-            "filetype": "PHOTOMETRIC CALIBRATION", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_photom_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "fgs_photom.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"0c8b22671495e338ee8d223ec0116109ef6d9f93",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"fgs_gain.tpn",
+            "unique_rowkeys":null
+        },
+        "ipc":{
+            "derived_from":"generated as stub rmap on 2014-03-24 15:03:37.039709",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"IPC",
+            "filetype":"INTERPIXEL CAPACITANCE",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_ipc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_ipc_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "0dab19ffd1c54ff5c9f7eb82dbcc61efecb0deda", 
-            "suffix": "photom", 
-            "text_descr": "Absolute Calibration", 
-            "tpn": "fgs_photom.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "readnoise": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "READNOISE", 
-            "filetype": "READNOISE", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_readnoise_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_readnoise_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"2ee487e0ad08a1c957842c684b07b5e9835a7c62",
+            "suffix":"ipc",
+            "text_descr":"Interpixel Capacitance",
+            "tpn":"fgs_ipc.tpn",
+            "unique_rowkeys":null
+        },
+        "linearity":{
+            "derived_from":"jwst_fgs_linearity_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LINEARITY",
+            "filetype":"LINEARITY",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_linearity_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_linearity_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "1983b76b584a7fc20e686e7af607dbbb0388bdc0", 
-            "suffix": "readnoise", 
-            "text_descr": "Read Noise", 
-            "tpn": "fgs_readnoise.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "regions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "REGIONS", 
-            "filetype": "REGIONS", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_regions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_regions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "regions", 
-            "text_descr": "Regions", 
-            "tpn": "fgs_regions.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "saturation": {
-            "derived_from": "jwst_fgs_saturation_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SATURATION", 
-            "filetype": "SATURATION", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_saturation_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_saturation_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"2011b7b58f2111177feef71af2adcde0ff3d8d95",
+            "suffix":"linearity",
+            "text_descr":"Detector Linearity Correction Coefficients",
+            "tpn":"fgs_linearity.tpn",
+            "unique_rowkeys":null
+        },
+        "mask":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-07-31",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"MASK",
+            "filetype":"MASK",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_mask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_mask_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "511287580b1f32521728e32c13dcade301803acd", 
-            "suffix": "saturation", 
-            "text_descr": "Saturation", 
-            "tpn": "fgs_saturation.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "specwcs": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "SPECWCS", 
-            "filetype": "SPECWCS", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_specwcs_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_specwcs_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "specwcs", 
-            "text_descr": "Spectroscopic World Coordinate System", 
-            "tpn": "fgs_specwcs.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "superbias": {
-            "derived_from": "handmade spec 05-01-2015", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "superbias", 
-            "filetype": "SUPERBIAS", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_sbias_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "fgs_superbias.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"d694b2074e597d1f0593ef993a7022f2f099b36e",
+            "suffix":"mask",
+            "text_descr":"Bad Pixel Mask",
+            "tpn":"fgs_mask.tpn",
+            "unique_rowkeys":null
+        },
+        "photom":{
+            "derived_from":"Hand derived 2016-02-19",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PHOTOM",
+            "filetype":"PHOTOMETRIC CALIBRATION",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_photom_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"fgs_photom.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR"
+                ]
+            ],
+            "sha1sum":"0dab19ffd1c54ff5c9f7eb82dbcc61efecb0deda",
+            "suffix":"photom",
+            "text_descr":"Absolute Calibration",
+            "tpn":"fgs_photom.tpn",
+            "unique_rowkeys":null
+        },
+        "readnoise":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"READNOISE",
+            "filetype":"READNOISE",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_readnoise_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_readnoise_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER"
+                ]
+            ],
+            "sha1sum":"1983b76b584a7fc20e686e7af607dbbb0388bdc0",
+            "suffix":"readnoise",
+            "text_descr":"Read Noise",
+            "tpn":"fgs_readnoise.tpn",
+            "unique_rowkeys":null
+        },
+        "regions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"REGIONS",
+            "filetype":"REGIONS",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_regions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_regions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"regions",
+            "text_descr":"Regions",
+            "tpn":"fgs_regions.tpn",
+            "unique_rowkeys":null
+        },
+        "saturation":{
+            "derived_from":"jwst_fgs_saturation_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SATURATION",
+            "filetype":"SATURATION",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_saturation_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_saturation_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER"
+                ]
+            ],
+            "sha1sum":"511287580b1f32521728e32c13dcade301803acd",
+            "suffix":"saturation",
+            "text_descr":"Saturation",
+            "tpn":"fgs_saturation.tpn",
+            "unique_rowkeys":null
+        },
+        "specwcs":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"SPECWCS",
+            "filetype":"SPECWCS",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_specwcs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_specwcs_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"specwcs",
+            "text_descr":"Spectroscopic World Coordinate System",
+            "tpn":"fgs_specwcs.tpn",
+            "unique_rowkeys":null
+        },
+        "superbias":{
+            "derived_from":"handmade spec 05-01-2015",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"superbias",
+            "filetype":"SUPERBIAS",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_sbias_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"fgs_superbias.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "6a8036af5271839a76827be860a86f5f6cba1cca", 
-            "suffix": "sbias", 
-            "text_descr": "Super Bias", 
-            "tpn": "fgs_sbias.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wcsregions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "WCSREGIONS", 
-            "filetype": "WCSREGIONS", 
-            "instrument": "FGS", 
-            "ld_tpn": "fgs_wcsregions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_fgs_wcsregions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "wcsregions", 
-            "text_descr": "World Coordinate System Regions", 
-            "tpn": "fgs_wcsregions.tpn", 
-            "unique_rowkeys": null
+            ],
+            "sha1sum":"6a8036af5271839a76827be860a86f5f6cba1cca",
+            "suffix":"sbias",
+            "text_descr":"Super Bias",
+            "tpn":"fgs_sbias.tpn",
+            "unique_rowkeys":null
+        },
+        "wcsregions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"WCSREGIONS",
+            "filetype":"WCSREGIONS",
+            "instrument":"FGS",
+            "ld_tpn":"fgs_wcsregions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_fgs_wcsregions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"wcsregions",
+            "text_descr":"World Coordinate System Regions",
+            "tpn":"fgs_wcsregions.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "miri": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "all", 
-            "filetype": "all", 
-            "instrument": "miri", 
-            "ld_tpn": "miri_all.tpn", 
-            "suffix": "all", 
-            "text_descr": "All MIRI reference file types.", 
-            "tpn": "miri_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "amplifier": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AMPLIFIER", 
-            "filetype": "DETECTOR PARAMETERS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_amplifier_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_amplifier_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+    },
+    "miri":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"all",
+            "filetype":"all",
+            "instrument":"miri",
+            "ld_tpn":"miri_all.tpn",
+            "suffix":"all",
+            "text_descr":"All MIRI reference file types.",
+            "tpn":"miri_all.tpn",
+            "unique_rowkeys":null
+        },
+        "amplifier":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AMPLIFIER",
+            "filetype":"DETECTOR PARAMETERS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_amplifier_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_amplifier_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "ded285924d4e3c40d34a64a58060cc4fa4a83073", 
-            "suffix": "amplifier", 
-            "text_descr": "Detector Amplifier Readout Parameters", 
-            "tpn": "miri_amplifier.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "area": {
-            "derived_from": "Hand made 2015-09-02 16:35:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AREA", 
-            "filetype": "AREA", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_area_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_area.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"ded285924d4e3c40d34a64a58060cc4fa4a83073",
+            "suffix":"amplifier",
+            "text_descr":"Detector Amplifier Readout Parameters",
+            "tpn":"miri_amplifier.tpn",
+            "unique_rowkeys":null
+        },
+        "area":{
+            "derived_from":"Hand made 2015-09-02 16:35:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AREA",
+            "filetype":"AREA",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_area_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_area.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "448a6d48825f4239335f42608551d4f73f0afc94", 
-            "suffix": "area", 
-            "text_descr": "Pixel-Area Map", 
-            "tpn": "miri_area.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "derived_from": "jwst_miri_dark_0003.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_dark_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_dark_0004.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"448a6d48825f4239335f42608551d4f73f0afc94",
+            "suffix":"area",
+            "text_descr":"Pixel-Area Map",
+            "tpn":"miri_area.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "derived_from":"jwst_miri_dark_0003.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_dark_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_dark_0004.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "1e6576c36b59c6977796277375c47e70753683da", 
-            "suffix": "dark", 
-            "text_descr": "Dark Frame", 
-            "tpn": "miri_dark.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "distortion": {
-            "derived_from": "jwst_miri_distortion_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "DISTORTION", 
-            "filetype": "DISTORTION", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_distortion_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_distortion_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"1e6576c36b59c6977796277375c47e70753683da",
+            "suffix":"dark",
+            "text_descr":"Dark Frame",
+            "tpn":"miri_dark.tpn",
+            "unique_rowkeys":null
+        },
+        "distortion":{
+            "derived_from":"jwst_miri_distortion_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"DISTORTION",
+            "filetype":"DISTORTION",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_distortion_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_distortion_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.CHANNEL", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.CHANNEL",
                     "META.INSTRUMENT.BAND"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "BAND": "META.INSTRUMENT.BAND", 
-                "CHANNEL": "META.INSTRUMENT.CHANNEL", 
-                "DETECTOR": "META.INSTRUMENT.DETECTOR"
-            }, 
-            "sha1sum": "e33265823224a35bab99d368fd22f33a31471845", 
-            "suffix": "distortion", 
-            "text_descr": "Distortion", 
-            "tpn": "miri_distortion.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "drizpars": {
-            "derived_from": "generated as stub rmap on 2014-08-29 15:33:50.917285", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DRIZPARS", 
-            "filetype": "DRIZPARS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_drizpars_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_drizpars_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "BAND":"META.INSTRUMENT.BAND",
+                "CHANNEL":"META.INSTRUMENT.CHANNEL",
+                "DETECTOR":"META.INSTRUMENT.DETECTOR"
+            },
+            "sha1sum":"e33265823224a35bab99d368fd22f33a31471845",
+            "suffix":"distortion",
+            "text_descr":"Distortion",
+            "tpn":"miri_distortion.tpn",
+            "unique_rowkeys":null
+        },
+        "drizpars":{
+            "derived_from":"generated as stub rmap on 2014-08-29 15:33:50.917285",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DRIZPARS",
+            "filetype":"DRIZPARS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_drizpars_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_drizpars_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 []
-            ], 
-            "sha1sum": "01859bb63de2f65b43aa3d72f2204141c3dabbcf", 
-            "suffix": "drizpars", 
-            "text_descr": "Drizzle Parameters used in Image Distortion Correction and Combination", 
-            "tpn": "miri_drizpars.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "extract1d": {
-            "derived_from": "Hand made 2015-10-17 16:00:00", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "EXTRACT1D", 
-            "filetype": "EXTRACT1D", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_extract1d_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_extract1d.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"01859bb63de2f65b43aa3d72f2204141c3dabbcf",
+            "suffix":"drizpars",
+            "text_descr":"Drizzle Parameters used in Image Distortion Correction and Combination",
+            "tpn":"miri_drizpars.tpn",
+            "unique_rowkeys":null
+        },
+        "extract1d":{
+            "derived_from":"Hand made 2015-10-17 16:00:00",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"EXTRACT1D",
+            "filetype":"EXTRACT1D",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_extract1d_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_extract1d.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "4320150debe9115dcacd91d6bd3fb8392f46828d", 
-            "suffix": "extract1d", 
-            "text_descr": "1-D Spectral Extraction", 
-            "tpn": "miri_extract1d.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "filteroffset": {
-            "derived_from": "Hand made 2015-10-09 09:12:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "filteroffset", 
-            "filetype": "FILTEROFFSET", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_filteroffset_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_filteroffset_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"4320150debe9115dcacd91d6bd3fb8392f46828d",
+            "suffix":"extract1d",
+            "text_descr":"1-D Spectral Extraction",
+            "tpn":"miri_extract1d.tpn",
+            "unique_rowkeys":null
+        },
+        "filteroffset":{
+            "derived_from":"Hand made 2015-10-09 09:12:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"filteroffset",
+            "filetype":"FILTEROFFSET",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_filteroffset_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_filteroffset_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "5c41a10fc0373a18e2511d1bc110793fe38ac0f5", 
-            "suffix": "filteroffset", 
-            "text_descr": "Imager Filter Offset", 
-            "tpn": "miri_filteroffset.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flat": {
-            "derived_from": "jwst_miri_flat_0011.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FLAT", 
-            "filetype": "PIXEL-TO-PIXEL FLAT", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_flat_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_flat_0012.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"5c41a10fc0373a18e2511d1bc110793fe38ac0f5",
+            "suffix":"filteroffset",
+            "text_descr":"Imager Filter Offset",
+            "tpn":"miri_filteroffset.tpn",
+            "unique_rowkeys":null
+        },
+        "flat":{
+            "derived_from":"jwst_miri_flat_0011.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FLAT",
+            "filetype":"PIXEL-TO-PIXEL FLAT",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_flat_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_flat_0012.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
-                    "META.INSTRUMENT.BAND", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.INSTRUMENT.BAND",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "d76040883de1ebd0a8b2440394155d5c49974b92", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "miri_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "fringe": {
-            "derived_from": "jwst_miri_fringe_0003.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FRINGE", 
-            "filetype": "SPECTRAL FRINGING CORRECTION FACTORS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_fringe_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_fringe_0004.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"d76040883de1ebd0a8b2440394155d5c49974b92",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"miri_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "fringe":{
+            "derived_from":"jwst_miri_fringe_0003.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FRINGE",
+            "filetype":"SPECTRAL FRINGING CORRECTION FACTORS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_fringe_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_fringe_0004.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.BAND"
                 ]
-            ], 
-            "sha1sum": "7a1dba015e8de2a11f96c6ad8e9f9500934027f2", 
-            "suffix": "fringe", 
-            "text_descr": "Spectral Fringing Correction Factors", 
-            "tpn": "miri_fringe.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gain": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "GAIN", 
-            "filetype": "GAIN", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_gain_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_gain_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"7a1dba015e8de2a11f96c6ad8e9f9500934027f2",
+            "suffix":"fringe",
+            "text_descr":"Spectral Fringing Correction Factors",
+            "tpn":"miri_fringe.tpn",
+            "unique_rowkeys":null
+        },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_gain_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "09f1b655e8999a1be2ef3aea286e74fc0588738c", 
-            "suffix": "gain", 
-            "text_descr": "Gain", 
-            "tpn": "miri_gain.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ipc": {
-            "derived_from": "generated as stub rmap on 2014-03-24 15:03:30.015471", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "IPC", 
-            "filetype": "INTERPIXEL CAPACITANCE", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_ipc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_ipc_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"09f1b655e8999a1be2ef3aea286e74fc0588738c",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"miri_gain.tpn",
+            "unique_rowkeys":null
+        },
+        "ipc":{
+            "derived_from":"generated as stub rmap on 2014-03-24 15:03:30.015471",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"IPC",
+            "filetype":"INTERPIXEL CAPACITANCE",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_ipc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_ipc_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "0f07718e051396c851bbaa03a917487abec80843", 
-            "suffix": "ipc", 
-            "text_descr": "Interpixel Capacitance", 
-            "tpn": "miri_ipc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "lastframe": {
-            "derived_from": "jwst_miri_lastframe_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LASTFRAME", 
-            "filetype": "LASTFRAME", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_lastframe_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_lastframe_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"0f07718e051396c851bbaa03a917487abec80843",
+            "suffix":"ipc",
+            "text_descr":"Interpixel Capacitance",
+            "tpn":"miri_ipc.tpn",
+            "unique_rowkeys":null
+        },
+        "lastframe":{
+            "derived_from":"jwst_miri_lastframe_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LASTFRAME",
+            "filetype":"LASTFRAME",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_lastframe_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_lastframe_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.SUBARRAY.NAME", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.SUBARRAY.NAME",
                     "META.EXPOSURE.READPATT"
                 ]
-            ], 
-            "sha1sum": "96b3e9ad00803aa2fffe30d03fc34edf21cb9549", 
-            "suffix": "lastframe", 
-            "text_descr": "Last Frame", 
-            "tpn": "miri_lastframe.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "linearity": {
-            "derived_from": "jwst_miri_linearity_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LINEARITY", 
-            "filetype": "LINEARITY", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_linearity_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_linearity_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"96b3e9ad00803aa2fffe30d03fc34edf21cb9549",
+            "suffix":"lastframe",
+            "text_descr":"Last Frame",
+            "tpn":"miri_lastframe.tpn",
+            "unique_rowkeys":null
+        },
+        "linearity":{
+            "derived_from":"jwst_miri_linearity_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LINEARITY",
+            "filetype":"LINEARITY",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_linearity_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_linearity_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "3b649b93a6fcb9c457630f3a78d30bab43f516cc", 
-            "suffix": "linearity", 
-            "text_descr": "Detector Linearity Correction Coefficients", 
-            "tpn": "miri_linearity.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mask": {
-            "derived_from": "jwst_miri_mask_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "MASK", 
-            "filetype": "MASK", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_mask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_mask_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"3b649b93a6fcb9c457630f3a78d30bab43f516cc",
+            "suffix":"linearity",
+            "text_descr":"Detector Linearity Correction Coefficients",
+            "tpn":"miri_linearity.tpn",
+            "unique_rowkeys":null
+        },
+        "mask":{
+            "derived_from":"jwst_miri_mask_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"MASK",
+            "filetype":"MASK",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_mask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_mask_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "14e365f2d096081fb0d05ac2657f724e63253e31", 
-            "suffix": "mask", 
-            "text_descr": "Bad Pixel Mask", 
-            "tpn": "miri_mask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "photom": {
-            "derived_from": "jwst_miri_photom_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "PHOTOM", 
-            "filetype": "PHOTOMETRIC CALIBRATION", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_photom_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_photom_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"14e365f2d096081fb0d05ac2657f724e63253e31",
+            "suffix":"mask",
+            "text_descr":"Bad Pixel Mask",
+            "tpn":"miri_mask.tpn",
+            "unique_rowkeys":null
+        },
+        "photom":{
+            "derived_from":"jwst_miri_photom_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PHOTOM",
+            "filetype":"PHOTOMETRIC CALIBRATION",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_photom_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_photom_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "c0e025d2c45a0bc1819f96545397a1580c830810", 
-            "suffix": "photom", 
-            "text_descr": "Absolute Calibration", 
-            "tpn": "miri_photom.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "readnoise": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "READNOISE", 
-            "filetype": "READNOISE", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_readnoise_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_readnoise_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"c0e025d2c45a0bc1819f96545397a1580c830810",
+            "suffix":"photom",
+            "text_descr":"Absolute Calibration",
+            "tpn":"miri_photom.tpn",
+            "unique_rowkeys":null
+        },
+        "readnoise":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"READNOISE",
+            "filetype":"READNOISE",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_readnoise_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_readnoise_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "313f5552fa46e18dba62468155a812386dc106fc", 
-            "suffix": "readnoise", 
-            "text_descr": "Read Noise", 
-            "tpn": "miri_readnoise.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "regions": {
-            "derived_from": "jwst_miri_regions_0002.rmap", 
-            "extra_keys": [
+            ],
+            "sha1sum":"313f5552fa46e18dba62468155a812386dc106fc",
+            "suffix":"readnoise",
+            "text_descr":"Read Noise",
+            "tpn":"miri_readnoise.tpn",
+            "unique_rowkeys":null
+        },
+        "regions":{
+            "derived_from":"jwst_miri_regions_0002.rmap",
+            "extra_keys":[
                 "META.EXPOSURE.TYPE"
-            ], 
-            "file_ext": ".fits", 
-            "filekind": "REGIONS", 
-            "filetype": "REGIONS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_regions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_regions_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "file_ext":".fits",
+            "filekind":"REGIONS",
+            "filetype":"REGIONS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_regions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_regions_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.CHANNEL", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.CHANNEL",
                     "META.INSTRUMENT.BAND"
                 ]
-            ], 
-            "rmap_relevance": "(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\", \"NRS_FIXEDSLIT\"))", 
-            "sha1sum": "abb8d82b034284be2d5ba6a7c657382b187efad4", 
-            "suffix": "regions", 
-            "text_descr": "Regions", 
-            "tpn": "miri_regions.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "reset": {
-            "derived_from": "jwst_miri_reset_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "RESET", 
-            "filetype": "RESET", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_reset_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_reset_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "rmap_relevance":"(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\", \"NRS_FIXEDSLIT\"))",
+            "sha1sum":"abb8d82b034284be2d5ba6a7c657382b187efad4",
+            "suffix":"regions",
+            "text_descr":"Regions",
+            "tpn":"miri_regions.tpn",
+            "unique_rowkeys":null
+        },
+        "reset":{
+            "derived_from":"jwst_miri_reset_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"RESET",
+            "filetype":"RESET",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_reset_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_reset_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.SUBARRAY.NAME", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.SUBARRAY.NAME",
                     "META.EXPOSURE.READPATT"
                 ]
-            ], 
-            "sha1sum": "14df9cb96858cb3db4b1dca0a6d01f5a53abafd2", 
-            "suffix": "reset", 
-            "text_descr": "Reset Correction", 
-            "tpn": "miri_reset.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "rscd": {
-            "classes": [
-                "Match", 
+            ],
+            "sha1sum":"14df9cb96858cb3db4b1dca0a6d01f5a53abafd2",
+            "suffix":"reset",
+            "text_descr":"Reset Correction",
+            "tpn":"miri_reset.tpn",
+            "unique_rowkeys":null
+        },
+        "rscd":{
+            "classes":[
+                "Match",
                 "UseAfter"
-            ], 
-            "derived_from": "Hand made 2016-08-22", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "RSCD", 
-            "filetype": "RSCD", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_rscd_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_rscd.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "derived_from":"Hand made 2016-08-22",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"RSCD",
+            "filetype":"RSCD",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_rscd_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_rscd.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
-                ], 
+                ],
                 [
-                    "META.OBSERVATION.DATE", 
+                    "META.OBSERVATION.DATE",
                     "META.OBSERVATION.TIME"
                 ]
-            ], 
-            "sha1sum": "ec43fcd3756a572d11405b7e683983c5d2fe51ff", 
-            "suffix": "rscd", 
-            "text_descr": "Reset Switch Charge Decay correction", 
-            "tpn": "miri_rscd.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "saturation": {
-            "derived_from": "jwst_miri_saturation_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SATURATION", 
-            "filetype": "SATURATION", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_saturation_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_saturation_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"ec43fcd3756a572d11405b7e683983c5d2fe51ff",
+            "suffix":"rscd",
+            "text_descr":"Reset Switch Charge Decay correction",
+            "tpn":"miri_rscd.tpn",
+            "unique_rowkeys":null
+        },
+        "saturation":{
+            "derived_from":"jwst_miri_saturation_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SATURATION",
+            "filetype":"SATURATION",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_saturation_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_saturation_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "6b8023a0e330f8133c90af9ce831bc3032173cbd", 
-            "suffix": "saturation", 
-            "text_descr": "Saturation", 
-            "tpn": "miri_saturation.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "specwcs": {
-            "derived_from": "jwst_miri_specwcs_0002.rmap", 
-            "extra_keys": [
+            ],
+            "sha1sum":"6b8023a0e330f8133c90af9ce831bc3032173cbd",
+            "suffix":"saturation",
+            "text_descr":"Saturation",
+            "tpn":"miri_saturation.tpn",
+            "unique_rowkeys":null
+        },
+        "specwcs":{
+            "derived_from":"jwst_miri_specwcs_0002.rmap",
+            "extra_keys":[
                 "META.EXPOSURE.TYPE"
-            ], 
-            "file_ext": ".json", 
-            "filekind": "SPECWCS", 
-            "filetype": "SPECWCS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_specwcs_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_specwcs_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "file_ext":".json",
+            "filekind":"SPECWCS",
+            "filetype":"SPECWCS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_specwcs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_specwcs_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.CHANNEL", 
-                    "META.INSTRUMENT.BAND", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.CHANNEL",
+                    "META.INSTRUMENT.BAND",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "BAND": "META.INSTRUMENT.BAND", 
-                "CHANNEL": "META.INSTRUMENT.CHANNEL", 
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "SUBARRAY": "META.SUBARRAY.NAME"
-            }, 
-            "rmap_relevance": "(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\"))", 
-            "sha1sum": "01196db33f55fd33bc7a6b43be17f8e99423a5ce", 
-            "suffix": "specwcs", 
-            "text_descr": "Spectroscopic World Coordinate System", 
-            "tpn": "miri_specwcs.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "straymask": {
-            "derived_from": "jwst_miri_straymask_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "STRAYMASK", 
-            "filetype": "STRAYMASK", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_straymask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_straymask_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "BAND":"META.INSTRUMENT.BAND",
+                "CHANNEL":"META.INSTRUMENT.CHANNEL",
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "SUBARRAY":"META.SUBARRAY.NAME"
+            },
+            "rmap_relevance":"(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\"))",
+            "sha1sum":"01196db33f55fd33bc7a6b43be17f8e99423a5ce",
+            "suffix":"specwcs",
+            "text_descr":"Spectroscopic World Coordinate System",
+            "tpn":"miri_specwcs.tpn",
+            "unique_rowkeys":null
+        },
+        "straymask":{
+            "derived_from":"jwst_miri_straymask_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"STRAYMASK",
+            "filetype":"STRAYMASK",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_straymask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_straymask_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.BAND"
                 ]
-            ], 
-            "sha1sum": "a7eca43e13d1adf19869bf765680eeee3a89d6e4", 
-            "suffix": "straymask", 
-            "text_descr": "Stray Light Mask", 
-            "tpn": "miri_straymask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "v2v3": {
-            "derived_from": "Hand made 2015-10-09 10:00:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "v2v3", 
-            "filetype": "V2V3", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_v2v3_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_v2v3_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"a7eca43e13d1adf19869bf765680eeee3a89d6e4",
+            "suffix":"straymask",
+            "text_descr":"Stray Light Mask",
+            "tpn":"miri_straymask.tpn",
+            "unique_rowkeys":null
+        },
+        "v2v3":{
+            "derived_from":"Hand made 2015-10-09 10:00:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"v2v3",
+            "filetype":"V2V3",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_v2v3_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_v2v3_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.EXP_TYPE", 
-                    "META.INSTRUMENT.CHANNEL", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.EXP_TYPE",
+                    "META.INSTRUMENT.CHANNEL",
                     "META.INSTRUMENT.BAND"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "BAND": "META.INSTRUMENT.BAND", 
-                "CHANNEL": "META.INSTRUMENT.CHANNEL", 
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "14f285c12c0c69e9232663b18c6e42847ef63714", 
-            "suffix": "v2v3", 
-            "text_descr": "v2-v3 map", 
-            "tpn": "miri_v2v3.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wavelengthrange": {
-            "derived_from": "Hand made 2015-10-09 10:30:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "wavelengthrange", 
-            "filetype": "WAVELENGTHRANGE", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_wavelengthrange_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_wavelengthrange_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "BAND":"META.INSTRUMENT.BAND",
+                "CHANNEL":"META.INSTRUMENT.CHANNEL",
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"14f285c12c0c69e9232663b18c6e42847ef63714",
+            "suffix":"v2v3",
+            "text_descr":"v2-v3 map",
+            "tpn":"miri_v2v3.tpn",
+            "unique_rowkeys":null
+        },
+        "wavelengthrange":{
+            "derived_from":"Hand made 2015-10-09 10:30:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"wavelengthrange",
+            "filetype":"WAVELENGTHRANGE",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_wavelengthrange_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_wavelengthrange_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "538d22e89cc7801c3f25d8d952aa9c7e29178356", 
-            "suffix": "wavelengthrange", 
-            "text_descr": "MIRI wavelength range", 
-            "tpn": "miri_wavelengthrange.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wcsregions": {
-            "derived_from": "jwst_miri_wcsregions_0002.rmap", 
-            "extra_keys": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"538d22e89cc7801c3f25d8d952aa9c7e29178356",
+            "suffix":"wavelengthrange",
+            "text_descr":"MIRI wavelength range",
+            "tpn":"miri_wavelengthrange.tpn",
+            "unique_rowkeys":null
+        },
+        "wcsregions":{
+            "derived_from":"jwst_miri_wcsregions_0002.rmap",
+            "extra_keys":[
                 "META.EXPOSURE.TYPE"
-            ], 
-            "file_ext": ".json", 
-            "filekind": "WCSREGIONS", 
-            "filetype": "WCSREGIONS", 
-            "instrument": "MIRI", 
-            "ld_tpn": "miri_wcsregions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_miri_wcsregions_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "file_ext":".json",
+            "filekind":"WCSREGIONS",
+            "filetype":"WCSREGIONS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_wcsregions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_wcsregions_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR"
-            }, 
-            "rmap_relevance": "(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\", \"NRS_FIXEDSLIT\"))", 
-            "sha1sum": "c08e23b5edd7d613aa92ddeed49024120bd743bb", 
-            "suffix": "wcsregions", 
-            "text_descr": "World Coordinate System Regions", 
-            "tpn": "miri_wcsregions.tpn", 
-            "unique_rowkeys": null
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR"
+            },
+            "rmap_relevance":"(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\", \"NRS_FIXEDSLIT\"))",
+            "sha1sum":"c08e23b5edd7d613aa92ddeed49024120bd743bb",
+            "suffix":"wcsregions",
+            "text_descr":"World Coordinate System Regions",
+            "tpn":"miri_wcsregions.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "nircam": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "all", 
-            "filetype": "all", 
-            "instrument": "nircam", 
-            "ld_tpn": "nircam_all.tpn", 
-            "suffix": "all", 
-            "text_descr": "All nircam reference file types.", 
-            "tpn": "nircam_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "amplifier": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AMPLIFIER", 
-            "filetype": "DETECTOR PARAMETERS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_amplifier_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_amplifier_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+    },
+    "nircam":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"all",
+            "filetype":"all",
+            "instrument":"nircam",
+            "ld_tpn":"nircam_all.tpn",
+            "suffix":"all",
+            "text_descr":"All nircam reference file types.",
+            "tpn":"nircam_all.tpn",
+            "unique_rowkeys":null
+        },
+        "amplifier":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AMPLIFIER",
+            "filetype":"DETECTOR PARAMETERS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_amplifier_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_amplifier_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "202e5e76e4ceb6b5f08673c0f5eb6592b14873e2", 
-            "suffix": "amplifier", 
-            "text_descr": "Detector Amplifier Readout Parameters", 
-            "tpn": "nircam_amplifier.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "area": {
-            "derived_from": "Hand made 2015-07-13 13:06:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AREA", 
-            "filetype": "AREA", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_area_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_area.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"202e5e76e4ceb6b5f08673c0f5eb6592b14873e2",
+            "suffix":"amplifier",
+            "text_descr":"Detector Amplifier Readout Parameters",
+            "tpn":"nircam_amplifier.tpn",
+            "unique_rowkeys":null
+        },
+        "area":{
+            "derived_from":"Hand made 2015-07-13 13:06:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AREA",
+            "filetype":"AREA",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_area_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_area.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.INSTRUMENT.PUPIL"
                 ]
-            ], 
-            "sha1sum": "03176778a96856efff3f3860e33739e0de2a9317", 
-            "suffix": "area", 
-            "text_descr": "Pixel-Area Map", 
-            "tpn": "nircam_area.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-07-31", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_dark_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_dark_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"03176778a96856efff3f3860e33739e0de2a9317",
+            "suffix":"area",
+            "text_descr":"Pixel-Area Map",
+            "tpn":"nircam_area.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-07-31",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_dark_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_dark_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "a3d970b12944b44dfda004879d5dc3e58468bc2d", 
-            "suffix": "dark", 
-            "text_descr": "Dark Frame", 
-            "tpn": "nircam_dark.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "distortion": {
-            "derived_from": "Hand made 2015-10-26 11:14:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DISTORTION", 
-            "filetype": "DISTORTION", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_distortion_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_distortion.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"a3d970b12944b44dfda004879d5dc3e58468bc2d",
+            "suffix":"dark",
+            "text_descr":"Dark Frame",
+            "tpn":"nircam_dark.tpn",
+            "unique_rowkeys":null
+        },
+        "distortion":{
+            "derived_from":"Hand made 2015-10-26 11:14:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DISTORTION",
+            "filetype":"DISTORTION",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_distortion_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_distortion.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.EXPOSURE.TYPE", 
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.EXPOSURE.TYPE",
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.CHANNEL"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "CHANNEL": "META.INSTRUMENT.CHANNEL", 
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "5cd52b10126e220a7cd248372221572730b63bd4", 
-            "suffix": "distortion", 
-            "text_descr": "Distortion", 
-            "tpn": "nircam_distortion.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "drizpars": {
-            "derived_from": "generated as stub rmap on 2014-08-29 15:33:54.199062", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DRIZPARS", 
-            "filetype": "DRIZPARS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_drizpars_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_drizpars_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "CHANNEL":"META.INSTRUMENT.CHANNEL",
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"5cd52b10126e220a7cd248372221572730b63bd4",
+            "suffix":"distortion",
+            "text_descr":"Distortion",
+            "tpn":"nircam_distortion.tpn",
+            "unique_rowkeys":null
+        },
+        "drizpars":{
+            "derived_from":"generated as stub rmap on 2014-08-29 15:33:54.199062",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DRIZPARS",
+            "filetype":"DRIZPARS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_drizpars_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_drizpars_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 []
-            ], 
-            "sha1sum": "4c347c518d0ae0bcd7d3f6bd32f5d517a7ab8ca0", 
-            "suffix": "drizpars", 
-            "text_descr": "Drizzle Parameters used in Image Distortion Correction and Combination", 
-            "tpn": "nircam_drizpars.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flat": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FLAT", 
-            "filetype": "PIXEL-TO-PIXEL FLAT", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_flat_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_flat_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"4c347c518d0ae0bcd7d3f6bd32f5d517a7ab8ca0",
+            "suffix":"drizpars",
+            "text_descr":"Drizzle Parameters used in Image Distortion Correction and Combination",
+            "tpn":"nircam_drizpars.tpn",
+            "unique_rowkeys":null
+        },
+        "flat":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FLAT",
+            "filetype":"PIXEL-TO-PIXEL FLAT",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_flat_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_flat_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.INSTRUMENT.PUPIL"
                 ]
-            ], 
-            "sha1sum": "4e1d209eebbeab1534b24db6f852f5641aa912bc", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "nircam_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gain": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "GAIN", 
-            "filetype": "GAIN", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_gain_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_gain_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"4e1d209eebbeab1534b24db6f852f5641aa912bc",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"nircam_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_gain_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "5cf2799869cff361301b4db7ed7dda2ae52bc520", 
-            "suffix": "gain", 
-            "text_descr": "Gain", 
-            "tpn": "nircam_gain.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ipc": {
-            "derived_from": "generated as stub rmap on 2014-03-24 15:03:34.187156", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "IPC", 
-            "filetype": "INTERPIXEL CAPACITANCE", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_ipc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_ipc_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"5cf2799869cff361301b4db7ed7dda2ae52bc520",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"nircam_gain.tpn",
+            "unique_rowkeys":null
+        },
+        "ipc":{
+            "derived_from":"generated as stub rmap on 2014-03-24 15:03:34.187156",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"IPC",
+            "filetype":"INTERPIXEL CAPACITANCE",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_ipc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_ipc_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "a52293a378962284d269925f716c3fbd73879920", 
-            "suffix": "ipc", 
-            "text_descr": "Interpixel Capacitance", 
-            "tpn": "nircam_ipc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "linearity": {
-            "derived_from": "jwst_nircam_linearity_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LINEARITY", 
-            "filetype": "LINEARITY", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_linearity_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_linearity_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"a52293a378962284d269925f716c3fbd73879920",
+            "suffix":"ipc",
+            "text_descr":"Interpixel Capacitance",
+            "tpn":"nircam_ipc.tpn",
+            "unique_rowkeys":null
+        },
+        "linearity":{
+            "derived_from":"jwst_nircam_linearity_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LINEARITY",
+            "filetype":"LINEARITY",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_linearity_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_linearity_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "154a7f07f7a900140dbf93c5b7b69cb8be3a7cc0", 
-            "suffix": "linearity", 
-            "text_descr": "Detector Linearity Correction Coefficients", 
-            "tpn": "nircam_linearity.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mask": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-07-31", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "MASK", 
-            "filetype": "MASK", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_mask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_mask_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"154a7f07f7a900140dbf93c5b7b69cb8be3a7cc0",
+            "suffix":"linearity",
+            "text_descr":"Detector Linearity Correction Coefficients",
+            "tpn":"nircam_linearity.tpn",
+            "unique_rowkeys":null
+        },
+        "mask":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-07-31",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"MASK",
+            "filetype":"MASK",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_mask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_mask_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "9ee1d24710682fc4a7f2ff897a437fde5d94e7d1", 
-            "suffix": "mask", 
-            "text_descr": "Bad Pixel Mask", 
-            "tpn": "nircam_mask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "photom": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-09-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "PHOTOM", 
-            "filetype": "PHOTOMETRIC CALIBRATION", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_photom_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_photom_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"9ee1d24710682fc4a7f2ff897a437fde5d94e7d1",
+            "suffix":"mask",
+            "text_descr":"Bad Pixel Mask",
+            "tpn":"nircam_mask.tpn",
+            "unique_rowkeys":null
+        },
+        "photom":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-09-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PHOTOM",
+            "filetype":"PHOTOMETRIC CALIBRATION",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_photom_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_photom_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "8b882aefccecf7de1ae321e78052f74cf84b164f", 
-            "suffix": "photom", 
-            "text_descr": "Absolute Calibration", 
-            "tpn": "nircam_photom.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "readnoise": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "READNOISE", 
-            "filetype": "READNOISE", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_readnoise_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_readnoise_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"8b882aefccecf7de1ae321e78052f74cf84b164f",
+            "suffix":"photom",
+            "text_descr":"Absolute Calibration",
+            "tpn":"nircam_photom.tpn",
+            "unique_rowkeys":null
+        },
+        "readnoise":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"READNOISE",
+            "filetype":"READNOISE",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_readnoise_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_readnoise_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "b92031752dbe615549b53aa20b642f98a2a136a0", 
-            "suffix": "readnoise", 
-            "text_descr": "Read Noise", 
-            "tpn": "nircam_readnoise.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "regions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "REGIONS", 
-            "filetype": "REGIONS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_regions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_regions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "regions", 
-            "text_descr": "Regions", 
-            "tpn": "nircam_regions.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "saturation": {
-            "derived_from": "jwst_nircam_saturation_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SATURATION", 
-            "filetype": "SATURATION", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_saturation_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_saturation_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"b92031752dbe615549b53aa20b642f98a2a136a0",
+            "suffix":"readnoise",
+            "text_descr":"Read Noise",
+            "tpn":"nircam_readnoise.tpn",
+            "unique_rowkeys":null
+        },
+        "regions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"REGIONS",
+            "filetype":"REGIONS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_regions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_regions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"regions",
+            "text_descr":"Regions",
+            "tpn":"nircam_regions.tpn",
+            "unique_rowkeys":null
+        },
+        "saturation":{
+            "derived_from":"jwst_nircam_saturation_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SATURATION",
+            "filetype":"SATURATION",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_saturation_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_saturation_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "43d6a19bd0acc6cebdf29338c4350c565016df49", 
-            "suffix": "saturation", 
-            "text_descr": "Saturation", 
-            "tpn": "nircam_saturation.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "specwcs": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "SPECWCS", 
-            "filetype": "SPECWCS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_specwcs_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_specwcs_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "specwcs", 
-            "text_descr": "Spectroscopic World Coordinate System", 
-            "tpn": "nircam_specwcs.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "superbias": {
-            "derived_from": "handmade spec 05-01-2015", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "superbias", 
-            "filetype": "SUPERBIAS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_sbias_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "nircam_superbias.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"43d6a19bd0acc6cebdf29338c4350c565016df49",
+            "suffix":"saturation",
+            "text_descr":"Saturation",
+            "tpn":"nircam_saturation.tpn",
+            "unique_rowkeys":null
+        },
+        "specwcs":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"SPECWCS",
+            "filetype":"SPECWCS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_specwcs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_specwcs_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"specwcs",
+            "text_descr":"Spectroscopic World Coordinate System",
+            "tpn":"nircam_specwcs.tpn",
+            "unique_rowkeys":null
+        },
+        "superbias":{
+            "derived_from":"handmade spec 05-01-2015",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"superbias",
+            "filetype":"SUPERBIAS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_sbias_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"nircam_superbias.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "e0acc692172dcade1c6575e0843988d939360524", 
-            "suffix": "sbias", 
-            "text_descr": "Super Bias", 
-            "tpn": "nircam_sbias.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wcsregions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "WCSREGIONS", 
-            "filetype": "WCSREGIONS", 
-            "instrument": "NIRCAM", 
-            "ld_tpn": "nircam_wcsregions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nircam_wcsregions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "wcsregions", 
-            "text_descr": "World Coordinate System Regions", 
-            "tpn": "nircam_wcsregions.tpn", 
-            "unique_rowkeys": null
+            ],
+            "sha1sum":"e0acc692172dcade1c6575e0843988d939360524",
+            "suffix":"sbias",
+            "text_descr":"Super Bias",
+            "tpn":"nircam_sbias.tpn",
+            "unique_rowkeys":null
+        },
+        "wcsregions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"WCSREGIONS",
+            "filetype":"WCSREGIONS",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_wcsregions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_wcsregions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"wcsregions",
+            "text_descr":"World Coordinate System Regions",
+            "tpn":"nircam_wcsregions.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "niriss": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "all", 
-            "filetype": "all", 
-            "instrument": "niriss", 
-            "ld_tpn": "niriss_all.tpn", 
-            "suffix": "all", 
-            "text_descr": "All NIRISS reference file types.", 
-            "tpn": "niriss_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "amplifier": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AMPLIFIER", 
-            "filetype": "DETECTOR PARAMETERS", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_amplifier_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_amplifier_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+    },
+    "niriss":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"all",
+            "filetype":"all",
+            "instrument":"niriss",
+            "ld_tpn":"niriss_all.tpn",
+            "suffix":"all",
+            "text_descr":"All NIRISS reference file types.",
+            "tpn":"niriss_all.tpn",
+            "unique_rowkeys":null
+        },
+        "amplifier":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AMPLIFIER",
+            "filetype":"DETECTOR PARAMETERS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_amplifier_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_amplifier_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "0335598536a0da3617e0521214191ba241ddc530", 
-            "suffix": "amplifier", 
-            "text_descr": "Detector Amplifier Readout Parameters", 
-            "tpn": "niriss_amplifier.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "area": {
-            "derived_from": "Hand made 2015-07-13 13:06:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AREA", 
-            "filetype": "AREA", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_area_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_area.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"0335598536a0da3617e0521214191ba241ddc530",
+            "suffix":"amplifier",
+            "text_descr":"Detector Amplifier Readout Parameters",
+            "tpn":"niriss_amplifier.tpn",
+            "unique_rowkeys":null
+        },
+        "area":{
+            "derived_from":"Hand made 2015-07-13 13:06:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AREA",
+            "filetype":"AREA",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_area_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_area.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.INSTRUMENT.PUPIL"
                 ]
-            ], 
-            "sha1sum": "859c41c85bb420c58c3f095b9b39967bbe7ebc27", 
-            "suffix": "area", 
-            "text_descr": "Pixel-Area Map", 
-            "tpn": "niriss_area.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "derived_from": "jwst_niriss_dark_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_dark_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_dark_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"859c41c85bb420c58c3f095b9b39967bbe7ebc27",
+            "suffix":"area",
+            "text_descr":"Pixel-Area Map",
+            "tpn":"niriss_area.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "derived_from":"jwst_niriss_dark_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_dark_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_dark_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "f619961f7d318a016ff56c470ba052e832766958", 
-            "suffix": "dark", 
-            "text_descr": "Dark Frame", 
-            "tpn": "niriss_dark.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "distortion": {
-            "derived_from": "Hand made 2015-10-26 11:14:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DISTORTION", 
-            "filetype": "DISTORTION", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_distortion_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_distortion.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"f619961f7d318a016ff56c470ba052e832766958",
+            "suffix":"dark",
+            "text_descr":"Dark Frame",
+            "tpn":"niriss_dark.tpn",
+            "unique_rowkeys":null
+        },
+        "distortion":{
+            "derived_from":"Hand made 2015-10-26 11:14:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DISTORTION",
+            "filetype":"DISTORTION",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_distortion_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_distortion.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "99d3cd8b9e3338b5f2542b633f07efac8ed276c9", 
-            "suffix": "distortion", 
-            "text_descr": "Distortion", 
-            "tpn": "niriss_distortion.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "extract1d": {
-            "derived_from": "Hand made 2015-10-17 16:00:00", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "EXTRACT1D", 
-            "filetype": "EXTRACT1D", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_extract1d_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_extract1d.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"99d3cd8b9e3338b5f2542b633f07efac8ed276c9",
+            "suffix":"distortion",
+            "text_descr":"Distortion",
+            "tpn":"niriss_distortion.tpn",
+            "unique_rowkeys":null
+        },
+        "extract1d":{
+            "derived_from":"Hand made 2015-10-17 16:00:00",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"EXTRACT1D",
+            "filetype":"EXTRACT1D",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_extract1d_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_extract1d.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "358fa2cb05ad4a29e1a73b1285777f8047662db1", 
-            "suffix": "extract1d", 
-            "text_descr": "1-D Spectral Extraction", 
-            "tpn": "niriss_extract1d.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flat": {
-            "derived_from": "jwst_niriss_flat_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FLAT", 
-            "filetype": "PIXEL-TO-PIXEL FLAT", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_flat_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_flat_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"358fa2cb05ad4a29e1a73b1285777f8047662db1",
+            "suffix":"extract1d",
+            "text_descr":"1-D Spectral Extraction",
+            "tpn":"niriss_extract1d.tpn",
+            "unique_rowkeys":null
+        },
+        "flat":{
+            "derived_from":"jwst_niriss_flat_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FLAT",
+            "filetype":"PIXEL-TO-PIXEL FLAT",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_flat_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_flat_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "5c2334eb57626da82b0d1e563f5db1b4949f8184", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "niriss_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gain": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "GAIN", 
-            "filetype": "GAIN", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_gain_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_gain_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"5c2334eb57626da82b0d1e563f5db1b4949f8184",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"niriss_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_gain_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "fee4fbd0950196f5211a6badfb7b51067489072b", 
-            "suffix": "gain", 
-            "text_descr": "Gain", 
-            "tpn": "niriss_gain.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ipc": {
-            "derived_from": "generated as stub rmap on 2014-03-24 15:03:35.559299", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "IPC", 
-            "filetype": "INTERPIXEL CAPACITANCE", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_ipc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_ipc_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"fee4fbd0950196f5211a6badfb7b51067489072b",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"niriss_gain.tpn",
+            "unique_rowkeys":null
+        },
+        "ipc":{
+            "derived_from":"generated as stub rmap on 2014-03-24 15:03:35.559299",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"IPC",
+            "filetype":"INTERPIXEL CAPACITANCE",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_ipc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_ipc_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "386dfb57b9775fc906e265a04d523d728bb14158", 
-            "suffix": "ipc", 
-            "text_descr": "Interpixel Capacitance", 
-            "tpn": "niriss_ipc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "linearity": {
-            "derived_from": "jwst_niriss_linearity_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LINEARITY", 
-            "filetype": "LINEARITY", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_linearity_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_linearity_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"386dfb57b9775fc906e265a04d523d728bb14158",
+            "suffix":"ipc",
+            "text_descr":"Interpixel Capacitance",
+            "tpn":"niriss_ipc.tpn",
+            "unique_rowkeys":null
+        },
+        "linearity":{
+            "derived_from":"jwst_niriss_linearity_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LINEARITY",
+            "filetype":"LINEARITY",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_linearity_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_linearity_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "de469bef89c357387646caabc5429c24a4668076", 
-            "suffix": "linearity", 
-            "text_descr": "Detector Linearity Correction Coefficients", 
-            "tpn": "niriss_linearity.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mask": {
-            "derived_from": "jwst_niriss_mask_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "MASK", 
-            "filetype": "MASK", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_mask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_mask_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"de469bef89c357387646caabc5429c24a4668076",
+            "suffix":"linearity",
+            "text_descr":"Detector Linearity Correction Coefficients",
+            "tpn":"niriss_linearity.tpn",
+            "unique_rowkeys":null
+        },
+        "mask":{
+            "derived_from":"jwst_niriss_mask_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"MASK",
+            "filetype":"MASK",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_mask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_mask_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "5ecad4ace0d22f271aad88f0138bfb0e43c3e4a7", 
-            "suffix": "mask", 
-            "text_descr": "Bad Pixel Mask", 
-            "tpn": "niriss_mask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "photom": {
-            "derived_from": "jwst_niriss_photom_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "PHOTOM", 
-            "filetype": "PHOTOMETRIC CALIBRATION", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_photom_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_photom_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"5ecad4ace0d22f271aad88f0138bfb0e43c3e4a7",
+            "suffix":"mask",
+            "text_descr":"Bad Pixel Mask",
+            "tpn":"niriss_mask.tpn",
+            "unique_rowkeys":null
+        },
+        "photom":{
+            "derived_from":"jwst_niriss_photom_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PHOTOM",
+            "filetype":"PHOTOMETRIC CALIBRATION",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_photom_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_photom_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "cabd72cf325dc5bc2a52ff480de22090e0f35730", 
-            "suffix": "photom", 
-            "text_descr": "Absolute Calibration", 
-            "tpn": "niriss_photom.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "readnoise": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "READNOISE", 
-            "filetype": "READNOISE", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_readnoise_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_readnoise_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"cabd72cf325dc5bc2a52ff480de22090e0f35730",
+            "suffix":"photom",
+            "text_descr":"Absolute Calibration",
+            "tpn":"niriss_photom.tpn",
+            "unique_rowkeys":null
+        },
+        "readnoise":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"READNOISE",
+            "filetype":"READNOISE",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_readnoise_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_readnoise_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "c100fd63ed12a77e7dff45bb6c295bf013958e03", 
-            "suffix": "readnoise", 
-            "text_descr": "Read Noise", 
-            "tpn": "niriss_readnoise.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "regions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "REGIONS", 
-            "filetype": "REGIONS", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_regions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_regions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "regions", 
-            "text_descr": "Regions", 
-            "tpn": "niriss_regions.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "saturation": {
-            "derived_from": "jwst_niriss_saturation_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SATURATION", 
-            "filetype": "SATURATION", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_saturation_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_saturation_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"c100fd63ed12a77e7dff45bb6c295bf013958e03",
+            "suffix":"readnoise",
+            "text_descr":"Read Noise",
+            "tpn":"niriss_readnoise.tpn",
+            "unique_rowkeys":null
+        },
+        "regions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"REGIONS",
+            "filetype":"REGIONS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_regions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_regions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"regions",
+            "text_descr":"Regions",
+            "tpn":"niriss_regions.tpn",
+            "unique_rowkeys":null
+        },
+        "saturation":{
+            "derived_from":"jwst_niriss_saturation_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SATURATION",
+            "filetype":"SATURATION",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_saturation_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_saturation_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "640e923e4543069313c34f2d3d29b297e20ba1fc", 
-            "suffix": "saturation", 
-            "text_descr": "Saturation", 
-            "tpn": "niriss_saturation.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "specwcs": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "SPECWCS", 
-            "filetype": "SPECWCS", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_specwcs_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_specwcs_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "specwcs", 
-            "text_descr": "Spectroscopic World Coordinate System", 
-            "tpn": "niriss_specwcs.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "superbias": {
-            "derived_from": "handmade spec 05-01-2015", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "superbias", 
-            "filetype": "SUPERBIAS", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_sbias_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "niriss_superbias.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"640e923e4543069313c34f2d3d29b297e20ba1fc",
+            "suffix":"saturation",
+            "text_descr":"Saturation",
+            "tpn":"niriss_saturation.tpn",
+            "unique_rowkeys":null
+        },
+        "specwcs":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"SPECWCS",
+            "filetype":"SPECWCS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_specwcs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_specwcs_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"specwcs",
+            "text_descr":"Spectroscopic World Coordinate System",
+            "tpn":"niriss_specwcs.tpn",
+            "unique_rowkeys":null
+        },
+        "superbias":{
+            "derived_from":"handmade spec 05-01-2015",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"superbias",
+            "filetype":"SUPERBIAS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_sbias_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"niriss_superbias.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "832ad7a6be6ccf3a35a426539affca9e0141d640", 
-            "suffix": "sbias", 
-            "text_descr": "Super Bias", 
-            "tpn": "niriss_sbias.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "throughput": {
-            "derived_from": "Hand made 2015-02-09 13:06:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "THROUGHPUT", 
-            "filetype": "THROUGHPUT", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_throughput_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_filter.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"832ad7a6be6ccf3a35a426539affca9e0141d640",
+            "suffix":"sbias",
+            "text_descr":"Super Bias",
+            "tpn":"niriss_sbias.tpn",
+            "unique_rowkeys":null
+        },
+        "throughput":{
+            "derived_from":"Hand made 2015-02-09 13:06:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"THROUGHPUT",
+            "filetype":"THROUGHPUT",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_throughput_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_filter.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "d8c838f8bec6c62d190f7e8b204fc888f19007a8", 
-            "suffix": "throughput", 
-            "text_descr": "Throughput", 
-            "tpn": "niriss_throughput.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wcsregions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "WCSREGIONS", 
-            "filetype": "WCSREGIONS", 
-            "instrument": "NIRISS", 
-            "ld_tpn": "niriss_wcsregions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_niriss_wcsregions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "wcsregions", 
-            "text_descr": "World Coordinate System Regions", 
-            "tpn": "niriss_wcsregions.tpn", 
-            "unique_rowkeys": null
+            ],
+            "sha1sum":"d8c838f8bec6c62d190f7e8b204fc888f19007a8",
+            "suffix":"throughput",
+            "text_descr":"Throughput",
+            "tpn":"niriss_throughput.tpn",
+            "unique_rowkeys":null
+        },
+        "wcsregions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"WCSREGIONS",
+            "filetype":"WCSREGIONS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_wcsregions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_wcsregions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"wcsregions",
+            "text_descr":"World Coordinate System Regions",
+            "tpn":"niriss_wcsregions.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "nirspec": {
-        "all": {
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "all", 
-            "filetype": "all", 
-            "instrument": "nirspec", 
-            "ld_tpn": "nirspec_all.tpn", 
-            "suffix": "all", 
-            "text_descr": "All NIRSPEC reference file types.", 
-            "tpn": "nirspec_all.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "amplifier": {
-            "derived_from": "cloning tool 0.03b (2012-09-11)", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AMPLIFIER", 
-            "filetype": "DETECTOR PARAMETERS", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_amplifier_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_amplifier_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+    },
+    "nirspec":{
+        "all":{
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"all",
+            "filetype":"all",
+            "instrument":"nirspec",
+            "ld_tpn":"nirspec_all.tpn",
+            "suffix":"all",
+            "text_descr":"All NIRSPEC reference file types.",
+            "tpn":"nirspec_all.tpn",
+            "unique_rowkeys":null
+        },
+        "amplifier":{
+            "derived_from":"cloning tool 0.03b (2012-09-11)",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AMPLIFIER",
+            "filetype":"DETECTOR PARAMETERS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_amplifier_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_amplifier_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "35de9bfc39e41e1b524d5fbd9f2e16085242b61c", 
-            "suffix": "amplifier", 
-            "text_descr": "Detector Amplifier Readout Parameters", 
-            "tpn": "nirspec_amplifier.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "area": {
-            "derived_from": "Hand made 2015-09-02 16:35:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "AREA", 
-            "filetype": "AREA", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_area_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_area.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"35de9bfc39e41e1b524d5fbd9f2e16085242b61c",
+            "suffix":"amplifier",
+            "text_descr":"Detector Amplifier Readout Parameters",
+            "tpn":"nirspec_amplifier.tpn",
+            "unique_rowkeys":null
+        },
+        "area":{
+            "derived_from":"Hand made 2015-09-02 16:35:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"AREA",
+            "filetype":"AREA",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_area_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_area.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "1af8d4ff01f72850f0b5f1a72ee33d38f14b3c6d", 
-            "suffix": "area", 
-            "text_descr": "Pixel-Area Map", 
-            "tpn": "nirspec_area.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "camera": {
-            "derived_from": "Hand made 2015-09-02 16:35:00", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "camera", 
-            "filetype": "CAMERA", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_camera_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_camera_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"1af8d4ff01f72850f0b5f1a72ee33d38f14b3c6d",
+            "suffix":"area",
+            "text_descr":"Pixel-Area Map",
+            "tpn":"nirspec_area.tpn",
+            "unique_rowkeys":null
+        },
+        "camera":{
+            "derived_from":"Hand made 2015-09-02 16:35:00",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"camera",
+            "filetype":"CAMERA",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_camera_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_camera_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "fc23653634e35f582c19104793efc163a18c1dc4", 
-            "suffix": "camera", 
-            "text_descr": "Camera Model", 
-            "tpn": "nirspec_camera.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "collimator": {
-            "derived_from": "Hand made 2015-10-19 10:23:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "collimator", 
-            "filetype": "COLLIMATOR", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_collimator_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_collimator_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"fc23653634e35f582c19104793efc163a18c1dc4",
+            "suffix":"camera",
+            "text_descr":"Camera Model",
+            "tpn":"nirspec_camera.tpn",
+            "unique_rowkeys":null
+        },
+        "collimator":{
+            "derived_from":"Hand made 2015-10-19 10:23:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"collimator",
+            "filetype":"COLLIMATOR",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_collimator_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_collimator_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "eeda82173e7c5844ebbfd7add656129d0e988753", 
-            "suffix": "collimator", 
-            "text_descr": "Collimator", 
-            "tpn": "nirspec_collimator.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "dark": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-07-31", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "DARK", 
-            "filetype": "DARK", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_dark_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_dark_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"eeda82173e7c5844ebbfd7add656129d0e988753",
+            "suffix":"collimator",
+            "text_descr":"Collimator",
+            "tpn":"nirspec_collimator.tpn",
+            "unique_rowkeys":null
+        },
+        "dark":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-07-31",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"DARK",
+            "filetype":"DARK",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_dark_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_dark_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "345cc330e534b04b8a06672b19be997f1b1a572d", 
-            "suffix": "dark", 
-            "text_descr": "Dark Frame", 
-            "tpn": "nirspec_dark.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "disperser": {
-            "derived_from": "Hand made 2015-10-09 10:49:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "disperser", 
-            "filetype": "DISPERSER", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_disperser_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_disperser_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"345cc330e534b04b8a06672b19be997f1b1a572d",
+            "suffix":"dark",
+            "text_descr":"Dark Frame",
+            "tpn":"nirspec_dark.tpn",
+            "unique_rowkeys":null
+        },
+        "disperser":{
+            "derived_from":"Hand made 2015-10-09 10:49:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"disperser",
+            "filetype":"DISPERSER",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_disperser_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_disperser_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.GRATING", 
+                    "META.INSTRUMENT.GRATING",
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE", 
-                "GRATING": "META.INSTRUMENT.GRATING"
-            }, 
-            "sha1sum": "4af514924f81557d9e36e67b679301576c582fdf", 
-            "suffix": "disperser", 
-            "text_descr": "Disperser", 
-            "tpn": "nirspec_disperser.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "distortion": {
-            "derived_from": "jwst_nirspec_distortion_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "DISTORTION", 
-            "filetype": "DISTORTION", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_distortion_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_distortion_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE",
+                "GRATING":"META.INSTRUMENT.GRATING"
+            },
+            "sha1sum":"4af514924f81557d9e36e67b679301576c582fdf",
+            "suffix":"disperser",
+            "text_descr":"Disperser",
+            "tpn":"nirspec_disperser.tpn",
+            "unique_rowkeys":null
+        },
+        "distortion":{
+            "derived_from":"jwst_nirspec_distortion_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"DISTORTION",
+            "filetype":"DISTORTION",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_distortion_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_distortion_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR"
-            }, 
-            "sha1sum": "1a2c18a0a523c00830af4ebf4be2d4f01573abd4", 
-            "suffix": "distortion", 
-            "text_descr": "Distortion", 
-            "tpn": "nirspec_distortion.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "extract1d": {
-            "derived_from": "Hand made 2015-10-17 16:00:00", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "EXTRACT1D", 
-            "filetype": "EXTRACT1D", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_extract1d_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_extract1d.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR"
+            },
+            "sha1sum":"1a2c18a0a523c00830af4ebf4be2d4f01573abd4",
+            "suffix":"distortion",
+            "text_descr":"Distortion",
+            "tpn":"nirspec_distortion.tpn",
+            "unique_rowkeys":null
+        },
+        "extract1d":{
+            "derived_from":"Hand made 2015-10-17 16:00:00",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"EXTRACT1D",
+            "filetype":"EXTRACT1D",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_extract1d_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_extract1d.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "b33d4be491c3930ceb8867fa8ad9a8021492c975", 
-            "suffix": "extract1d", 
-            "text_descr": "1-D Spectral Extraction", 
-            "tpn": "nirspec_extract1d.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "flat": {
-            "derived_from": "jwst_nirspec_flat_0002.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "FLAT", 
-            "filetype": "PIXEL-TO-PIXEL FLAT", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_flat_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_flat_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"b33d4be491c3930ceb8867fa8ad9a8021492c975",
+            "suffix":"extract1d",
+            "text_descr":"1-D Spectral Extraction",
+            "tpn":"nirspec_extract1d.tpn",
+            "unique_rowkeys":null
+        },
+        "flat":{
+            "derived_from":"jwst_nirspec_flat_0002.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"FLAT",
+            "filetype":"PIXEL-TO-PIXEL FLAT",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_flat_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_flat_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.FILTER", 
-                    "META.INSTRUMENT.GRATING", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.INSTRUMENT.GRATING",
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "sha1sum": "db1d885edff103a746f163793a349d94a13a1ef2", 
-            "suffix": "flat", 
-            "text_descr": "Flat Field", 
-            "tpn": "nirspec_flat.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "fore": {
-            "derived_from": "Hand made 2015-10-09 11:43:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "fore", 
-            "filetype": "FORE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_fore_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_fore_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"db1d885edff103a746f163793a349d94a13a1ef2",
+            "suffix":"flat",
+            "text_descr":"Flat Field",
+            "tpn":"nirspec_flat.tpn",
+            "unique_rowkeys":null
+        },
+        "fore":{
+            "derived_from":"Hand made 2015-10-09 11:43:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"fore",
+            "filetype":"FORE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_fore_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_fore_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.EXP_TYPE", 
+                    "META.INSTRUMENT.EXP_TYPE",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE", 
-                "FILTER": "META.INSTRUMENT.FILTER"
-            }, 
-            "sha1sum": "1d5404d1402176db89ca31e80164c31600404b48", 
-            "suffix": "fore", 
-            "text_descr": "Transform through the FORE optics", 
-            "tpn": "nirspec_fore.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "fpa": {
-            "derived_from": "Hand made 2015-10-09 11:46:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "fpa", 
-            "filetype": "FPA", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_fpa_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_fpa_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE",
+                "FILTER":"META.INSTRUMENT.FILTER"
+            },
+            "sha1sum":"1d5404d1402176db89ca31e80164c31600404b48",
+            "suffix":"fore",
+            "text_descr":"Transform through the FORE optics",
+            "tpn":"nirspec_fore.tpn",
+            "unique_rowkeys":null
+        },
+        "fpa":{
+            "derived_from":"Hand made 2015-10-09 11:46:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"fpa",
+            "filetype":"FPA",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_fpa_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_fpa_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "d7fb052691732827cece84142106c82343e8b3db", 
-            "suffix": "fpa", 
-            "text_descr": "Transform in the Focal Plane Array", 
-            "tpn": "nirspec_fpa.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "gain": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "GAIN", 
-            "filetype": "GAIN", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_gain_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_gain_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"d7fb052691732827cece84142106c82343e8b3db",
+            "suffix":"fpa",
+            "text_descr":"Transform in the Focal Plane Array",
+            "tpn":"nirspec_fpa.tpn",
+            "unique_rowkeys":null
+        },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_gain_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "4ed43baeb63fbb32efc116ff3c26ba94b627120d", 
-            "suffix": "gain", 
-            "text_descr": "Gain", 
-            "tpn": "nirspec_gain.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ifufore": {
-            "derived_from": "Hand made 2016-04-26", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "ifufore", 
-            "filetype": "IFUFORE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_ifufore_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_ifufore_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"4ed43baeb63fbb32efc116ff3c26ba94b627120d",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"nirspec_gain.tpn",
+            "unique_rowkeys":null
+        },
+        "ifufore":{
+            "derived_from":"Hand made 2016-04-26",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"ifufore",
+            "filetype":"IFUFORE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_ifufore_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_ifufore_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "afddd14cffebcd87b30a2300aded95eedf8f3660", 
-            "suffix": "ifufore", 
-            "text_descr": "IFU fore", 
-            "tpn": "nirspec_ifufore.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ifupost": {
-            "derived_from": "Hand made 2016-04-26", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "ifupost", 
-            "filetype": "IFUPOST", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_ifupost_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_ifupost_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"afddd14cffebcd87b30a2300aded95eedf8f3660",
+            "suffix":"ifufore",
+            "text_descr":"IFU fore",
+            "tpn":"nirspec_ifufore.tpn",
+            "unique_rowkeys":null
+        },
+        "ifupost":{
+            "derived_from":"Hand made 2016-04-26",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"ifupost",
+            "filetype":"IFUPOST",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_ifupost_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_ifupost_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "c4264392e21f719c66b88bb16b6806c36faed09d", 
-            "suffix": "ifupost", 
-            "text_descr": "IFU post", 
-            "tpn": "nirspec_ifupost.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ifuslicer": {
-            "derived_from": "Hand made 2016-04-26", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "ifuslicer", 
-            "filetype": "IFUSLICER", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_ifuslicer_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_ifuslicer_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"c4264392e21f719c66b88bb16b6806c36faed09d",
+            "suffix":"ifupost",
+            "text_descr":"IFU post",
+            "tpn":"nirspec_ifupost.tpn",
+            "unique_rowkeys":null
+        },
+        "ifuslicer":{
+            "derived_from":"Hand made 2016-04-26",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"ifuslicer",
+            "filetype":"IFUSLICER",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_ifuslicer_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_ifuslicer_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.EXPOSURE.TYPE"
-            }, 
-            "sha1sum": "3cda291146217d8d2f4319c9d5e6c2b0b6943cd6", 
-            "suffix": "ifuslicer", 
-            "text_descr": "IFU slicer", 
-            "tpn": "nirspec_ifuslicer.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ipc": {
-            "derived_from": "generated as stub rmap on 2014-03-24 15:03:31.517206", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "IPC", 
-            "filetype": "INTERPIXEL CAPACITANCE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_ipc_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_ipc_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"3cda291146217d8d2f4319c9d5e6c2b0b6943cd6",
+            "suffix":"ifuslicer",
+            "text_descr":"IFU slicer",
+            "tpn":"nirspec_ifuslicer.tpn",
+            "unique_rowkeys":null
+        },
+        "ipc":{
+            "derived_from":"generated as stub rmap on 2014-03-24 15:03:31.517206",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"IPC",
+            "filetype":"INTERPIXEL CAPACITANCE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_ipc_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_ipc_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "sha1sum": "08c19ead33751574f4494989ecb467654fae06ed", 
-            "suffix": "ipc", 
-            "text_descr": "Interpixel Capacitance", 
-            "tpn": "nirspec_ipc.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "linearity": {
-            "derived_from": "jwst_nirspec_linearity_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "LINEARITY", 
-            "filetype": "LINEARITY", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_linearity_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_linearity_0002.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"08c19ead33751574f4494989ecb467654fae06ed",
+            "suffix":"ipc",
+            "text_descr":"Interpixel Capacitance",
+            "tpn":"nirspec_ipc.tpn",
+            "unique_rowkeys":null
+        },
+        "linearity":{
+            "derived_from":"jwst_nirspec_linearity_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"LINEARITY",
+            "filetype":"LINEARITY",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_linearity_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_linearity_0002.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "ca2a8ff797f66a0f7de113d916b1817c34915e3a", 
-            "suffix": "linearity", 
-            "text_descr": "Detector Linearity Correction Coefficients", 
-            "tpn": "nirspec_linearity.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "mask": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-07-31", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "MASK", 
-            "filetype": "MASK", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_mask_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_mask_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"ca2a8ff797f66a0f7de113d916b1817c34915e3a",
+            "suffix":"linearity",
+            "text_descr":"Detector Linearity Correction Coefficients",
+            "tpn":"nirspec_linearity.tpn",
+            "unique_rowkeys":null
+        },
+        "mask":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-07-31",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"MASK",
+            "filetype":"MASK",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_mask_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_mask_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "3cafee9685385d21c0e9d2cb23bacb51739df384", 
-            "suffix": "mask", 
-            "text_descr": "Bad Pixel Mask", 
-            "tpn": "nirspec_mask.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "msa": {
-            "derived_from": "Hand made 2015-10-09 13:27:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "msa", 
-            "filetype": "MSA", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_msa_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_msa_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"3cafee9685385d21c0e9d2cb23bacb51739df384",
+            "suffix":"mask",
+            "text_descr":"Bad Pixel Mask",
+            "tpn":"nirspec_mask.tpn",
+            "unique_rowkeys":null
+        },
+        "msa":{
+            "derived_from":"Hand made 2015-10-09 13:27:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"msa",
+            "filetype":"MSA",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_msa_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_msa_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "ecb67d915b325671fac3a2d5d490e7255e230500", 
-            "suffix": "msa", 
-            "text_descr": "Transform on the Multi Shutter Array", 
-            "tpn": "nirspec_msa.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "ote": {
-            "derived_from": "Hand made 2015-10-09 14:27:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "ote", 
-            "filetype": "OTE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_ote_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_ote_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"ecb67d915b325671fac3a2d5d490e7255e230500",
+            "suffix":"msa",
+            "text_descr":"Transform on the Multi Shutter Array",
+            "tpn":"nirspec_msa.tpn",
+            "unique_rowkeys":null
+        },
+        "ote":{
+            "derived_from":"Hand made 2015-10-09 14:27:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"ote",
+            "filetype":"OTE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_ote_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_ote_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "ed707f0f08e062c6e93838af65f9c7f79b600b18", 
-            "suffix": "ote", 
-            "text_descr": "Transform through the Optical Telescope Element", 
-            "tpn": "nirspec_ote.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "photom": {
-            "derived_from": "handmade spec 07-18-2016", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "photom", 
-            "filetype": "PHOTOM", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_photom_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "nirspec_photom.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"ed707f0f08e062c6e93838af65f9c7f79b600b18",
+            "suffix":"ote",
+            "text_descr":"Transform through the Optical Telescope Element",
+            "tpn":"nirspec_ote.tpn",
+            "unique_rowkeys":null
+        },
+        "photom":{
+            "derived_from":"handmade spec 07-18-2016",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"photom",
+            "filetype":"PHOTOM",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_photom_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"nirspec_photom.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "sha1sum": "245afb7ea97b599dba7cd1460650074d141e1b22", 
-            "suffix": "photom", 
-            "text_descr": "Absolute Calibration", 
-            "tpn": "nirspec_photom.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "readnoise": {
-            "derived_from": "cloning tool 0.05b (2013-04-12) used on 2013-10-04", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "READNOISE", 
-            "filetype": "READNOISE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_readnoise_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_readnoise_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"245afb7ea97b599dba7cd1460650074d141e1b22",
+            "suffix":"photom",
+            "text_descr":"Absolute Calibration",
+            "tpn":"nirspec_photom.tpn",
+            "unique_rowkeys":null
+        },
+        "readnoise":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"READNOISE",
+            "filetype":"READNOISE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_readnoise_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_readnoise_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "850e8d76cf1d825217843bec416945b9326d9a38", 
-            "suffix": "readnoise", 
-            "text_descr": "Read Noise", 
-            "tpn": "nirspec_readnoise.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "refpix": {
-            "derived_from": "handmade spec 03-01-2016", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "refpix", 
-            "filetype": "REFPIX", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_refpix_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "nirspec_refpix.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"850e8d76cf1d825217843bec416945b9326d9a38",
+            "suffix":"readnoise",
+            "text_descr":"Read Noise",
+            "tpn":"nirspec_readnoise.tpn",
+            "unique_rowkeys":null
+        },
+        "refpix":{
+            "derived_from":"handmade spec 03-01-2016",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"refpix",
+            "filetype":"REFPIX",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_refpix_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"nirspec_refpix.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.EXPOSURE.READPATT"
                 ]
-            ], 
-            "sha1sum": "2fb54a5895bf0f8348c70d0f1f9710f66e4f07a0", 
-            "substitutions": {
-                "META.EXPOSURE.READPATT": {
-                    "ALLIRS2": "NRSIRS2|NRSIRS2RAPID"
+            ],
+            "sha1sum":"2fb54a5895bf0f8348c70d0f1f9710f66e4f07a0",
+            "substitutions":{
+                "META.EXPOSURE.READPATT":{
+                    "ALLIRS2":"NRSIRS2|NRSIRS2RAPID"
                 }
-            }, 
-            "suffix": "refpix", 
-            "text_descr": "Reference Pixels", 
-            "tpn": "nirspec_refpix.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "regions": {
-            "derived_from": "jwst_nirspec_regions_0002.rmap", 
-            "extra_keys": [
+            },
+            "suffix":"refpix",
+            "text_descr":"Reference Pixels",
+            "tpn":"nirspec_refpix.tpn",
+            "unique_rowkeys":null
+        },
+        "regions":{
+            "derived_from":"jwst_nirspec_regions_0002.rmap",
+            "extra_keys":[
                 "META.EXPOSURE.TYPE"
-            ], 
-            "file_ext": ".json", 
-            "filekind": "REGIONS", 
-            "filetype": "REGIONS", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_regions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_regions_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "file_ext":".json",
+            "filekind":"REGIONS",
+            "filetype":"REGIONS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_regions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_regions_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.INSTRUMENT.GRATING", 
-                    "META.INSTRUMENT.FILTER", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.GRATING",
+                    "META.INSTRUMENT.FILTER",
                     "META.EXPOSURE.TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR", 
-                "EXP_TYPE": "META.EXPOSURE.TYPE", 
-                "FILTER": "META.INSTRUMENT.FILTER", 
-                "GRATING": "META.INSTRUMENT.GRATING"
-            }, 
-            "rmap_relevance": "(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\"))", 
-            "sha1sum": "49857936deae765788cad0f839e2ed4206e539e0", 
-            "suffix": "regions", 
-            "text_descr": "Regions", 
-            "tpn": "nirspec_regions.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "saturation": {
-            "derived_from": "jwst_nirspec_saturation_0000.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "SATURATION", 
-            "filetype": "SATURATION", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_saturation_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_saturation_0001.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR",
+                "EXP_TYPE":"META.EXPOSURE.TYPE",
+                "FILTER":"META.INSTRUMENT.FILTER",
+                "GRATING":"META.INSTRUMENT.GRATING"
+            },
+            "rmap_relevance":"(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\", \"MIR_LRS-FIXEDSLIT\", \"MIR_LRS-SLITLESS\"))",
+            "sha1sum":"49857936deae765788cad0f839e2ed4206e539e0",
+            "suffix":"regions",
+            "text_descr":"Regions",
+            "tpn":"nirspec_regions.tpn",
+            "unique_rowkeys":null
+        },
+        "saturation":{
+            "derived_from":"jwst_nirspec_saturation_0000.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"SATURATION",
+            "filetype":"SATURATION",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_saturation_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_saturation_0001.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
+                    "META.INSTRUMENT.DETECTOR",
                     "META.INSTRUMENT.FILTER"
                 ]
-            ], 
-            "sha1sum": "43172b4d92f9a5e3bc4283bae3ab7635b81d5b2a", 
-            "suffix": "saturation", 
-            "text_descr": "Saturation", 
-            "tpn": "nirspec_saturation.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "specwcs": {
-            "derived_from": "jwst_nirspec_specwcs_0002.rmap", 
-            "extra_keys": [
+            ],
+            "sha1sum":"43172b4d92f9a5e3bc4283bae3ab7635b81d5b2a",
+            "suffix":"saturation",
+            "text_descr":"Saturation",
+            "tpn":"nirspec_saturation.tpn",
+            "unique_rowkeys":null
+        },
+        "specwcs":{
+            "derived_from":"jwst_nirspec_specwcs_0002.rmap",
+            "extra_keys":[
                 "META.EXPOSURE.TYPE"
-            ], 
-            "file_ext": ".json", 
-            "filekind": "SPECWCS", 
-            "filetype": "SPECWCS", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_specwcs_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_specwcs_0003.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "file_ext":".json",
+            "filekind":"SPECWCS",
+            "filetype":"SPECWCS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_specwcs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_specwcs_0003.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.DETECTOR"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "DETECTOR": "META.INSTRUMENT.DETECTOR"
-            }, 
-            "rmap_relevance": "(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\"))", 
-            "sha1sum": "f0a3fb1ba255cc02307e9b33beacf371f5df991a", 
-            "suffix": "specwcs", 
-            "text_descr": "Spectroscopic World Coordinate System", 
-            "tpn": "nirspec_specwcs.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "superbias": {
-            "derived_from": "handmade spec 05-01-2015", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "superbias", 
-            "filetype": "SUPERBIAS", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_sbias_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "nirspec_superbias.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "reference_to_dataset":{
+                "DETECTOR":"META.INSTRUMENT.DETECTOR"
+            },
+            "rmap_relevance":"(META.EXPOSURE.TYPE not in (\"MIR_IMAGE\", \"NRC_IMAGE\", \"NIS_IMAGE\"))",
+            "sha1sum":"f0a3fb1ba255cc02307e9b33beacf371f5df991a",
+            "suffix":"specwcs",
+            "text_descr":"Spectroscopic World Coordinate System",
+            "tpn":"nirspec_specwcs.tpn",
+            "unique_rowkeys":null
+        },
+        "superbias":{
+            "derived_from":"handmade spec 05-01-2015",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"superbias",
+            "filetype":"SUPERBIAS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_sbias_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"nirspec_superbias.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR", 
-                    "META.EXPOSURE.READPATT", 
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.EXPOSURE.READPATT",
                     "META.SUBARRAY.NAME"
                 ]
-            ], 
-            "sha1sum": "0e450528863c8b320ee56bf45b547f8a3943f64e", 
-            "suffix": "sbias", 
-            "text_descr": "Super Bias", 
-            "tpn": "nirspec_sbias.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wavelengthrange": {
-            "derived_from": "Hand made 2015-10-09 15:35:00", 
-            "extra_keys": null, 
-            "file_ext": ".asdf", 
-            "filekind": "wavelengthrange", 
-            "filetype": "WAVELENGTHRANGE", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_wavelengthrange_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_wavelengthrange_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "sha1sum":"0e450528863c8b320ee56bf45b547f8a3943f64e",
+            "suffix":"sbias",
+            "text_descr":"Super Bias",
+            "tpn":"nirspec_sbias.tpn",
+            "unique_rowkeys":null
+        },
+        "wavelengthrange":{
+            "derived_from":"Hand made 2015-10-09 15:35:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"wavelengthrange",
+            "filetype":"WAVELENGTHRANGE",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_wavelengthrange_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_wavelengthrange_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.INSTRUMENT.EXP_TYPE"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "EXP_TYPE": "META.INSTRUMENT.EXP_TYPE"
-            }, 
-            "sha1sum": "8e2347c1b401cb0a43f4a16ffb569d86fd8c5454", 
-            "suffix": "wavelengthrange", 
-            "text_descr": "Spectral Configurations", 
-            "tpn": "nirspec_wavelengthrange.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "wcsregions": {
-            "derived_from": "Handmade spec", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "WCSREGIONS", 
-            "filetype": "WCSREGIONS", 
-            "instrument": "NIRSPEC", 
-            "ld_tpn": "nirspec_wcsregions_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_nirspec_wcsregions_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [], 
-            "suffix": "wcsregions", 
-            "text_descr": "World Coordinate System Regions", 
-            "tpn": "nirspec_wcsregions.tpn", 
-            "unique_rowkeys": null
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.INSTRUMENT.EXP_TYPE"
+            },
+            "sha1sum":"8e2347c1b401cb0a43f4a16ffb569d86fd8c5454",
+            "suffix":"wavelengthrange",
+            "text_descr":"Spectral Configurations",
+            "tpn":"nirspec_wavelengthrange.tpn",
+            "unique_rowkeys":null
+        },
+        "wcsregions":{
+            "derived_from":"Handmade spec",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"WCSREGIONS",
+            "filetype":"WCSREGIONS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_wcsregions_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_wcsregions_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[],
+            "suffix":"wcsregions",
+            "text_descr":"World Coordinate System Regions",
+            "tpn":"nirspec_wcsregions.tpn",
+            "unique_rowkeys":null
         }
-    }, 
-    "system": {
-        "calver": {
-            "classes": [
-                "Match", 
+    },
+    "system":{
+        "calver":{
+            "classes":[
+                "Match",
                 "UseAfter"
-            ], 
-            "derived_from": "Hand made 2016-08-25", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "CALVER", 
-            "filetype": "CALVER", 
-            "instrument": "SYSTEM", 
-            "ld_tpn": "system_calver_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_system_calver_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "derived_from":"Hand made 2016-08-25",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"CALVER",
+            "filetype":"CALVER",
+            "instrument":"SYSTEM",
+            "ld_tpn":"system_calver_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_system_calver_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "CAL_VER"
-                ], 
+                ],
                 [
-                    "META.OBSERVATION.DATE", 
+                    "META.OBSERVATION.DATE",
                     "META.OBSERVATION.TIME"
                 ]
-            ], 
-            "sha1sum": "f86296b13da8e7b6d5edefac1493391f837efab9", 
-            "suffix": "calver", 
-            "text_descr": "Calibration Software Component Versions", 
-            "tpn": "system_calver.tpn", 
-            "unique_rowkeys": null
-        }, 
-        "datalvl": {
-            "classes": [
+            ],
+            "sha1sum":"f86296b13da8e7b6d5edefac1493391f837efab9",
+            "suffix":"calver",
+            "text_descr":"Calibration Software Component Versions",
+            "tpn":"system_calver.tpn",
+            "unique_rowkeys":null
+        },
+        "datalvl":{
+            "classes":[
                 "VersionAfter"
-            ], 
-            "derived_from": "Hand made 2016-09-09", 
-            "extra_keys": null, 
-            "file_ext": ".json", 
-            "filekind": "DATALVL", 
-            "filetype": "DATALVL", 
-            "instrument": "SYSTEM", 
-            "ld_tpn": "system_datalvl_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "jwst_system_datalvl_0000.rmap", 
-            "observatory": "JWST", 
-            "parkey": [
+            ],
+            "derived_from":"Hand made 2016-09-09",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"DATALVL",
+            "filetype":"DATALVL",
+            "instrument":"SYSTEM",
+            "ld_tpn":"system_datalvl_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_system_datalvl_0000.rmap",
+            "observatory":"JWST",
+            "parkey":[
                 [
                     "META.CALIBRATION_SOFTWARE_VERSION"
                 ]
-            ], 
-            "reference_to_dataset": {
-                "CAL_VER": "META.CALIBRATION_SOFTWARE_VERSION"
-            }, 
-            "sha1sum": "a4fa79f50d44a9145694260e0d8982ab17150381", 
-            "suffix": "datalvl", 
-            "text_descr": "Reference Type to Processing Data Level", 
-            "tpn": "system_datalvl.tpn", 
-            "unique_rowkeys": null
+            ],
+            "reference_to_dataset":{
+                "CAL_VER":"META.CALIBRATION_SOFTWARE_VERSION"
+            },
+            "sha1sum":"a4fa79f50d44a9145694260e0d8982ab17150381",
+            "suffix":"datalvl",
+            "text_descr":"Reference Type to Processing Data Level",
+            "tpn":"system_datalvl.tpn",
+            "unique_rowkeys":null
         }
     }
 }

--- a/crds/reftypes.py
+++ b/crds/reftypes.py
@@ -113,7 +113,7 @@ def load_raw_specs(spec_path):
 
 def save_json_specs(specs, combined_specs_path):
     """Write out the specs dictionary returned by _load_specs() as .json in one combined file."""
-    specs_json = json.dumps(specs, indent=4, sort_keys=True)
+    specs_json = json.dumps(specs, indent=4, sort_keys=True, separators=(',', ':'))
     with open(combined_specs_path, "w+") as specs_file:
         specs_file.write(specs_json)
         log.info("Saved combined type specs to", repr(combined_specs_path))

--- a/crds/tobs/specs/combined_specs.json
+++ b/crds/tobs/specs/combined_specs.json
@@ -1,25 +1,25 @@
 {
-    "tinstr": {
-        "tfilekind": {
-            "derived_from": "jwst_miri_distortion_0001.rmap", 
-            "extra_keys": null, 
-            "file_ext": ".fits", 
-            "filekind": "TFILEKIND", 
-            "filetype": "TFILEKIND", 
-            "instrument": "TINSTR", 
-            "ld_tpn": "tinstr_tfk_ld.tpn", 
-            "mapping": "REFERENCE", 
-            "name": "tobs_tinstr_tfilekind.rmap", 
-            "observatory": "TOBS", 
-            "parkey": [
-                "TEST_CASE", 
+    "tinstr":{
+        "tfilekind":{
+            "derived_from":"jwst_miri_distortion_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"TFILEKIND",
+            "filetype":"TFILEKIND",
+            "instrument":"TINSTR",
+            "ld_tpn":"tinstr_tfk_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"tobs_tinstr_tfilekind.rmap",
+            "observatory":"TOBS",
+            "parkey":[
+                "TEST_CASE",
                 "PARAMETER"
-            ], 
-            "sha1sum": "e33265823224a35bab99d368fd22f33a31471845", 
-            "suffix": "tfk", 
-            "text_descr": "Test File Type", 
-            "tpn": "tinstr_tfk.tpn", 
-            "unique_rowkeys": null
+            ],
+            "sha1sum":"e33265823224a35bab99d368fd22f33a31471845",
+            "suffix":"tfk",
+            "text_descr":"Test File Type",
+            "tpn":"tinstr_tfk.tpn",
+            "unique_rowkeys":null
         }
     }
 }


### PR DESCRIPTION
OS-X and Linux were producing different results for the combined type spec .json formatting. The scheme requires continually rewriting the specs to avoid forgetting it when adding new types.  Adding explicit separators parameter to dumps() eliminated platform specific white space so both Linux and OS-X rewrite the same spec... hence it doesn't change just because of platform,  only when the individual specs change.