### PR TITLE
Refactor pipeline

### DIFF
--- a/crds/bestrefs/bestrefs.py
+++ b/crds/bestrefs/bestrefs.py
@@ -717,7 +717,7 @@ amount of informational and debug output.
         """
         applicable_types = set()
         with log.verbose_warning_on_exception("Failed determining reftypes for", repr(dataset)):
-            applicable_types = set(self.locator.header_to_reftypes(header))
+            applicable_types = set(self.locator.header_to_reftypes(context, header))
         if self.affected_instruments:
             types = set(self.affected_instruments[instrument.lower()])
             if applicable_types:

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -342,7 +342,7 @@ def hv_best_references(context_file, header, include=None, condition=True):
     conditioned = utils.condition_header(header) if condition else header
     if include is None:
         # requires conditioned header,  or compatible header
-        include = set(ctx.locate.header_to_reftypes(conditioned))
+        include = set(ctx.locate.header_to_reftypes(context_file, conditioned))
         ctx_filekinds = set(ctx.get_filekinds(conditioned))
         include = list(ctx_filekinds & include)
     minheader = ctx.minimize_header(conditioned)

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -2307,7 +2307,7 @@ Restore debug configuration.
         "." and matched against the corresponding parameter.
         """
         if len(self._parameters) == 1:
-            return ((self._parameters[0], key.split(".")),)
+            return ((self._parameters[0], key),)   # XXX needs split?
         else:
             return tuple(zip(self._parameters, key.split(".")))
     

