### PR TITLE
Add default substitutions

### DIFF
--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -260,7 +260,7 @@ class Selector(object):
             assert isinstance(selections, dict),  \
                 "selections should be a dictionary { key: choice, ... }."
             self._raw_selections = sorted([Selection(s) for s in selections.items()])
-            self._substitutions = DEFAULT_SUBSTITUTIONS
+            self._substitutions = dict(DEFAULT_SUBSTITUTIONS)
             self._substitutions.update(self._rmap_header.get("substitutions", {}))
             selects = self.do_substitutions(parameters, selections, self._substitutions)
             self._selections = [Selection(s) for s in self.condition_selections(selects)]

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -339,29 +339,31 @@ class Selector(object):
         return selections
 
     def _substitute(self, selections, parkey):
-        selections2 = dict(selections)
-        for match in selections.keys():
+        matches = list(selections.keys())
+        for match in matches:
             if isinstance(match, tuple):
                 new_match = self._substitute_tuple_value(match, parkey)
             else:
                 new_match = self._substitute_simple_value(match, parkey)
-            selections2[new_match] = selections2.pop(match)
-        return selections2
+            selections[new_match] = selections.pop(match)
+        return selections
     
     def _substitute_tuple_value(self, match, parkey):
-        new_match = list(match)
         which = self._parameters.index(parkey)
         old_parvalue = match[which]
         if old_parvalue in self._substitutions[parkey]:
+            new_match = list(match)
+            old_match = new_match[:]
             replacement = self._substitutions[parkey][old_parvalue]
             if isinstance(replacement, list):
                 replacement = tuple(replacement)
-            old_match = new_match[:]
             new_match[which] = replacement
             log.verbose("In", repr(self._rmap_header["name"]), "applying substitution", 
                         (parkey, old_parvalue, replacement), "transforms",
                         repr(old_match), "-->", repr(new_match), verbosity=70)
-        new_match = tuple(new_match)
+            new_match = tuple(new_match)
+        else:
+            new_match = match
         return new_match
         
     

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -215,6 +215,22 @@ class Selection(tuple):
     def __lt__(self, other):
         return self._cmp_key(self.key) < self._cmp_key(other.key)
 
+    
+
+# ==============================================================================
+
+# These subsitutions will apply to all rmaps,  only add those which are truly generic
+# and widely accepted.
+
+DEFAULT_SUBSTITUTIONS = {
+    'META.SUBARRAY.NAME' : {
+        'GENERIC' : 'N/A',
+    },
+    'SUBARRAY' : {
+        'GENERIC' : 'N/A',
+    },
+}
+
 # ==============================================================================
 
 class Selector(object):
@@ -244,11 +260,9 @@ class Selector(object):
             assert isinstance(selections, dict),  \
                 "selections should be a dictionary { key: choice, ... }."
             self._raw_selections = sorted([Selection(s) for s in selections.items()])
-            self._substitutions = dict(self._rmap_header.get("substitutions", {}))
-            if self._substitutions:
-                selects = self.do_substitutions(parameters, selections, self._substitutions)
-            else:
-                selects = selections
+            self._substitutions = DEFAULT_SUBSTITUTIONS
+            self._substitutions.update(self._rmap_header.get("substitutions", {}))
+            selects = self.do_substitutions(parameters, selections, self._substitutions)
             self._selections = [Selection(s) for s in self.condition_selections(selects)]
         else:
             # This branch exists to efficiently implement the
@@ -257,6 +271,7 @@ class Selector(object):
             # is really only good for a single lookup operation.
             assert isinstance(merge_selections, list),  \
                 "merge_selections should be a sorted item list,  not: " + repr(merge_selections)
+            # Because merge_selections are derived from selections, no substitutions are done here
             self._raw_selections = merge_selections  # XXX not really,  nominally unused XXXX
             self._selections = merge_selections
         self._parkey_map = self.get_parkey_map()


### PR DESCRIPTION
Modified the rmap substitutions logic used to implement SUBARRAY=GENERIC to provide for default substitutions since the translation for GENERIC to N/A is frequently forgotten when SUBARRAY is added as a matching parameter.