### PR TITLE
Enhanced newcontext script and functions to support a pseudo-rmap

### DIFF
--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -44,6 +44,15 @@ from crds.hst.tpn import get_tpninfos, reference_name_to_tpn_text, reference_nam
 
 # =======================================================================
 
+def match_context_key(key):
+    """Set the case of a context key (instrument or type) appropriately
+    for this project, HST used upper case for instruments,  lower case
+    for type names.
+    """
+    return key.upper() if key.upper() in INSTRUMENTS else key.lower()
+ 
+# =======================================================================
+
 def reference_keys_to_dataset_keys(rmapping, header):
     """Given a header dictionary for a reference file,  map the header back to
     keys relevant to datasets.

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -52,6 +52,14 @@ suffix_to_filekind = TYPES.suffix_to_filekind
 
 # =======================================================================
 
+def match_context_key(key):
+    """Set the case of a context key appropriately for this project, JWST
+    always uses upper case.
+    """
+    return key.upper()
+
+# =======================================================================
+
 def mapping_validator_key(mapping):
     """For now,  just use instrument based constraints."""
     return (mapping.instrument + "_all_ld.tpn", mapping.name)

--- a/crds/rmap.py
+++ b/crds/rmap.py
@@ -639,18 +639,16 @@ class ContextMapping(Mapping):
             selection.force_load()
 
     def set_item(self, key, value):
-        """Add or replace and element of this mapping's selector.   For re-writing only."""
-        key = str(key)
-        if key.upper() in self.selector:
-            key = key.upper()
-            replaced = self.selector[key]
-        elif key.lower() in self.selector:
-            key = key.lower()
-            replaced = self.selector[key]
-        else:
-            replaced = None
-        self.selector[key] = str(value)
-        return replaced
+        """Add or replace and element of this mapping's selector.   For re-writing only.
+
+        Return the case-corrected value of `key` and the value that was replaced or None
+        as (corrected_key, replaced_value).
+        """
+        key, value = str(key), str(value)
+        key = self.locate.match_context_key(key)
+        replaced = self.selector.get(key, None)
+        self.selector[key] = value
+        return key, replaced
 
     def validate(self):
         """Validate nested mappings, common properties for all context mappings."""


### PR DESCRIPTION
notation used to set values to N/A.

Normally crds.newcontext takes an existing pmap and a list of new
rmaps to inject in order to create a new pmap and related imaps.  With
this enhancement, one can also specify e.g. miri_dflat_n/a and
newcontext will set the MIRI DFLAT value to N/A instead of an
rmap.