### PR TITLE
Bugfix for dictionary mutation during iteration in substitution code

### DIFF
--- a/crds/selectors.py
+++ b/crds/selectors.py
@@ -257,9 +257,10 @@ class Selector(object):
         for parkey in substitutions:
             try:
                 which = parameters.index(parkey)
-            except ValueError as exc:
+            except Exception:
                 continue
-            for match in selections:
+            matches = sorted(list(selections.keys()))
+            for match in matches:
                 old_parvalue = match[which]
                 if old_parvalue in substitutions[parkey]:
                     replacement = substitutions[parkey][old_parvalue]


### PR DESCRIPTION
Fixes replacement of rmap matching values of GENERIC with N/A.   Bug intermittent,
limited to rmaps which use "substitutions" and witnessed for Python-3 only during reprocessing regressions.