### PR TITLE
Changed default rmap structure for JWST

### DIFF
--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -790,9 +790,7 @@ class Selector(object):
         """Return the pattern of selector nesting for this rmap."""
         if "classes" in self._rmap_header:
             return tuple(self._rmap_header["classes"])
-        elif self._rmap_header["observatory"] == "jwst":
-            return ("Match",)
-        else:  # nominally HST / CDBS
+        else: 
             return ("Match", "UseAfter")
         
     @property


### PR DESCRIPTION
Made the default class nesting:
   Match
       UseAfter
so that the "classes" rmap header directive is no longer required for the now nominal JWST case.