### PR TITLE
Switched back to hard coded __version__ since the pkg_resources version

### DIFF
--- a/crds/__init__.py
+++ b/crds/__init__.py
@@ -16,11 +16,7 @@ warnings.filterwarnings(
 
 # ============================================================================
 
-try:
-    import pkg_resources
-    __version__ = pkg_resources.require(__name__)[0].version
-except Exception:
-    __version__ = 'unknown'
+__version__ = "7.1.5"   # XXXX  see also ../setup.cfg
 __rationale__ = "3rd/4th quarter 2017 JWST development" 
 
 # ============================================================================


### PR DESCRIPTION
conflicts with the CRDS server version number obscuring the client version.