### PR TITLE
Softened imports of requests and lxml modules

### DIFF
--- a/crds/misc/check_archive.py
+++ b/crds/misc/check_archive.py
@@ -9,10 +9,15 @@ from __future__ import absolute_import
 import os.path
 import sys
 
-import requests
-
 from crds.core import python23, log, config, utils, cmdline
 from crds.client import api
+
+DISABLED = []
+try:
+    import requests
+except (ImportError, RuntimeError):
+    log.verbose_warning("Failed to import 'requests' module.  check_archive disabled.")
+    DISABLED.append("requests")
 
 class CheckArchiveScript(cmdline.Script):
     """Command line script for for checking archive file availability."""
@@ -68,6 +73,8 @@ the archive and appropriate CRDS server.
     """
 
     def __init__(self, *args, **keys):
+        if DISABLED:
+            log.fatal_error("Missing or broken dependencies:", DISABLED)
         super(CheckArchiveScript, self).__init__(*args, **keys)
         self.file_info = {}
         self.missing_files = []

--- a/crds/submit/web.py
+++ b/crds/submit/web.py
@@ -2,13 +2,22 @@
 web server file submission system.
 """
 
-# from requests_toolbelt.multipart.encoder import MultipartEncoder, MultipartEncoderMonitor
-import requests
-from lxml import html
-
 from crds.core import config, log, utils, exceptions
 from crds.core.python23 import *
 from . import background
+
+# from requests_toolbelt.multipart.encoder import MultipartEncoder, MultipartEncoderMonitor
+try:
+    import requests
+    DISABLED = []
+except (ImportError, RuntimeError):
+    log.verbose_warning("Import of 'requests' failed.  submit disabled.")
+    DISABLED.append("requests")
+try:
+    from lxml import html
+except (ImportError, RuntimeError):
+    log.verbose_warning("Import of 'lxml' failed.  submit disabled.")
+    DISABLED.append("lxml")
 
 # ==================================================================================================
 
@@ -28,6 +37,8 @@ class CrdsDjangoConnection(object):
     """
 
     def __init__(self, locked_instrument="none", username=None, password=None, base_url=None):
+        if DISABLED:
+            log.fatal_error("Missing or broken depenencies:", DISABLED)
         self.locked_instrument = locked_instrument
         self.username = username
         self.password = password


### PR DESCRIPTION
Failed 3rd party imports (requests, lxml) for non-essential tools (submit, check_archive) don't obstruct basic CRDS functions.