### PR TITLE
Generated new JWST combined_specs.json including msa and pathloss specs.

### DIFF
--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -739,6 +739,36 @@
             "tpn":"miri_mask.tpn",
             "unique_rowkeys":null
         },
+        "pathloss":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"Hand made 2016-10-20",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PATHLOSS",
+            "filetype":"PATHLOSS",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_pathloss_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_pathloss.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"237111ef3bdba8734aa03f7ebd6a6e04b8b04523",
+            "suffix":"pathloss",
+            "text_descr":"Path loss correction",
+            "tpn":"miri_pathloss.tpn",
+            "unique_rowkeys":null
+        },
         "photom":{
             "derived_from":"jwst_miri_photom_0002.rmap",
             "extra_keys":null,
@@ -1672,6 +1702,36 @@
             "tpn":"niriss_mask.tpn",
             "unique_rowkeys":null
         },
+        "pathloss":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"Hand made 2016-10-20",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PATHLOSS",
+            "filetype":"PATHLOSS",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_pathloss_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_pathloss.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"69994ee55fa75fdd1b551647c87490e2d719b466",
+            "suffix":"pathloss",
+            "text_descr":"Path loss correction",
+            "tpn":"niriss_pathloss.tpn",
+            "unique_rowkeys":null
+        },
         "photom":{
             "derived_from":"jwst_niriss_photom_0002.rmap",
             "extra_keys":null,
@@ -1896,6 +1956,34 @@
             "suffix":"area",
             "text_descr":"Pixel-Area Map",
             "tpn":"nirspec_area.tpn",
+            "unique_rowkeys":null
+        },
+        "badshutter":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"Hand made 2016-10-20",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"BADSHUTTER",
+            "filetype":"BADSHUTTER",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_badshutter_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_badshutter.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"f73154cebd23df653910ee7b8d2da3d80b300196",
+            "suffix":"badshutter",
+            "text_descr":"Flagging bad shutters step",
+            "tpn":"nirspec_badshutter.tpn",
             "unique_rowkeys":null
         },
         "camera":{
@@ -2401,6 +2489,36 @@
             "suffix":"ote",
             "text_descr":"Transform through the Optical Telescope Element",
             "tpn":"nirspec_ote.tpn",
+            "unique_rowkeys":null
+        },
+        "pathloss":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"Hand made 2016-10-20",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"PATHLOSS",
+            "filetype":"PATHLOSS",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_pathloss_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_pathloss.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"903d4d5fc543ff1bc9166b816e78684b5f4d32ce",
+            "suffix":"pathloss",
+            "text_descr":"Path loss correction",
+            "tpn":"nirspec_pathloss.tpn",
             "unique_rowkeys":null
         },
         "photom":{


### PR DESCRIPTION
Files in the project "specs" directory are now loaded and combined into combined_specs.json files that are generated automatically by running ./install and then committed to the code base.   This is a file count i/o optimization needed due to Isilon performance issues that exaggerate the cost of every file open.