--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -62,7 +62,7 @@ CROSS_STRAPPED_KEYWORDS = {
 
 # =======================================================================
 
-def header_to_reftypes(header):
+def header_to_reftypes(context, header):
     """Based on `header` return the default list of appropriate reference type names."""
     return []  # translates to everything.
 

--- a/crds/jwst/jwst_system_crdscfg.yaml
+++ b/crds/jwst/jwst_system_crdscfg.yaml
@@ -1,0 +1,86 @@
+author: CRDS
+descrip: "Reference used to determine pipeline configuration from dataset parameters."
+history: "First version generated from calcode .cfg files and EXP_TYPE/LEVEL mapping."
+instrument: SYSTEM
+pedigree: DUMMY
+reftype: CRDSCFG
+telescope: JWST
+useafter: 1900-01-01T00:00:00
+cal_ver: "0.0.0"
+
+pipeline_cfgs: [calwebb_dark.cfg, calwebb_sloper.cfg, calwebb_spec2.cfg, calniriss_soss2.cfg,
+  calwebb_image2.cfg]
+
+level_pipeline_exptypes:
+    level2a:
+        - calwebb_dark.cfg: [FGS_DARK, MIR_DARK, NRC_DARK, NIS_DARK, NRS_DARK]
+
+        - calwebb_sloper.cfg: ["*"]
+
+    level2b:
+        - calwebb_spec2.cfg: [MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, MIR_MRS, NRS_FIXEDSLIT, 
+                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE]
+
+        - calniriss_soss2.cfg: [NIS_SOSS]
+
+        - calwebb_image2.cfg: [NRC_IMAGE, NRC_TACQ, NRC_CORON, NRC_FOCUS, 
+                             MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_CORONCAL,
+                             NIS_IMAGE, NIS_AMI, NIS_TACQ,
+                             NRS_IMAGE, NRS_FOCUS, NRS_MIMF, NRS_BOTA, NRS_TACQ, NRS_TASLIT, NRS_TACONFIRM, NRS_CONFIRM,
+                             FGS_IMAGE, FGS_FOCUS]
+
+        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NIS_FOCUS, NIS_WFSS, NRS_AUTOWAVE]
+
+pipeline_cfgs_to_steps:
+  calniriss_soss2.cfg: [assign_wcs, bkg_subtract, cube_build, extract_1d, extract_2d,
+    flat_field, fringe, imprint_subtract, pathloss, photom, resample_spec, srctype,
+    straylight]
+  calwebb_dark.cfg: [dq_init, ipc, lastframe, linearity, refpix, rscd, saturation,
+    superbias]
+  calwebb_image2.cfg: [assign_wcs, flat_field, photom]
+  calwebb_sloper.cfg: [dark_current, dq_init, ipc, jump, lastframe, linearity, persistence,
+    ramp_fit, refpix, rscd, saturation, superbias]
+  calwebb_spec2.cfg: [assign_wcs, bkg_subtract, cube_build, extract_1d, extract_2d,
+    flat_field, fringe, imprint_subtract, pathloss, photom, resample_spec, srctype,
+    straylight]
+  skip_2b.cfg: []
+
+steps_to_reftypes:
+  assign_wcs: [camera, collimator, disperser, distortion, filteroffset, fore, fpa,
+    ifufore, ifupost, ifuslicer, msa, ote, regions, specwcs, v2v3, wavelengthrange]
+  bkg_subtract: []
+  cube_build: []
+  dark_current: [dark]
+  dq_init: [mask]
+  extract_1d: [extract1d]
+  extract_2d: []
+  flat_field: []
+  fringe: [fringe]
+  imprint_subtract: []
+  ipc: [ipc]
+  jump: [gain, readnoise]
+  lastframe: []
+  linearity: [linearity]
+  pathloss: [pathloss]
+  persistence: []
+  photom: [area, photom]
+  ramp_fit: [gain, readnoise]
+  refpix: [refpix]
+  resample_spec: [drizpars]
+  rscd: [rscd]
+  saturation: [saturation]
+  srctype: []
+  straylight: [straymask]
+  superbias: [superbias]
+
+steps_to_reftypes_exceptions:
+    flat_field:
+        - case1:
+            exp_types: [NRS_FIXEDSLIT, NRS_IFU, NRS_MSASPEC]
+            reftypes: [dflat, fflat, sflat]
+        - case2:
+            exp_types: ["NRS_*"]
+            reftypes: []
+        - case3:
+            exp_types: ["*"]
+            reftypes: [flat]

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -1,16 +1,16 @@
 """This module provides functions that interface with the JWST calibration code to determine
 things like "reference types used by a pipeline."
 
->>> header_to_reftypes(test_header("0.7.0", "FGS_DARK"))
+>>> header_to_reftypes("jwst-operational", test_header("0.7.0", "FGS_DARK"))
 ['ipc', 'linearity', 'mask', 'refpix', 'rscd', 'saturation', 'superbias']
 
->>> header_to_reftypes(test_header("0.7.0", "NRS_BRIGHTOBJ"))
+>>> header_to_reftypes("jwst-operational", test_header("0.7.0", "NRS_BRIGHTOBJ"))
 ['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'fore', 'fpa', 'fringe', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'pathloss', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'straymask', 'superbias', 'v2v3', 'wavelengthrange']
 
->>> header_to_reftypes(test_header("0.7.0", "MIR_IMAGE"))
+>>> header_to_reftypes("jwst-operational", test_header("0.7.0", "MIR_IMAGE"))
 ['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'filteroffset', 'flat', 'fore', 'fpa', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'superbias', 'v2v3', 'wavelengthrange']
 
->>> header_to_reftypes(test_header("0.7.0", "MIR_LRS-FIXEDSLIT"))
+>>> header_to_reftypes("jwst-operational", test_header("0.7.0", "MIR_LRS-FIXEDSLIT"))
 ['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'flat', 'fore', 'fpa', 'fringe', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'pathloss', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'straymask', 'superbias', 'v2v3', 'wavelengthrange']
 
 """
@@ -20,7 +20,8 @@ import re
 
 # import yaml
 
-from crds.core import exceptions, config, log, utils
+import crds
+from crds.core import exceptions, log, utils, python23
 from crds.core.log import srepr
 
 # from jwst.stpipe import cmdline
@@ -28,7 +29,7 @@ from crds.core.log import srepr
 def test_header(calver, exp_type):
     header = {
         "META.INSTRUMENT.NAME" : "SYSTEM",
-        "META.REFTYPE" : "CRDSCFG",
+        "REFTYPE" : "CRDSCFG",
         "META.CALIBRATION_SOFTWARE_VERSION" : calver,
         "META.EXPOSURE.TYPE" : exp_type,
         }
@@ -47,7 +48,7 @@ descrip: "Reference used to determine pipeline configuration from dataset parame
 history: "First version generated from calcode .cfg files and EXP_TYPE/LEVEL mapping."
 instrument: SYSTEM
 pedigree: DUMMY
