### PR TITLE
Accept "versions" defaut context specifier

### DIFF
--- a/crds/config.py
+++ b/crds/config.py
@@ -929,10 +929,10 @@ CONTEXT_OBS_INSTR_KIND_RE_STR = r"[a-z]{1,8}(\-[a-z0-9]{1,32}(\-[a-z0-9]{1,32})?
 CONTEXT_OBS_RE_STR = r"[a-z]{1,8}" 
 
 # e.g.   2040-02-22T12:01:30.4567,  hst-2040-02-22T12:01:30.4567, hst-acs-2040-02-22T12:01:30.4567, ...
-CONTEXT_RE_STR = r"(?P<context>" + CONTEXT_OBS_INSTR_KIND_RE_STR + r"\-)?((?P<date>" + CONTEXT_DATETIME_RE_STR + r"|edit|operational))"
+CONTEXT_RE_STR = r"(?P<context>" + CONTEXT_OBS_INSTR_KIND_RE_STR + r"\-)?((?P<date>" + CONTEXT_DATETIME_RE_STR + r"|edit|operational|versions))"
 CONTEXT_RE = re.compile(complete_re(CONTEXT_RE_STR))
 
-PIPELINE_CONTEXT_RE_STR = r"(?P<context>" + CONTEXT_OBS_RE_STR + r"\-)?((?P<date>" + CONTEXT_DATETIME_RE_STR + r"|edit|operational))"
+PIPELINE_CONTEXT_RE_STR = r"(?P<context>" + CONTEXT_OBS_RE_STR + r"\-)?((?P<date>" + CONTEXT_DATETIME_RE_STR + r"|edit|operational|versions))"
 PIPELINE_CONTEXT_RE = re.compile(complete_re(PIPELINE_CONTEXT_RE_STR))
 
 MAPPING_RE_STR = CRDS_NAME_RE_STR + r".map"


### PR DESCRIPTION
Added "versions" as a kind of default context that can be queried,  nominally
this is the last defined context,   or more ideally,  the last context
in which SYSTEM CALVER changed.   This is not necessarily the context in use
in the pipeline,  or the context from which future rules are derived.   This
is the context that reflects the monotonically increasing ability of CRDS to
interpret cal code master version numbers into a component version reference
file.   So even when say the calibration references temporarily revert to an
old version of CRDS rules,  the ability of CRDS to interpret version strings
should not correspondingly revert;   that would couple reversions in the cal
code as well and generally those do not occur.   This is a regex change making the -versions 
decoration legal, added here mainly because the CRDS server uses this same regex and
requires it.