### PR TITLE
Fix determine reftypes

### DIFF
--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -333,12 +333,14 @@ def hv_best_references(context_file, header, include=None, condition=True):
     filekinds listed in `include`.
     """
     ctx = get_symbolic_mapping(context_file, cached=True)
+    conditioned = utils.condition_header(header) if condition else header
     if include is None:
-        include = ctx.locate.header_to_reftypes(header)
-    minheader = ctx.minimize_header(header)
+        # requires conditioned header,  or compatible header
+        include = set(ctx.locate.header_to_reftypes(conditioned))
+        ctx_filekinds = set(ctx.get_filekinds(conditioned))
+        include = list(ctx_filekinds - include)
+    minheader = ctx.minimize_header(conditioned)
     log.verbose("Bestrefs header:\n", log.PP(minheader))
-    if condition:
-        minheader = utils.condition_header(minheader)
     return ctx.get_best_references(minheader, include=include)
 
 # ============================================================================

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -338,7 +338,7 @@ def hv_best_references(context_file, header, include=None, condition=True):
         # requires conditioned header,  or compatible header
         include = set(ctx.locate.header_to_reftypes(conditioned))
         ctx_filekinds = set(ctx.get_filekinds(conditioned))
-        include = list(ctx_filekinds - include)
+        include = list(ctx_filekinds & include)
     minheader = ctx.minimize_header(conditioned)
     log.verbose("Bestrefs header:\n", log.PP(minheader))
     return ctx.get_best_references(minheader, include=include)

--- a/crds/core/rmap.py
+++ b/crds/core/rmap.py
@@ -1110,6 +1110,12 @@ class ReferenceMapping(Mapping):
         """Property, dictionary of valid values for each parameter loaded from .tpn files or equivalent."""
         return self.get_valid_values_map()
 
+    def get_filekinds(self, dataset=None):
+        """Return the filekinds associated with this dataset, but for an rmap,
+        just the rmap's filekind.
+        """
+        return [self.filekind]
+        
     def get_best_references(self, header, include=None):
         """Shim so that .rmaps can be used for bestrefs in place of a .pmap or .imap for single type development."""
         if include is not None and self.filekind not in include:


### PR DESCRIPTION
Reordered hv_best_references() to condition header parameters before calling project specific header_to_reftypes.   Limited requested types to the types actually supplied in a context,  possibly fewer than those recommended by the EXP_TYPE and Step config files.   This logic applies only to the case where the specified reftypes (include parameter) is left defaulted as None;  for that case,  CRDS attempts to figure out the  complete set of appropriate references based on both the context and CRDS knowledge of applicable Steps and their references.