-reftype: CALCFG
+reftype: CRDSCFG
 telescope: JWST
 useafter: 1900-01-01T00:00:00
 """
@@ -98,16 +99,16 @@ steps_to_reftypes_exceptions:
 
 # --------------------------------------------------------------------------------------
 
-def generate_calcfg_yaml():
-    """Generate the SYSTEM CALCFG reference YAML."""
+def generate_crdscfg_yaml():
+    """Generate the SYSTEM CRDSCFG reference YAML."""
     import yaml
     pipeline_cfgs = yaml.load(PIPELINE_CFGS_YAML)["pipeline_cfgs"]
     pipeline_cfgs_to_steps, all_steps_to_reftypes = generate_pipeline_info(pipeline_cfgs)
-    calcfg = HEADER_YAML + PIPELINE_CFGS_YAML + LEVEL_PIPELINE_EXPTYPE_YAML + "\n"
-    calcfg += yaml.dump({"pipeline_cfgs_to_steps" : pipeline_cfgs_to_steps}) + "\n"
-    calcfg += yaml.dump({"steps_to_reftypes" : all_steps_to_reftypes})
-    calcfg += STEPS_TO_REFTYPE_EXCEPTIONS_YAML
-    return calcfg
+    crdscfg = HEADER_YAML + PIPELINE_CFGS_YAML + LEVEL_PIPELINE_EXPTYPE_YAML + "\n"
+    crdscfg += yaml.dump({"pipeline_cfgs_to_steps" : pipeline_cfgs_to_steps}) + "\n"
+    crdscfg += yaml.dump({"steps_to_reftypes" : all_steps_to_reftypes})
+    crdscfg += STEPS_TO_REFTYPE_EXCEPTIONS_YAML
+    return crdscfg
     
 def generate_pipeline_info(pipeline_cfgs):
     from jwst.stpipe import cmdline
@@ -121,13 +122,13 @@ def generate_pipeline_info(pipeline_cfgs):
     return pipeline_cfgs_to_steps, all_steps_to_reftypes
 
 # --------------------------------------------------------------------------------------
-CALCFG_REFERENCE_YAML = '''
+CRDSCFG_REFERENCE_YAML = '''
 author: CRDS
 descrip: "Reference used to determine pipeline configuration from dataset parameters."
 history: "First version generated from calcode .cfg files and EXP_TYPE/LEVEL mapping."
 instrument: SYSTEM
 pedigree: DUMMY
-reftype: CALCFG
+reftype: CRDSCFG
 telescope: JWST
 useafter: 1900-01-01T00:00:00
 
@@ -211,95 +212,117 @@ steps_to_reftypes_exceptions:
 
 # --------------------------------------------------------------------------------------
 
-def header_to_reftypes(header):
+def header_to_reftypes(context, header):
     """Given a dataset `header`,  extract the EXP_TYPE or META.EXPOSURE.TYPE keyword
     from and use it to look up the reftypes required to process it.
 
     Return a list of reftype names.
     """
     with log.warn_on_exception("Failed determining required reftypes from header", log.PP(header)):
-        exp_type = header.get("META.EXPOSURE.TYPE")
-        if not exp_type:
-            exp_type = header["EXP_TYPE"]
-        return exptype_to_reftypes(exp_type)
+        cal_ver = header.get("META.CALIBRATION_SOFTWARE_VERSION", header.get("CAL_VER"))
+        exp_type = header.get("META.EXPOSURE.TYPE",  header.get("EXP_TYPE"))
+        config_manager = get_config_manager(context, cal_ver)
+        if config_manager is not None:
+            return config_manager.exptype_to_reftypes(exp_type)
     return []
 
-@utils.cached
-def exptype_to_reftypes(exp_type):
-    """For a given EXP_TYPE string, return a list of reftypes needed to process that
-    EXP_TYPE through the data levels appropriate for that EXP_TYPE.
-
-    Return [reftypes... ]
-    """
-    level_2a_pipeline = get_level_pipeline("level2a", exp_type)
-    level_2b_pipeline = get_level_pipeline("level2b", exp_type)
-    level_2a_types = get_pipeline_types(level_2a_pipeline, exp_type)
-    level_2b_types = get_pipeline_types(level_2b_pipeline, exp_type)
-    combined = sorted(list(set(level_2a_types + level_2b_types)))
-    return combined
-
-@utils.cached
-def load_calcfg_reference():
-    """Load the CALCFG reference info into a Python data structure and
-    return it.  Set global CALCFG.
+@utils.cached  # for caching,  pars must be immutable, ideally simple
+def get_config_manager(context, cal_ver):
+    """Construct a pipeline configuration manager appropriate for the given CRDS `context`
+    and calibration s/w version `calver`.
     """
     import yaml
