### PR TITLE
Centralize pipeline awareness

### DIFF
--- a/crds/cmdline.py
+++ b/crds/cmdline.py
@@ -529,6 +529,7 @@ class UniqueErrorsMixin(object):
         self.ue_mixin = Struct()
         self.ue_mixin.messages = {}
         self.ue_mixin.count = Counter()
+        self.ue_mixin.tracked_errors = 0
         self.ue_mixin.unique_data_names = set()
         self.ue_mixin.all_data_names = set()
         self.ue_mixin.announce_suppressed = Counter()
@@ -556,6 +557,7 @@ class UniqueErrorsMixin(object):
         is defined as (instrument, filekind, msg_text) and omits data id.
         """
         # Always count messages
+        self.ue_mixin.tracked_errors += 1
         msg = self.format_prefix(data, instrument, filekind, *params, **keys)
         key = log.format(instrument, filekind.upper(), *params, **keys)
         if key not in self.ue_mixin.messages:
@@ -596,7 +598,9 @@ class UniqueErrorsMixin(object):
                 if self.ue_mixin.count[key] >= self.args.unique_threshold:
                     log.info("%06d" % self.ue_mixin.count[key], "total errors like::", self.ue_mixin.messages[key])
             log.info("All unique error types:", len(self.ue_mixin.messages))
+            log.info("Untracked errors:", log.errors() - self.ue_mixin.tracked_errors)            
             log.info("="*20, "="*len("unique error classes"), "="*20)
+
         if self.args.all_errors_file:
             self.dump_error_data(self.args.all_errors_file, self.ue_mixin.all_data_names)
         if self.args.unique_errors_file:

--- a/crds/heavy_client.py
+++ b/crds/heavy_client.py
@@ -330,6 +330,8 @@ def hv_best_references(context_file, header, include=None, condition=True):
     filekinds listed in `include`.
     """
     ctx = get_symbolic_mapping(context_file, cached=True)
+    if include is None:
+        include = ctx.locate.header_to_reftypes(header)
     minheader = ctx.minimize_header(header)
     log.verbose("Bestrefs header:\n", log.PP(minheader))
     if condition:

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -191,9 +191,12 @@ def header_to_reftypes(header):
 
     Return a list of reftype names.
     """
-    with log.augment_exception("Can't find EXP_TYPE for:\n", log.PP(header)):
-        exp_type = header.get("META.EXPOSURE.TYPE", header.get("EXP_TYPE"))
-    return exptype_to_reftypes(exp_type)
+    with log.verbose_warning_on_exception("Failed determining required reftypes from header", log.PP(header)):
+        exp_type = header.get("META.EXPOSURE.TYPE")
+        if not exp_type:
+            exp_type = header["EXP_TYPE"]
+        return exptype_to_reftypes(exp_type)
+    return []
 
 def exptype_to_reftypes(exp_type):
     """For a given EXP_TYPE string, return a list of reftypes needed to process that

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -290,10 +290,12 @@ def dt_test_jwst_header_to_reftypes():
     >>> header_to_reftypes({"EXP_TYPE":"MIR_DARK"})
     ['ipc', 'linearity', 'mask', 'refpix', 'rscd', 'saturation', 'superbias']
 
-    >>> header_to_reftypes({"EXP_TYPE":"NIRCAM_IMAGE"})
-    Traceback (most recent call last):
-    ...
-    RuntimeError: Unhandled EXP_TYPE 'NIRCAM_IMAGE'
+    >>> header_to_reftypes({"EXP_TYPE":"NIR_IMAGE"})
+    []
+
+    # Traceback (most recent call last):
+    # ...
+    # RuntimeError: Unhandled EXP_TYPE 'NIR_IMAGE'
 
     >>> header_to_reftypes({"EXP_TYPE":"MIR_IMAGE"})
     ['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'filteroffset', 'fore', 'fpa', 'gain', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'photom', 'readnoise', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'superbias', 'v2v3', 'wavelengthrange']


### PR DESCRIPTION
Fix for JWST header_to_reftypes EXP_TYPE determination,  new default of [] (all types) when determination fails.   

Improved unique errors mixin by adding count of untracked errors to summary