### PR TITLE
Improve jwst overlap warning

### DIFF
--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -240,10 +240,10 @@ class Selector(object):
             "parameters should be a list or tuple of header keys"
         self._rmap_header = rmap_header or {}
         self._parameters = tuple(parameters)
-        if "raise_ambiguous" in self._rmap_header:
-            self._raise_ambiguous = self._rmap_header["raise_ambiguous"] in ["True", "true", "TRUE", "1"]
+        if "merge_overlaps" in self._rmap_header:
+            self._merge_overlaps = str(self._rmap_header["merge_overlaps"]).upper() in ["TRUE", "1"]
         else:
-            self._raise_ambiguous =  self._rmap_header.get("observatory", None) != "hst"
+            self._merge_overlaps =  self._rmap_header.get("observatory", None) == "hst"
         if selections is not None:
             assert isinstance(selections, dict),  \
                 "selections should be a dictionary { key: choice, ... }."
@@ -1841,7 +1841,7 @@ Restore original debug behavior:
         # merging equivalently weighted candidate match_tuples.
         for _weight, match_tuples in sorted_candidates:
             if len(match_tuples) > 1:
-                if self._raise_ambiguous:
+                if not self._merge_overlaps:
                     raise AmbiguousMatchError("More than one match clause matched.")
                 subselectors = tuple([remaining[match_tuple].choice for match_tuple in match_tuples])
                 if isinstance(subselectors[0], Selector):
@@ -1967,7 +1967,7 @@ Restore original debug behavior:
         for other in self.keys():
             if key != other and match_superset(other, key) and \
                 not different_match_weight(key, other):
-                warn = log.warning if self._raise_ambiguous else log.verbose_warning
+                warn = log.verbose_warning if self._merge_overlaps else log.warning
                 warn("Match tuple " + repr(key) + 
                     " is an equal weight special case of " + repr(other),
                     " requiring dynamic merging.")

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -397,8 +397,17 @@ def filekind_to_keyword(filekind):
     """
     from . import schema
     flat_schema = schema.get_flat_schema()
-    meta_path = "META.REF_FILE.{}.NAME.FITS_KEYWORD".format(filekind.upper())
-    return flat_schema[meta_path]
+    filekind = filekind.upper()
+    meta_path = "META.REF_FILE.{}.NAME.FITS_KEYWORD".format(filekind)
+    try:
+        return flat_schema[meta_path]
+    except KeyError:
+        warn_filekind_once(filekind)
+        return filekind
+
+@utils.cached
+def warn_filekind_once(filekind):
+    log.warning("No apparent JWST cal code data models schema support for", log.srepr(filekind))
 
 def locate_file(refname, mode=None):
     """Given a valid reffilename in CDBS or CRDS format,  return a cache path for the file.

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -176,11 +176,7 @@ def _get_config_refpath(context, cal_ver):
         refpath = SYSTEM_CRDSCFG_B7_PATH
     else:
         refpath = SYSTEM_CRDSCFG_B7_1_PATH
-        
-    with log.verbose_warning_on_exception(
-            "Failed locating SYSTEM CRDSCFG reference",
-            "under context", repr(context),
-            "and cal_ver", repr(cal_ver) + "."):
+    try:  # Use a normal try/except because exceptions are expected.
         header = {
             "META.INSTRUMENT.NAME" : "SYSTEM", 
             "META.CALIBRATION_SOFTWARE_VERSION": cal_ver 
@@ -191,6 +187,11 @@ def _get_config_refpath(context, cal_ver):
         ref = rmapping.get_best_ref(header)
         refpath = rmapping.locate_file(ref)
         api.dump_references(context, [ref])
+    except Exception:
+        log.verbose_warning(
+            "Failed locating SYSTEM CRDSCFG reference",
+            "under context", repr(context),
+            "and cal_ver", repr(cal_ver) + ".")
     log.verbose("Using", srepr(os.path.basename(refpath)),
                 "to determine applicable default reftypes for", srepr(cal_ver))
     return refpath


### PR DESCRIPTION
CRDS for JWST raises exceptions when multiple rmap cases match the same parameter set with the same weight.   This mod makes crds.certify issue warnings for JWST when it sees overlapping cases in an rmap.  

For HST overlaps can be detected by adding --verbose to crds.certify.   

For JWST no --verbose is needed.  For HST overlaps are dynamically merged by default.   For JWST overlaps encountered at runtime result in an exception by default.

Overt warnings and exceptions can be avoided by adding "merge_overlaps" : "True" to the rmap's header.   However,  it is better to address the warnings by eliminating overlaps:

1.  Try to combine the overlapping cases,  perhaps broadening or narrowing the scope of files.
2.  Remove obsolete files and corresponding cases.