-    return yaml.load(CALCFG_REFERENCE_YAML)
-    
-def get_level_pipeline(level, exp_type):
-    """Interpret the level_pipeline_exptypes data structure relative to
-    processing `level` and `exp_type` to determine a pipeline .cfg file.
+    with log.verbose_warning_on_exception(
+            "Failed to load SYSTEM CRDSCFG for determining required reftypes.   Using build-7 default."):
+        header = {
+            "META.INSTRUMENT.NAME" : "SYSTEM", 
+            "META.CALIBRATION_SOFTWARE_VERSION": cal_ver 
+        }
+        pmap = crds.get_symbolic_mapping(context)
+        imap = pmap.get_imap("system")
+        rmapping = imap.get_rmap("crdscfg")
+        refpath = rmapping.get_bestref(header)
+        with open(refpath) as opened:
+            crdscfg =  yaml.load(opened)
+        return CrdsCfgManager(context, refpath, crdscfg)
+    crdscfg = yaml.load(python23.StringIO(CRDSCFG_REFERENCE_YAML))
+    return CrdsCfgManager(context, "no_system_crdscfg_reference_found", crdscfg)
 
-    Return pipeline .cfg
-    """
-    CALCFG = load_calcfg_reference()
-    pipeline_exptypes = CALCFG["level_pipeline_exptypes"][level]
-    for mapping in pipeline_exptypes:
-        for pipeline, exptypes in mapping.items():
-            for exptype_pattern in exptypes:
-                if glob_match(exptype_pattern, exp_type):
-                    log.verbose("Pipeline .cfg for", srepr(level), "and", 
-                                srepr(exp_type), "is:", srepr(pipeline))
-                    return pipeline
-    raise exceptions.CrdsPipelineCfgDeterminationError("Unhandled EXP_TYPE", srepr(exp_type))
+class CrdsCfgManager(object):
+    """The CrdsCfgManager handles find."""
+    def __init__(self, context, refpath, crdscfg):
+        self._context = context
+        self._refpath = refpath
+        self._crdscfg = crdscfg
+        
+    @utils.cached
+    def exptype_to_reftypes(self, exp_type):
+        """For a given EXP_TYPE string, return a list of reftypes needed to process that
+        EXP_TYPE through the data levels appropriate for that EXP_TYPE.
 
-def get_pipeline_types(pipeline, exp_type):
-    """Based on a pipeline .cfg filename and an EXP_TYPE,  look up
-    the Steps corresponding to the .cfg and extrapolate those to the
-    reftypes used by those Steps.   If there are exceptions to the
-    reftypes assigned for a particular Step that depend on EXP_TYPE,
-    return the revised types for that Step instead.
-    
-    Return [reftypes ...]
-    """
-    CALCFG = load_calcfg_reference()
-    steps = CALCFG["pipeline_cfgs_to_steps"][pipeline]
-    exceptions = CALCFG["steps_to_reftypes_exceptions"]
-    reftypes = []
-    for step in steps:
-        if step not in exceptions:
-            reftypes.extend(CALCFG["steps_to_reftypes"][step])
-        else:
-            for case in exceptions[step]:
-                item = list(case.values())[0]
-                more_reftypes = item["reftypes"][:]
-                exptypes = item["exp_types"][:]
-                found = False
+        Return [reftypes... ]
+        """
+        level_2a_pipeline = self.get_level_pipeline("level2a", exp_type)
+        level_2b_pipeline = self.get_level_pipeline("level2b", exp_type)
+        level_2a_types = self.get_pipeline_types(level_2a_pipeline, exp_type)
+        level_2b_types = self.get_pipeline_types(level_2b_pipeline, exp_type)
+        combined = sorted(list(set(level_2a_types + level_2b_types)))
+        return combined
+
+    @utils.cached
+    def get_level_pipeline(self, level, exp_type):
+        """Interpret the level_pipeline_exptypes data structure relative to
+        processing `level` and `exp_type` to determine a pipeline .cfg file.
+
+        Return pipeline .cfg
+        """
+        pipeline_exptypes = self._crdscfg["level_pipeline_exptypes"][level]
+        for mapping in pipeline_exptypes:
+            for pipeline, exptypes in mapping.items():
                 for exptype_pattern in exptypes:
                     if glob_match(exptype_pattern, exp_type):
