### PR TITLE
Modified bestrefs to simplify ID output 

### DIFF
--- a/crds/bestrefs/bestrefs.py
+++ b/crds/bestrefs/bestrefs.py
@@ -861,6 +861,9 @@ amount of informational and debug output.
         """Track and categorize the specified error,  printing out the dataset header
         if requested on the command line.
         """
+        parts = dataset.split(":")
+        if parts[0] == parts[-1]:  # no guarantee len() == 2
+            dataset = parts[0]
         super(BestrefsScript, self).log_and_track_error(dataset, *pars, **keys)
         if self.args.print_error_headers:
             log.info("Header for", repr(dataset) + ":\n", log.PP(self.active_header))

--- a/crds/tests/test_special.py
+++ b/crds/tests/test_special.py
@@ -60,29 +60,29 @@ def dt_bestrefs_na_undefined_single_ctx_defaults():
 
     First a postitive result:  OK,  lowercase-original-result,  uppercase-final-result-for-update
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "FLATFILE")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "FLATFILE")
     (True, 'X5V1944HL_FLAT.FITS')
     
     Second a formal N/A result:  OK,  bestrefs string,  final update value
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BADTTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BADTTAB")
     (True, 'N/A')
 
     An explicit response of UNDEFINED,  by default converted to N/A for update,  considered OK
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BRFTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BRFTAB")
     (True, 'N/A')
     
     An implicit response of UNDEFINED, i.e. OMIT, also coverted to N/A for update
     XTRACTAB intentionally omitted from BESTREFS
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "XTRACTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "XTRACTAB")
     (True, 'N/A')
 
     An explicit error response from CRDS,  not OK
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "TRACETAB")
-    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "TRACETAB")
+    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     (False, 'NOT FOUND SOME OTHER ERROR')
     
     >>> test_config.cleanup(old_state)
@@ -106,30 +106,30 @@ def dt_bestrefs_na_undefined_single_ctx_undefined_matters():
 
     First a postitive result:  OK,  lowercase-original-result,  uppercase-final-result-for-update
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "FLATFILE")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "FLATFILE")
     (True, 'X5V1944HL_FLAT.FITS')
     
     Second a formal N/A result:  OK,  bestrefs string,  final update value
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BADTTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BADTTAB")
     (True, 'N/A')
 
     An explicit response of UNDEFINED,  by default converted to N/A for update,  not OK since -undefined-differences-matter
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BRFTAB")
-    CRDS - ERROR - instrument='COS' type='BRFTAB' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BRFTAB")
+    CRDS - ERROR - instrument='COS' type='BRFTAB' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     (False, 'UNDEFINED')
     
     An implicit response of UNDEFINED, i.e. OMIT, also coverted to N/A for update, not OK since -undefined-differences-matter
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "XTRACTAB")
-    CRDS - ERROR - instrument='COS' type='XTRACTAB' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "XTRACTAB")
+    CRDS - ERROR - instrument='COS' type='XTRACTAB' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     (False, 'UNDEFINED')
 
     An explicit error response from CRDS,  not OK
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "TRACETAB")
-    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "TRACETAB")
+    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     (False, 'NOT FOUND SOME OTHER ERROR')
     
     >>> test_config.cleanup(old_state)
@@ -153,28 +153,28 @@ def dt_bestrefs_na_undefined_single_ctx_na_matters():
 
     First a postitive result:  OK,  lowercase-original-result,  uppercase-final-result-for-update
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "FLATFILE")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "FLATFILE")
     (True, 'X5V1944HL_FLAT.FITS')
     
     Second a formal N/A result:  OK,  bestrefs string,  final update value
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BADTTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BADTTAB")
     (True, 'N/A')
 
     An explicit response of UNDEFINED,  by default converted to N/A for update,  considered OK
     
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "BRFTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "BRFTAB")
     (True, 'N/A')
     
     An implicit response of UNDEFINED, i.e. OMIT, also coverted to N/A for update
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "XTRACTAB")
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "XTRACTAB")
     (True, 'N/A')
 
     An explicit error response from CRDS, not OK
 
-    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q:LA9K03C3Q", "COS", "TRACETAB")
-    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> script.handle_na_and_not_found("New:", BESTREFS, "LA9K03C3Q", "COS", "TRACETAB")
+    CRDS - ERROR - instrument='COS' type='TRACETAB' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     (False, 'NOT FOUND SOME OTHER ERROR')
     
     >>> test_config.cleanup(old_state)
@@ -225,7 +225,7 @@ def dt_compare_bestrefs_%s_%s_%s_%s():
        
        undef, na,
 
-       "COS","LA9K03C3Q:LA9K03C3Q", bestrefs1, bestrefs2))
+       "COS","LA9K03C3Q", bestrefs1, bestrefs2))
 
 def generate_all():
     for undef_matters in [False, True]:
