### PR TITLE
Reduced crds.sync --save-pickles memory utilization

### DIFF
--- a/crds/config.py
+++ b/crds/config.py
@@ -407,7 +407,7 @@ def locate_pickle(mapping, observatory=None):
         return mapping
     if observatory is None:
         observatory = mapping_to_observatory(mapping)
-    return os.path.join(get_crds_picklepath(observatory), mapping)
+    return os.path.join(get_crds_picklepath(observatory), mapping + ".pkl")
 
 USE_PICKLED_CONTEXTS = BooleanConfigItem("CRDS_USE_PICKLED_CONTEXTS", False,
     "When True,  CRDS contexts should be loaded from a pickled version if possible.")

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -608,7 +608,7 @@ def get_symbolic_mapping(
         
 # ============================================================================
 
-@utils.cached
+@utils.cached   # check callers for .uncached before removing.
 def get_pickled_mapping(mapping, cached=True, use_pickles=None, save_pickles=None, **keys):
     """Load CRDS mapping from a context pickle if possible, nominally as a file
     system optimization to prevent 100+ file reads.   
@@ -638,7 +638,7 @@ def load_pickled_mapping(mapping):
     in the hierarchy is read.  In general pickles for sub-mappings should not
     exist because of storage waste.
     """
-    pickle_file = config.locate_pickle(mapping + ".pkl")
+    pickle_file = config.locate_pickle(mapping)
     pickled = open(pickle_file, "rb").read()
     loaded = python23.pickle.loads(pickled)
     log.info("Loaded pickled context", repr(mapping))
@@ -646,7 +646,7 @@ def load_pickled_mapping(mapping):
 
 def save_pickled_mapping(mapping, loaded):
     """Save live mapping `loaded` as a pickle under named based on `mapping` name."""
-    pickle_file = config.locate_pickle(mapping + ".pkl")
+    pickle_file = config.locate_pickle(mapping)
     if not utils.is_writable(pickle_file):  # Don't even bother pickling
         log.verbose("Pickle file", repr(pickle_file), "is not writable,  skipping pickle save.")
         return
@@ -654,7 +654,7 @@ def save_pickled_mapping(mapping, loaded):
         loaded.force_load()
         pickled = python23.pickle.dumps(loaded)
         cache_atomic_write(pickle_file, pickled, "CONTEXT PICKLE")
-        log.info("Saved pickled context", repr(mapping))
+        log.info("Saved pickled context", repr(pickle_file))
 
 # =============================================================================
 

--- a/crds/list.py
+++ b/crds/list.py
@@ -442,7 +442,7 @@ and ids used for CRDS reprocessing recommendations.
         
     def list_cached_pickles(self):
         """List the pickle paths in the local cache."""
-        _print_list(rmap.list_pickles("*.pkl", self.observatory, full_path=self.args.full_path))
+        _print_list(rmap.list_pickles("*", self.observatory, full_path=self.args.full_path))
         
     def list_cached_references(self):
         """List the reference paths in the local cache."""

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -325,7 +325,7 @@ class SyncScript(cmdline.ContextsScript):
     def clear_pickles(self, contexts):
         """Remove pickles specified by `contexts`."""
         for context in contexts:
-            path = config.locate_pickle(context + ".pkl")
+            path = config.locate_pickle(context)
             if os.path.exists(path):
                 utils.remove(path, self.observatory)
 
@@ -336,9 +336,7 @@ class SyncScript(cmdline.ContextsScript):
         """
         for context in contexts:
             with log.error_on_exception("Failed pickling", repr(context)):
-                pickle_path = config.locate_pickle(context, self.observatory)
-                if not os.path.exists(context):
-                    crds.get_pickled_mapping(context, use_pickles=True, save_pickles=True)  # reviewed
+                crds.get_pickled_mapping.uncached(context, use_pickles=True, save_pickles=True)  # reviewed
     
     # ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Switched to uncached version of get_pickled_mapping() in crds.sync --save-pickles method,  simplified method, simplified config.locate_pickle() to automatically add ".pkl" suffix and refactored all calls.
