### PR TITLE
List all datasets

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -332,12 +332,20 @@ def get_required_parkeys(context):
 
 def get_dataset_headers_by_instrument(context, instrument, datasets_since=None):
     """Return { dataset_id : { header } } for `instrument`."""
-    max_ids_per_rpc = get_server_info().get("max_headers_per_rpc", 5000)
+    log.verbose("Dumping datasets for", repr(instrument))
     ids = get_dataset_ids(context, instrument, datasets_since)
+    return get_dataset_headers_unlimited(context, ids, datasets_since)
+
+def get_dataset_headers_unlimited(context, ids, datasets_since=None):
+    """Return { dataset_id : { header } } for `ids`,  potentially more
+    ids than can be serviced with a single JSONRPC request, looping 
+    internally.
+    """
+    max_ids_per_rpc = get_server_info().get("max_headers_per_rpc", 5000)
     headers = {}
     for i in range(0, len(ids), max_ids_per_rpc):
+        log.verbose("Dumping dataset headers", i , "of", len(ids), verbosity=20)
         id_slice = ids[i : i + max_ids_per_rpc]
-        log.verbose("Dumping datasets for", repr(instrument), "ids", i , "of", len(ids), verbosity=20)
         header_slice = get_dataset_headers_by_id(context, id_slice)
         headers.update(header_slice)
     return headers

--- a/crds/core/pysh.py
+++ b/crds/core/pysh.py
@@ -56,6 +56,11 @@ import os.path
 import io
 import inspect
 
+if sys.version_info >= (3,0,0):
+    from io import StringIO
+else:
+    import StringIO
+
 from subprocess import PIPE, STDOUT, Popen
 
 # =========================================================================
@@ -63,7 +68,7 @@ from subprocess import PIPE, STDOUT, Popen
 __all__ = [
     "sys", "os", "re", "glob",
 
-    "sh", "out", "err", "out_err", "status", "words", "lines", "usage",
+    "sh", "out", "err", "out_err", "status", "words", "lines", "usage",  "arg",
 
     "Shell", "pysh_execfile"
 ]
@@ -314,6 +319,23 @@ def usage(description, min_args, max_args=sys.maxsize, help=""):
     if not (min_args <= len(sys.argv)-1 <= max_args) or "--help" in sys.argv:
         fail("\nusage: " + progname + " "  + description + help)
 
+def arg(index, default=None, typecast=str):
+    """Ultra-simple convenience function for extracting command line parameters by
+    index, optionally using a `default` value if fewer than `index` parameters
+    are provided.  The function `typecast` can be set to a python type object
+    to cast parameter strings to other python types like int or float.
+
+    $ program  arg1 arg2 arg3
+
+    progname = arg(0)
+    arg1 = arg(1, "foo")
+    arg2 = arg(2, 57, int)
+    arg3 = arg(3, 45.0, float)
+
+    """
+    val = sys.argv[index] if len(sys.argv) >= index+1 else default
+    return typecast(val)
+        
 # =========================================================================
 
 # Code for rewriting a file of pysh-script as an ordinary python module.

--- a/crds/list.py
+++ b/crds/list.py
@@ -484,12 +484,16 @@ and ids used for CRDS reprocessing recommendations.
         
     def list_dataset_headers(self):
         """List dataset header info for self.args.dataset_headers with respect to self.args.context"""
+        
+        # treate ids specified in dataset_headers param as files to get @-file handling
+        ids = self.get_files(self.args.dataset_headers)
+        
         for context in self.contexts:
             with log.error_on_exception("Failed fetching dataset parameters with repect to", repr(context), 
                                         "for", repr(self.args.dataset_headers)):
-                pars = api.get_dataset_headers_by_id(context, self.args.dataset_headers)
+                pars = api.get_dataset_headers_unlimited(context, ids)
                 pmap = crds.get_cached_mapping(context)
-                for requested_id in self.args.dataset_headers:
+                for requested_id in ids:
                     for returned_id in sorted(pars.keys()):
                         if requested_id.upper() in returned_id.upper():
                             header = pars[returned_id]
@@ -526,7 +530,10 @@ and ids used for CRDS reprocessing recommendations.
                 for context in self.contexts:
                     ids = api.get_dataset_ids(context, instrument)
                     for dataset_id in ids:
-                        print(context, dataset_id)
+                        if len(self.contexts) > 1:
+                            print(context, dataset_id)
+                        else:
+                            print(dataset_id)
 
     def list_config(self):
         """Print out configuration info about the current environment and server."""


### PR DESCRIPTION
Modified crds.list to support dumping unlimited numbers of dataset IDs.   This entailed supporting @-file syntax on the command line to exceed UNIX command line word limits as well as adding an API call that implicitly loops around more primitive fixed-block-length header reads.

As an unrelated commit,  added lightweight arg() function to crds.core.pysh to support trivial command line parameter handling for *hitty little scripts that don't rate argparse.