@@ -248,7 +248,7 @@ def dt_compare_bestrefs_defined_defined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -259,7 +259,7 @@ def dt_compare_bestrefs_defined_na_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -270,7 +270,7 @@ def dt_compare_bestrefs_defined_undefined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -281,7 +281,7 @@ def dt_compare_bestrefs_defined_omitted_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -292,8 +292,8 @@ def dt_compare_bestrefs_defined_error_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -304,7 +304,7 @@ def dt_compare_bestrefs_na_defined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -315,7 +315,7 @@ def dt_compare_bestrefs_na_na_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -326,7 +326,7 @@ def dt_compare_bestrefs_na_undefined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -337,7 +337,7 @@ def dt_compare_bestrefs_na_omitted_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -348,8 +348,8 @@ def dt_compare_bestrefs_na_error_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
     
     >>> test_config.cleanup(old_state)
@@ -360,7 +360,7 @@ def dt_compare_bestrefs_undefined_defined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -371,7 +371,7 @@ def dt_compare_bestrefs_undefined_na_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -382,7 +382,7 @@ def dt_compare_bestrefs_undefined_undefined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -393,7 +393,7 @@ def dt_compare_bestrefs_undefined_omitted_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -404,8 +404,8 @@ def dt_compare_bestrefs_undefined_error_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -416,7 +416,7 @@ def dt_compare_bestrefs_omitted_defined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -427,7 +427,7 @@ def dt_compare_bestrefs_omitted_na_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -438,7 +438,7 @@ def dt_compare_bestrefs_omitted_undefined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -449,7 +449,7 @@ def dt_compare_bestrefs_omitted_omitted_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {})
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -460,8 +460,8 @@ def dt_compare_bestrefs_omitted_error_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -472,8 +472,8 @@ def dt_compare_bestrefs_error_defined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -484,8 +484,8 @@ def dt_compare_bestrefs_error_na_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -496,8 +496,8 @@ def dt_compare_bestrefs_error_undefined_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
     >>> test_config.cleanup(old_state)
     ''' 
@@ -507,8 +507,8 @@ def dt_compare_bestrefs_error_omitted_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -519,9 +519,9 @@ def dt_compare_bestrefs_error_error_undefok_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -532,7 +532,7 @@ def dt_compare_bestrefs_defined_defined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -541,7 +541,7 @@ def dt_compare_bestrefs_defined_defined2_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'y5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'y5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='Y5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -552,7 +552,7 @@ def dt_compare_bestrefs_defined_na_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -563,7 +563,7 @@ def dt_compare_bestrefs_defined_undefined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -574,7 +574,7 @@ def dt_compare_bestrefs_defined_omitted_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -585,8 +585,8 @@ def dt_compare_bestrefs_defined_error_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -597,7 +597,7 @@ def dt_compare_bestrefs_na_defined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -608,7 +608,7 @@ def dt_compare_bestrefs_na_na_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -619,7 +619,7 @@ def dt_compare_bestrefs_na_undefined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -630,7 +630,7 @@ def dt_compare_bestrefs_na_omitted_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -641,8 +641,8 @@ def dt_compare_bestrefs_na_error_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -653,7 +653,7 @@ def dt_compare_bestrefs_undefined_defined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -664,7 +664,7 @@ def dt_compare_bestrefs_undefined_na_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -675,7 +675,7 @@ def dt_compare_bestrefs_undefined_undefined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
     []
     
     >>> test_config.cleanup(old_state)
@@ -686,7 +686,7 @@ def dt_compare_bestrefs_undefined_omitted_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -697,8 +697,8 @@ def dt_compare_bestrefs_undefined_error_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -709,7 +709,7 @@ def dt_compare_bestrefs_omitted_defined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -720,7 +720,7 @@ def dt_compare_bestrefs_omitted_na_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -731,7 +731,7 @@ def dt_compare_bestrefs_omitted_undefined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -742,7 +742,7 @@ def dt_compare_bestrefs_omitted_omitted_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {})
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -753,8 +753,8 @@ def dt_compare_bestrefs_omitted_error_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -765,8 +765,8 @@ def dt_compare_bestrefs_error_defined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -777,8 +777,8 @@ def dt_compare_bestrefs_error_na_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -788,8 +788,8 @@ def dt_compare_bestrefs_error_undefined_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -800,8 +800,8 @@ def dt_compare_bestrefs_error_omitted_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -812,9 +812,9 @@ def dt_compare_bestrefs_error_error_undefok_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFOK_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -825,7 +825,7 @@ def dt_compare_bestrefs_defined_defined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -836,7 +836,7 @@ def dt_compare_bestrefs_defined_na_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -847,8 +847,8 @@ def dt_compare_bestrefs_defined_undefined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -859,8 +859,8 @@ def dt_compare_bestrefs_defined_omitted_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -871,8 +871,8 @@ def dt_compare_bestrefs_defined_error_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -883,7 +883,7 @@ def dt_compare_bestrefs_na_defined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -894,7 +894,7 @@ def dt_compare_bestrefs_na_na_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -905,8 +905,8 @@ def dt_compare_bestrefs_na_undefined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -917,8 +917,8 @@ def dt_compare_bestrefs_na_omitted_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -929,8 +929,8 @@ def dt_compare_bestrefs_na_error_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -941,8 +941,8 @@ def dt_compare_bestrefs_undefined_defined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -953,8 +953,8 @@ def dt_compare_bestrefs_undefined_na_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -965,9 +965,9 @@ def dt_compare_bestrefs_undefined_undefined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -978,9 +978,9 @@ def dt_compare_bestrefs_undefined_omitted_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -991,9 +991,9 @@ def dt_compare_bestrefs_undefined_error_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1004,8 +1004,8 @@ def dt_compare_bestrefs_omitted_defined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1016,8 +1016,8 @@ def dt_compare_bestrefs_omitted_na_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1028,9 +1028,9 @@ def dt_compare_bestrefs_omitted_undefined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1041,7 +1041,7 @@ def dt_compare_bestrefs_omitted_omitted_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {})
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -1052,9 +1052,9 @@ def dt_compare_bestrefs_omitted_error_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1065,8 +1065,8 @@ def dt_compare_bestrefs_error_defined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1077,8 +1077,8 @@ def dt_compare_bestrefs_error_na_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1089,9 +1089,9 @@ def dt_compare_bestrefs_error_undefined_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1102,9 +1102,9 @@ def dt_compare_bestrefs_error_omitted_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1115,9 +1115,9 @@ def dt_compare_bestrefs_error_error_undefmatters_naok():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAOK.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1128,7 +1128,7 @@ def dt_compare_bestrefs_defined_defined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -1139,7 +1139,7 @@ def dt_compare_bestrefs_defined_na_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND n/a'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='X5V1944HL_FLAT.FITS', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1150,8 +1150,8 @@ def dt_compare_bestrefs_defined_undefined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1162,8 +1162,8 @@ def dt_compare_bestrefs_defined_omitted_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1174,8 +1174,8 @@ def dt_compare_bestrefs_defined_error_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'x5v1944hl_flat.fits'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1186,7 +1186,7 @@ def dt_compare_bestrefs_na_defined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='N/A', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1197,7 +1197,7 @@ def dt_compare_bestrefs_na_na_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND n/a'})
     []
 
     >>> test_config.cleanup(old_state)
@@ -1208,8 +1208,8 @@ def dt_compare_bestrefs_na_undefined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1220,8 +1220,8 @@ def dt_compare_bestrefs_na_omitted_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1232,8 +1232,8 @@ def dt_compare_bestrefs_na_error_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND n/a'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1244,8 +1244,8 @@ def dt_compare_bestrefs_undefined_defined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1256,8 +1256,8 @@ def dt_compare_bestrefs_undefined_na_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1268,9 +1268,9 @@ def dt_compare_bestrefs_undefined_undefined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1281,9 +1281,9 @@ def dt_compare_bestrefs_undefined_omitted_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1294,9 +1294,9 @@ def dt_compare_bestrefs_undefined_error_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'UNDEFINED'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1307,8 +1307,8 @@ def dt_compare_bestrefs_omitted_defined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1319,8 +1319,8 @@ def dt_compare_bestrefs_omitted_na_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='UNDEFINED', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1331,9 +1331,9 @@ def dt_compare_bestrefs_omitted_undefined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1344,7 +1344,7 @@ def dt_compare_bestrefs_omitted_omitted_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {})
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {})
     []
 
     >>> test_config.cleanup(old_state)
@@ -1355,9 +1355,9 @@ def dt_compare_bestrefs_omitted_error_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: No match found: 'UNDEFINED'
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)
@@ -1368,8 +1368,8 @@ def dt_compare_bestrefs_error_defined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'x5v1944hl_flat.fits'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='X5V1944HL_FLAT.FITS')]
 
     >>> test_config.cleanup(old_state)
@@ -1380,8 +1380,8 @@ def dt_compare_bestrefs_error_na_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND n/a'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
     [UpdateTuple(instrument='COS', filekind='flatfile', old_reference='NOT FOUND SOME OTHER ERROR', new_reference='N/A')]
 
     >>> test_config.cleanup(old_state)
@@ -1392,9 +1392,9 @@ def dt_compare_bestrefs_error_undefined_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'UNDEFINED'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1405,9 +1405,9 @@ def dt_compare_bestrefs_error_omitted_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: No match found: 'UNDEFINED'
     []
 
     >>> test_config.cleanup(old_state)
@@ -1418,9 +1418,9 @@ def dt_compare_bestrefs_error_error_undefmatters_namatters():
     '''
     >>> old_state = test_config.setup()
     
-    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q:LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
-    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q:LA9K03C3Q' ::  New: Bestref FAILED:  some other error
+    >>> SCRIPT_UNDEFMATTERS_NAMATTERS.compare_bestrefs('COS', 'LA9K03C3Q', {'FLATFILE': 'NOT FOUND some other error'}, {'FLATFILE': 'NOT FOUND some other error'})
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  Old: Bestref FAILED:  some other error
+    CRDS - ERROR - instrument='COS' type='FLATFILE' data='LA9K03C3Q' ::  New: Bestref FAILED:  some other error
     []
 
     >>> test_config.cleanup(old_state)


### PR DESCRIPTION
Changed log error messages of form <id:id> to <id>.  This is mainly for JWST but applies to any unassociated parameter set.