-                        log.verbose("Adding exceptional types", more_reftypes, 
-                                    "for step", srepr(step), "case", srepr(exptype_pattern), 
-                                    "based on exp_type", srepr(exp_type))
-                        found = True
-                        reftypes.extend(more_reftypes)
-                        break
-                if found:
-                    break
+                        log.verbose("Pipeline .cfg for", srepr(level), "and", 
+                                    srepr(exp_type), "is:", srepr(pipeline))
+                        return pipeline
+        raise exceptions.CrdsPipelineCfgDeterminationError("Unhandled EXP_TYPE", srepr(exp_type))
+
+    def get_pipeline_types(self, pipeline, exp_type):
+        """Based on a pipeline .cfg filename and an EXP_TYPE,  look up
+        the Steps corresponding to the .cfg and extrapolate those to the
+        reftypes used by those Steps.   If there are exceptions to the
+        reftypes assigned for a particular Step that depend on EXP_TYPE,
+        return the revised types for that Step instead.
+        
+        Return [reftypes ...]
+        """
+        crdscfg = self._crdscfg
+        steps = crdscfg["pipeline_cfgs_to_steps"][pipeline]
+        exceptions = crdscfg["steps_to_reftypes_exceptions"]
+        reftypes = []
+        for step in steps:
+            if step not in exceptions:
+                reftypes.extend(crdscfg["steps_to_reftypes"][step])
             else:
-                raise exceptions.CrdsPipelineTypeDeterminationError("Unhandled EXP_TYPE for exceptional Step", srepr(step))
-    log.verbose("Reftypes for pipeline", srepr(pipeline), "and", srepr(exp_type), 
-                "are:", srepr(reftypes))
-    return reftypes
+                for case in exceptions[step]:
+                    item = list(case.values())[0]
+                    more_reftypes = item["reftypes"][:]
+                    exptypes = item["exp_types"][:]
+                    found = False
+                    for exptype_pattern in exptypes:
+                        if glob_match(exptype_pattern, exp_type):
+                            log.verbose("Adding exceptional types", more_reftypes, 
+                                        "for step", srepr(step), "case", srepr(exptype_pattern), 
+                                        "based on exp_type", srepr(exp_type))
+                            found = True
+                            reftypes.extend(more_reftypes)
+                            break
+                    if found:
+                        break
+                else:
+                    raise exceptions.CrdsPipelineTypeDeterminationError("Unhandled EXP_TYPE for exceptional Step", srepr(step))
+        log.verbose("Reftypes for pipeline", srepr(pipeline), "and", srepr(exp_type), 
+                    "are:", srepr(reftypes))
+        return reftypes
 
 def glob_match(expr, value):
     """Convert the given glob `expr` to a regex and match it to `value`."""
@@ -313,4 +336,4 @@ def test():
 # --------------------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    print(generate_calcfg_yaml())
+    print(generate_crdscfg_yaml())

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -1,6 +1,20 @@
 """This module provides functions that interface with the JWST calibration code to determine
 things like "reference types used by a pipeline."
+
+>>> header_to_reftypes(test_header("0.7.0", "FGS_DARK"))
+['ipc', 'linearity', 'mask', 'refpix', 'rscd', 'saturation', 'superbias']
+
+>>> header_to_reftypes(test_header("0.7.0", "NRS_BRIGHTOBJ"))
+['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'fore', 'fpa', 'fringe', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'pathloss', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'straymask', 'superbias', 'v2v3', 'wavelengthrange']
+
+>>> header_to_reftypes(test_header("0.7.0", "MIR_IMAGE"))
+['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'filteroffset', 'flat', 'fore', 'fpa', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'superbias', 'v2v3', 'wavelengthrange']
+
+>>> header_to_reftypes(test_header("0.7.0", "MIR_LRS-FIXEDSLIT"))
+['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'flat', 'fore', 'fpa', 'fringe', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'pathloss', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'straymask', 'superbias', 'v2v3', 'wavelengthrange']
+
 """
+
 import fnmatch
 import re
 
@@ -10,6 +24,15 @@ from crds.core import exceptions, config, log, utils
 from crds.core.log import srepr
 
 # from jwst.stpipe import cmdline
