### PR TITLE
Datamodel useafter workaround

### DIFF
--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -257,6 +257,8 @@ def reference_keys_to_dataset_keys(rmapping, header):
                 rval = header[rkey]
                 if dval in [None, "N/A", "UNDEFINED"] and rval not in [None, "UNDEFINED"]:
                     header[dkey] = rval
+    if "USEAFTER" not in header and "META.REFFILE.USEAFTER" in header:
+        header["USEAFTER"] = header["META.REFFILE.USEAFTER"]
     if "USEAFTER" in header:  # and "DATE-OBS" not in header:
         reformatted = timestamp.reformat_useafter(rmapping, header).split()
         header["DATE-OBS"] = header["META.OBSERVATION.DATE"] = reformatted[0]

--- a/crds/timestamp.py
+++ b/crds/timestamp.py
@@ -388,11 +388,10 @@ class Jwstdate(DateParser):
     _format = re.compile(
         r"^(?P<year>\d\d\d\d)\-" + \
             r"(?P<month>\d\d)\-" + \
-            r"(?P<day>\d\d)" + \
-            r"T(?P<hour>\d\d):" + \
+            r"(?P<day>\d\d)(T" + \
+            r"(?P<hour>\d\d):" + \
             r"(?P<minute>\d\d):" + \
-            r"(?P<second>\d\d)$"
-        )
+            r"(?P<second>\d\d))?$")
 
     @classmethod
     def _get_date_dict(cls, match):


### PR DESCRIPTION
Modified CRDS to support USEAFTER values without time once again.   Also switched to support fetching USEAFTER from data model META.REFFILE.USEAFTER.