### PR TITLE
Improves invalid date/time diagnostics

### DIFF
--- a/crds/core/exceptions.py
+++ b/crds/core/exceptions.py
@@ -128,7 +128,10 @@ class VersionAfterError(CrdsLookupError):
 
 # -------------------------------------------------------------------------------------------
 
-class InvalidUseAfterFormat(CrdsError):
+class InvalidDatetimeError(CrdsError):
+    """CRDS was unable to parse the value from date/time related keywords."""
+
+class InvalidUseAfterFormat(InvalidDatetimeError):
     """CRDS was unable to parse the value from a USEAFTER keyword or equivalent."""
 
 class InvalidVersionFormat(CrdsError):

--- a/crds/core/timestamp.py
+++ b/crds/core/timestamp.py
@@ -56,10 +56,20 @@ def parse_date(date):
     >>> dtval = parse_date(datetime.datetime.now())
     >>> isinstance(dtval, datetime.datetime)
     True
+
+    >>> parse_date("2008-10-15T08:44:44.619 UNDEFINED")
+    Traceback (most recent call last):
+    ...
+    InvalidDatetimeError: One or more required date/time values is UNDEFINED
+
     """
     if isinstance(date, datetime.datetime):
         date = str(date)
 
+    if "UNDEFINED" in date:
+        raise exceptions.InvalidDatetimeError(
+            "One or more required date/time values is UNDEFINED")
+    
     if date.endswith(" UT"):  # Dec 01 1993 00:00:00 UT
         date = date[:-3]
 


### PR DESCRIPTION
Handles common error case where 1/2 of required date/time keywords is left undefined and the other contains all of date/time.