+
+def test_header(calver, exp_type):
+    header = {
+        "META.INSTRUMENT.NAME" : "SYSTEM",
+        "META.REFTYPE" : "CRDSCFG",
+        "META.CALIBRATION_SOFTWARE_VERSION" : calver,
+        "META.EXPOSURE.TYPE" : exp_type,
+        }
+    return header
 
 '''
 DARK, (LED, LAMP, FLAT)  all level2a only
@@ -184,8 +207,6 @@ steps_to_reftypes_exceptions:
         - case3:
             exp_types: ["*"]
             reftypes: [flat]
-
-
 '''
 
 # --------------------------------------------------------------------------------------
@@ -284,6 +305,10 @@ def glob_match(expr, value):
     """Convert the given glob `expr` to a regex and match it to `value`."""
     re_str = fnmatch.translate(expr)
     return re.match(re_str, value)
+
+def test():
+    import doctest, crds.jwst.pipeline
+    return doctest.testmod(crds.jwst.pipeline)
 
 # --------------------------------------------------------------------------------------
 

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -3374,6 +3374,28 @@
             "tpn":"system_calver.tpn",
             "unique_rowkeys":null
         },
+        "crdscfg":{
+            "derived_from":"handmade spec 07-20-2017",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"crdscfg",
+            "filetype":"CRDSCFG",
+            "instrument":"SYSTEM",
+            "ld_tpn":"system_crdscfg_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"system_crdscfg.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "CAL_VER"
+                ]
+            ],
+            "sha1sum":"b53969290a4d61c923343fbfa732b6e4dd57b775",
+            "suffix":"crdscfg",
+            "text_descr":"Parameters for CRDS",
+            "tpn":"system_crdscfg.tpn",
+            "unique_rowkeys":null
+        },
         "datalvl":{
             "classes":[
                 "VersionAfter"

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -3387,10 +3387,13 @@
             "observatory":"JWST",
             "parkey":[
                 [
-                    "CAL_VER"
+                    "META.CALIBRATION_SOFTWARE_VERSION"
                 ]
             ],
-            "sha1sum":"b53969290a4d61c923343fbfa732b6e4dd57b775",
+            "reference_to_dataset":{
+                "CAL_VER":"META.CALIBRATION_SOFTWARE_VERSION"
+            },
+            "sha1sum":"982e919c575150563fd9e37fd9db85282d34c751",
             "suffix":"crdscfg",
             "text_descr":"Parameters for CRDS",
             "tpn":"system_crdscfg.tpn",

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -3375,6 +3375,9 @@
             "unique_rowkeys":null
         },
         "crdscfg":{
+            "classes":[
+                "VersionAfter"
+            ],
             "derived_from":"handmade spec 07-20-2017",
             "extra_keys":null,
             "file_ext":".fits",
@@ -3393,7 +3396,7 @@
             "reference_to_dataset":{
                 "CAL_VER":"META.CALIBRATION_SOFTWARE_VERSION"
             },
-            "sha1sum":"982e919c575150563fd9e37fd9db85282d34c751",
+            "sha1sum":"555e2388728e047419770df8fa09d18309304996",
             "suffix":"crdscfg",
             "text_descr":"Parameters for CRDS",
             "tpn":"system_crdscfg.tpn",

--- a/crds/jwst/specs/system_crdscfg.rmap
+++ b/crds/jwst/specs/system_crdscfg.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'handmade spec 07-20-2017',
+    'file_ext' : '.fits',
+    'filekind' : 'crdscfg',
+    'filetype' : 'CRDSCFG',
+    'instrument' : 'SYSTEM',
+    'mapping' : 'REFERENCE',
+    'name' : 'system_crdscfg.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('CAL_VER',),),
+    'sha1sum' : 'b53969290a4d61c923343fbfa732b6e4dd57b775',
+    'suffix' : 'crdscfg',
+    'text_descr' : 'Parameters for CRDS',
+}
+
+selector = Match({
+})

--- a/crds/jwst/specs/system_crdscfg.rmap
+++ b/crds/jwst/specs/system_crdscfg.rmap
@@ -7,8 +7,11 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'system_crdscfg.rmap',
     'observatory' : 'JWST',
-    'parkey' : (('CAL_VER',),),
-    'sha1sum' : 'b53969290a4d61c923343fbfa732b6e4dd57b775',
+    'parkey' : (('META.CALIBRATION_SOFTWARE_VERSION',),),
+    'reference_to_dataset' : {
+        'CAL_VER' : 'META.CALIBRATION_SOFTWARE_VERSION',
+    },
+    'sha1sum' : '982e919c575150563fd9e37fd9db85282d34c751',
     'suffix' : 'crdscfg',
     'text_descr' : 'Parameters for CRDS',
 }

