### PR TITLE
Add NIRISS SPECWCS N/A EXP_TYPE's

### DIFF
--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1847,7 +1847,7 @@
                 "EXP_TYPE":"META.EXPOSURE.TYPE",
                 "SUBARRAY":"META.SUBARRAY.NAME"
             },
-            "sha1sum":"260018a9310d25d6e34c6fe1d5b30611f48ff27a",
+            "sha1sum":"a5000097c9b856f751b84f5caeb1bb9e44353dd2",
             "substitutions":{
                 "META.SUBARRAY.NAME":{
                     "GENERIC":"N/A"

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1835,6 +1835,7 @@
             "observatory":"JWST",
             "parkey":[
                 [
+                    "META.SUBARRAY.NAME",
                     "META.EXPOSURE.TYPE"
                 ],
                 [
@@ -1842,7 +1843,16 @@
                     "META.OBSERVATION.TIME"
                 ]
             ],
-            "sha1sum":"eeadc2cc43a1e31f83b8a34b6555768abe5321f8",
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE",
+                "SUBARRAY":"META.SUBARRAY.NAME"
+            },
+            "sha1sum":"799efae38a9f9524a393a148e50c80fbb25e4601",
+            "substitutions":{
+                "META.SUBARRAY.NAME":{
+                    "GENERIC":"N/A"
+                }
+            },
             "suffix":"specwcs",
             "text_descr":"Spectral World Coordinate System",
             "tpn":"niriss_specwcs.tpn",

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1847,7 +1847,7 @@
                 "EXP_TYPE":"META.EXPOSURE.TYPE",
                 "SUBARRAY":"META.SUBARRAY.NAME"
             },
-            "sha1sum":"799efae38a9f9524a393a148e50c80fbb25e4601",
+            "sha1sum":"260018a9310d25d6e34c6fe1d5b30611f48ff27a",
             "substitutions":{
                 "META.SUBARRAY.NAME":{
                     "GENERIC":"N/A"

--- a/crds/jwst/specs/niriss_specwcs.rmap
+++ b/crds/jwst/specs/niriss_specwcs.rmap
@@ -13,7 +13,7 @@ header = {
         'EXP_TYPE' : 'META.EXPOSURE.TYPE',
         'SUBARRAY' : 'META.SUBARRAY.NAME',
     },
-    'sha1sum' : '799efae38a9f9524a393a148e50c80fbb25e4601',
+    'sha1sum' : '260018a9310d25d6e34c6fe1d5b30611f48ff27a',
     'substitutions' : {
         'META.SUBARRAY.NAME' : {
             'GENERIC' : 'N/A',
@@ -24,4 +24,13 @@ header = {
 }
 
 selector = Match({
+    ('ANY', 'NIS_AMI') : 'N/A',
+    ('ANY', 'NIS_DARK') : 'N/A',
+    ('ANY', 'NIS_FOCUS') : 'N/A',
+    ('ANY', 'NIS_IMAGE') : 'N/A',
+    ('ANY', 'NIS_LAMP') : 'N/A',
+    ('ANY', 'NIS_SOSS') : 'N/A',
+    ('ANY', 'NIS_TACONFIRM') : 'N/A',
+    ('ANY', 'NIS_TACQ') : 'N/A',
+    ('ANY', 'NIS_WFSS') : 'N/A',
 })

--- a/crds/jwst/specs/niriss_specwcs.rmap
+++ b/crds/jwst/specs/niriss_specwcs.rmap
@@ -8,8 +8,17 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'jwst_niriss_specwcs.rmap',
     'observatory' : 'JWST',
-    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : 'eeadc2cc43a1e31f83b8a34b6555768abe5321f8',
+    'parkey' : (('META.SUBARRAY.NAME', 'META.EXPOSURE.TYPE'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'reference_to_dataset' : {
+        'EXP_TYPE' : 'META.EXPOSURE.TYPE',
+        'SUBARRAY' : 'META.SUBARRAY.NAME',
+    },
+    'sha1sum' : '799efae38a9f9524a393a148e50c80fbb25e4601',
+    'substitutions' : {
+        'META.SUBARRAY.NAME' : {
+            'GENERIC' : 'N/A',
+        },
+    },
     'suffix' : 'specwcs',
     'text_descr' : 'Spectral World Coordinate System',
 }

--- a/crds/jwst/specs/niriss_specwcs.rmap
+++ b/crds/jwst/specs/niriss_specwcs.rmap
@@ -13,7 +13,7 @@ header = {
         'EXP_TYPE' : 'META.EXPOSURE.TYPE',
         'SUBARRAY' : 'META.SUBARRAY.NAME',
     },
-    'sha1sum' : '260018a9310d25d6e34c6fe1d5b30611f48ff27a',
+    'sha1sum' : 'a5000097c9b856f751b84f5caeb1bb9e44353dd2',
     'substitutions' : {
         'META.SUBARRAY.NAME' : {
             'GENERIC' : 'N/A',
@@ -29,7 +29,6 @@ selector = Match({
     ('ANY', 'NIS_FOCUS') : 'N/A',
     ('ANY', 'NIS_IMAGE') : 'N/A',
     ('ANY', 'NIS_LAMP') : 'N/A',
-    ('ANY', 'NIS_SOSS') : 'N/A',
     ('ANY', 'NIS_TACONFIRM') : 'N/A',
     ('ANY', 'NIS_TACQ') : 'N/A',
     ('ANY', 'NIS_WFSS') : 'N/A',

--- a/install
+++ b/install
@@ -32,6 +32,9 @@ st=0
 # source code.
 
 find . -name combined_specs.json | xargs rm
+
+find crds/hst/specs crds/jwst/specs crds/tobs/specs -name '*.rmap' | xargs python -m crds.checksum
+
 python -m crds.hst
 python -m crds.jwst
 python -m crds.tobs


### PR DESCRIPTION
Updated NIRISS SPECWCS baseline rmap to include:

"reference_to_dataset" header  field for rmap update translations from ASDF tree names to data model names.

"substitutions" header field to define run time substitution from GENERIC to N/A.

EXP_TYPE's defined explicitly as N/A to support data driven operation of assign_wcs, skipped processing.

