### PR TITLE
Improved diagnostic messages for rmap updates

### DIFF
--- a/crds/core/exceptions.py
+++ b/crds/core/exceptions.py
@@ -111,6 +111,12 @@ class BadValueError(CrdsError):
 class ModificationError(CrdsError):
     """Failed attempt to modify rmap, e.g. replacement vs. addition."""
 
+class OverlappingMatchError(ModificationError):
+    """At least two of the references being added to an rmap had exactly the
+    same matching criteria (for at least one of their applicable cases) causing
+    one of the two submissions to be omitted from the update.
+    """
+
 class MatchingError(CrdsLookupError):
     """Represents a MatchSelector lookup which failed."""
 


### PR DESCRIPTION
Added better logging and exception messages for case where one or more references in an rmap update have identical matching criteria and overwrite one another.   The overwrite results in some of the submitted files not appearing in the new rmap.   This update identifies both conflicting file names in the exception message.   The command line tool can also identify all conflicts in a series of references before raising a final fatal exception.