--- a/crds/jwst/specs/system_crdscfg.rmap
+++ b/crds/jwst/specs/system_crdscfg.rmap
@@ -1,4 +1,5 @@
 header = {
+    'classes' : ('VersionAfter',),
     'derived_from' : 'handmade spec 07-20-2017',
     'file_ext' : '.fits',
     'filekind' : 'crdscfg',
@@ -11,10 +12,10 @@ header = {
     'reference_to_dataset' : {
         'CAL_VER' : 'META.CALIBRATION_SOFTWARE_VERSION',
     },
-    'sha1sum' : '982e919c575150563fd9e37fd9db85282d34c751',
+    'sha1sum' : '555e2388728e047419770df8fa09d18309304996',
     'suffix' : 'crdscfg',
     'text_descr' : 'Parameters for CRDS',
 }
 
-selector = Match({
+selector = VersionAfter({
 })

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -340,10 +340,10 @@ def dt_test_cleanpath():
 def dt_test_hst_tobs_header_to_reftypes():
     """
     >>> from crds.hst.locate import header_to_reftypes
-    >>> header_to_reftypes({})
+    >>> header_to_reftypes("hst.pmap", {})
     []
     >>> from crds.tobs.locate import header_to_reftypes
-    >>> header_to_reftypes({})
+    >>> header_to_reftypes("tobs.pmap", {})
     []
     """
 
@@ -351,17 +351,17 @@ def dt_test_jwst_header_to_reftypes():
     """
     >>> from crds.jwst.locate import header_to_reftypes
 
-    >>> header_to_reftypes({"EXP_TYPE":"MIR_DARK"})
+    >>> header_to_reftypes("jwst_0301.pmap", {"EXP_TYPE":"MIR_DARK", "CAL_VER": "0.7.0"})
     ['ipc', 'linearity', 'mask', 'refpix', 'rscd', 'saturation', 'superbias']
 
-    >>> header_to_reftypes({"EXP_TYPE":"NIR_IMAGE"})
+    >>> header_to_reftypes("jwst_0301.pmap", {"EXP_TYPE":"NIR_IMAGE", "CAL_VER": "0.7.0"})
     []
 
     # Traceback (most recent call last):
     # ...
     # RuntimeError: Unhandled EXP_TYPE 'NIR_IMAGE'
 
-    >>> header_to_reftypes({"EXP_TYPE":"MIR_IMAGE"})
+    >>> header_to_reftypes("jwst_0301.pmap", {"EXP_TYPE":"MIR_IMAGE", "CAL_VER": "0.7.0"})
     ['area', 'camera', 'collimator', 'dark', 'disperser', 'distortion', 'filteroffset', 'flat', 'fore', 'fpa', 'gain', 'ifufore', 'ifupost', 'ifuslicer', 'ipc', 'linearity', 'mask', 'msa', 'ote', 'photom', 'readnoise', 'refpix', 'regions', 'rscd', 'saturation', 'specwcs', 'superbias', 'v2v3', 'wavelengthrange']
     """
 

--- a/crds/tobs/locate.py
+++ b/crds/tobs/locate.py
@@ -202,7 +202,7 @@ def ref_properties_from_header(filename):
     
 # =======================================================================
 
-def header_to_reftypes(header):
+def header_to_reftypes(context, header):
     """Based on `header` return the default list of appropriate reference type names."""
     return [] # translates to all types.
 


### PR DESCRIPTION
Modified crds.jwst.pipeline module (determines required types for reprocessing w/o running cal code.) to operate via a system crdscfg reference file.   This is still prospective code, the necessary rmap and initial reference are not yet delivered.   An alternative approach would be to generate rmap relevance expressions for all rmaps based on these inputs and then maintain rmaps later rather than this consolidated reference.    Retaining B7 reprocessing  behavior with old contexts probably/does require retaining the initial builtin default form of this reference file. 
