### PR TITLE
Refactor imports

### DIFF
--- a/crds/__init__.py
+++ b/crds/__init__.py
@@ -21,16 +21,17 @@ __rationale__ = "3rd/4th quarter 2017 JWST development"
 
 # ============================================================================
 
-from crds.core import config   # module
+from .core import config   # module
 
-from crds.core.heavy_client import getreferences, getrecommendations
-from crds.core.heavy_client import get_symbolic_mapping, get_pickled_mapping
-from crds.core.rmap import get_cached_mapping, asmapping
-from crds.core.config import locate_mapping, locate_file
+from .core.rmap import get_cached_mapping, asmapping
+from .core.config import locate_mapping, locate_file
 
-from crds.core import exceptions
-from crds.core.exceptions import *
-from crds.core.constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
+from .core import exceptions
+from .core.exceptions import *
+from .core.constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
+
+from .core.heavy_client import getreferences, getrecommendations
+from .core.heavy_client import get_symbolic_mapping, get_pickled_mapping
 
 from crds.client import api
 from crds.client import get_default_context

--- a/crds/bestrefs/bestrefs.py
+++ b/crds/bestrefs/bestrefs.py
@@ -9,9 +9,13 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# ===================================================================
+
 import sys
 import os
 from collections import namedtuple, OrderedDict
+
+# ===================================================================
 
 import crds
 from crds.core import log, config, utils, timestamp, cmdline, heavy_client

--- a/crds/bestrefs/headers.py
+++ b/crds/bestrefs/headers.py
@@ -9,8 +9,12 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# ===================================================================
+
 import json
 import gc
+
+# ===================================================================
 
 import crds
 from crds.core import log, utils, python23, heavy_client

--- a/crds/bestrefs/table_effects.py
+++ b/crds/bestrefs/table_effects.py
@@ -13,10 +13,14 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# ===================================================================
+
 from crds.core import rmap, log
 from crds.core.python23 import *
 from crds.io import tables
 from crds.client import api
+
+# ===================================================================
 
 def is_reprocessing_required(dataset,  dataset_parameters, old_context, new_context, update):
     """This is the top level interface to crds.bestrefs running in "Affected Datasets" mode.

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -6,22 +6,25 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# ==============================================================================
+
 import os
 import os.path
 import base64
 import re
 import zlib
 
+# ==============================================================================
+
 # heavy versions of core CRDS modules defined in one place, client minimally
 # dependent on core for configuration, logging, and  file path management.
-import crds
-from crds.core import utils, log, config
+# import crds
+from crds.core import utils, log, config, python23
 from crds.core.log import srepr
 
 from crds.core.exceptions import ServiceError, CrdsLookupError
 from crds.core.exceptions import CrdsNetworkError, CrdsDownloadError
 from crds.core.exceptions import CrdsRemoteContextError
-from crds.core import python23
 from crds.core.python23 import *
 
 from . import proxy
@@ -511,6 +514,7 @@ class FileCacher(object):
 
     def observatory_from_context(self):
         """Determine the observatory from `pipeline_context`,  based on name if possible."""
+        import crds
         if "jwst" in self.pipeline_context:
             observatory = "jwst"
         elif "hst" in self.pipeline_context:
@@ -829,6 +833,7 @@ def get_minimum_header(context, dataset, ignore_cache=False):
     """Given a `dataset` and a `context`,  extract relevant header 
     information from the `dataset`.
     """
+    import crds
     dump_mappings(context, ignore_cache=ignore_cache)
     ctx = crds.get_pickled_mapping(context)   # reviewed
     return ctx.get_minimum_header(dataset)

--- a/crds/client/proxy.py
+++ b/crds/client/proxy.py
@@ -14,7 +14,7 @@ import json
 import time
 import os
 
-import crds
+# import crds
 from crds.core import python23, exceptions, log, config
 
 # ============================================================================
@@ -35,6 +35,7 @@ def apply_with_retries(func, *pars, **keys):
 
 def message_id():
     """Return a nominal identifier for this program."""
+    import crds
     return _program_name() + "-" + crds.__version__ + "-" + _PROCESS_ID + "-" + _request_id()
 
 def _program_name():

--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -16,10 +16,10 @@ from collections import Counter, defaultdict
 
 from argparse import RawTextHelpFormatter
 
-import crds
-from crds.core import python23, log, heavy_client
-from crds.core import config, utils, exceptions
+from . import python23, log, heavy_client, constants
+from . import config, utils, exceptions, rmap
 from crds.client import api
+
 # from crds import data_file
 
 # =============================================================================
@@ -78,7 +78,7 @@ def reference_mapping(filename):
 def observatory(obs):
     """Verify that `obs` is the name of an observatory and return it."""
     obs = obs.lower()
-    assert obs in crds.ALL_OBSERVATORIES, "Unknown observatory " + repr(obs)
+    assert obs in ALL_OBSERVATORIES, "Unknown observatory " + repr(obs)
     return obs
 
 def nrange(string):
@@ -220,7 +220,7 @@ class Script(object):
 
         url = os.environ.get("CRDS_SERVER_URL", None)
         if url is not None:
-            for obs in crds.ALL_OBSERVATORIES:
+            for obs in ALL_OBSERVATORIES:
                 if obs in url.lower():
                     return self.set_server(obs)
 
@@ -720,13 +720,13 @@ class ContextsScript(Script):
                     self.dump_files(pmaps[-1], files)
             for context in self.contexts:
                 with log.warn_on_exception("Failed loading context", repr(context)):
-                    pmap = crds.get_cached_mapping(context)
+                    pmap = rmap.get_cached_mapping(context)
                     useable_contexts.append(context)
         else:
             for context in self.contexts:
                 with log.warn_on_exception("Failed listing mappings for", repr(context)):
                     try:
-                        pmap = crds.get_cached_mapping(context)
+                        pmap = rmap.get_cached_mapping(context)
                         files |= set(pmap.mapping_names())
                     except Exception:
                         files |= set(api.get_mapping_names(context))
@@ -748,7 +748,7 @@ class ContextsScript(Script):
         files = set()
         for context in self.contexts:
             try:
-                pmap = crds.get_cached_mapping(context)
+                pmap = rmap.get_cached_mapping(context)
                 files |= set(pmap.reference_names())
                 log.verbose("Determined references from cached mapping", repr(context))
             except Exception:  # only ask the server if loading context fails
@@ -767,7 +767,7 @@ def expand_all_instruments(observatory, context):
     mtch = re.match(pattern, context)
     if mtch:
         root_context = observatory + "-" + mtch.group(2)
-        pmap = crds.get_symbolic_mapping(root_context)
+        pmap = heavy_client.get_symbolic_mapping(root_context)
         all_imaps = [ "-".join([observatory, instrument, mtch.group(1), mtch.group(2)])
                 for instrument in pmap.selections.keys() if instrument != "system"]
     else:

--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -78,7 +78,8 @@ def reference_mapping(filename):
 def observatory(obs):
     """Verify that `obs` is the name of an observatory and return it."""
     obs = obs.lower()
-    assert obs in ALL_OBSERVATORIES, "Unknown observatory " + repr(obs)
+    assert obs in constants.ALL_OBSERVATORIES, \
+        "Unknown observatory " + repr(obs)
     return obs
 
 def nrange(string):
@@ -220,7 +221,7 @@ class Script(object):
 
         url = os.environ.get("CRDS_SERVER_URL", None)
         if url is not None:
-            for obs in ALL_OBSERVATORIES:
+            for obs in constants.ALL_OBSERVATORIES:
                 if obs in url.lower():
                     return self.set_server(obs)
 

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -36,11 +36,11 @@ import traceback
 import uuid
 import fnmatch 
 
-from . import rmap, log, utils, config
+from . import rmap, log, utils, config, python23
+from .constants import ALL_OBSERVATORIES
+from .log import srepr
+from .exceptions import CrdsError, CrdsBadRulesError, CrdsBadReferenceError, CrdsNetworkError, CrdsConfigError
 from crds.client import api
-from crds.core.log import srepr
-from crds.core.exceptions import CrdsError, CrdsBadRulesError, CrdsBadReferenceError, CrdsNetworkError, CrdsConfigError
-from crds.core import python23
 # import crds  forward
 
 __all__ = [
@@ -236,7 +236,7 @@ def mapping_names(context):
     else consult server.
     """
     try:
-        mapping = crds.get_symbolic_mapping(context)
+        mapping = get_symbolic_mapping(context)
         contained_mappings = mapping.mapping_names()
     except IOError:
         contained_mappings = api.get_mapping_names(context)
@@ -399,7 +399,7 @@ def translate_date_based_context(context, observatory=None):
         return context
 
     if observatory is None:
-        for observatory in crds.ALL_OBSERVATORIES:
+        for observatory in ALL_OBSERVATORIES:
             if context.startswith(observatory):
                 break
         else:
@@ -559,6 +559,7 @@ def load_server_info(observatory):
 # XXXX which cause problems for other systems.
 def version_info():
     """Return CRDS checkout URL and revision,  client side."""
+    import crds
     try:
         from . import git_version
         branch = revision = "none"
@@ -677,8 +678,4 @@ def save_pickled_mapping(mapping, loaded):
         pickled = python23.pickle.dumps(loaded)
         cache_atomic_write(pickle_file, pickled, "CONTEXT PICKLE")
         log.info("Saved pickled context", repr(pickle_file))
-
-# =============================================================================
-
-import crds # for __version__,  circular dependency.
 

--- a/crds/core/mapping_verifier.py
+++ b/crds/core/mapping_verifier.py
@@ -7,8 +7,8 @@ Mapping is loaded, and is non-recursive.
 import ast
 import sys
 
-from crds.core import exceptions as crexc
-from crds.core import selectors
+from . import exceptions as crexc
+from . import selectors
 
 # ===================================================================
 

--- a/crds/core/naming.py
+++ b/crds/core/naming.py
@@ -9,9 +9,9 @@ from __future__ import absolute_import
 import os
 import re
 
-import crds
-from crds.core  import python23, config, log, utils
-from crds.core.exceptions import NameComparisonError
+from . import python23, config, log, utils
+from .exceptions import NameComparisonError
+from .constants import ALL_OBSERVATORIES
 from crds.client import api
 
 # =============================================================================================================
@@ -190,7 +190,7 @@ def crds_name(name):
     >>> crds_name("hst_acs_darkfile_0001.fits")
     True
     """
-    return name.startswith(tuple(crds.ALL_OBSERVATORIES))
+    return name.startswith(tuple(ALL_OBSERVATORIES))
 
 OLD_CDBS = re.compile(config.complete_re(r"[A-Za-z][A-Za-z0-9]{8}_[A-Za-z0-9]{1,8}\.[A-Za-z0-9]{1,6}"))
 NEW_CDBS = re.compile(config.complete_re(r"[0-9][A-Za-z0-9]{8}_[A-Za-z0-9]{1,8}\.[A-Za-z0-9]{1,6}"))

--- a/crds/core/rmap.py
+++ b/crds/core/rmap.py
@@ -65,18 +65,18 @@ from collections import namedtuple
 
 # ===================================================================
 
-import crds
-from crds.core import python23, log, utils, config, selectors, substitutions
+from . import python23, log, utils, config, selectors, substitutions
 
 # XXX For backward compatability until refactored away.
-from crds.core.config import locate_file, locate_mapping, locate_reference
-from crds.core.config import mapping_exists, is_mapping
+from .config import locate_file, locate_mapping, locate_reference
+from .config import mapping_exists, is_mapping
 
-from crds.core import exceptions as crexc
-from crds.core import python23
-from crds.core.custom_dict import LazyFileDict
-from crds.core.mapping_verifier import MAPPING_VERIFIER
-from crds.core.log import srepr
+from . import exceptions as crexc
+from . import python23
+from .custom_dict import LazyFileDict
+from .mapping_verifier import MAPPING_VERIFIER
+from .log import srepr
+from .constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
 
 # from crds import data_file   (deferred to actual uses)
 
@@ -186,7 +186,7 @@ class Mapping(object):
 
     def check_observatory(self):
         """Verify self.observatory is a supported observatory."""
-        assert self.observatory in crds.ALL_OBSERVATORIES, \
+        assert self.observatory in ALL_OBSERVATORIES, \
             "Invalid observatory " + repr(self.obsevatory) + " in " + repr(self.filename)
 
     def check_instrument(self):
@@ -761,7 +761,7 @@ class PipelineContext(ContextMapping):
 
     def get_instrument(self, header):
         """Get the instrument name defined by file `header`."""
-        for key in [self.instrument_key.upper(), self.instrument_key.lower()] + crds.INSTRUMENT_KEYWORDS:
+        for key in [self.instrument_key.upper(), self.instrument_key.lower()] + INSTRUMENT_KEYWORDS:
             try: # This hack makes FITS headers work prior to back-mapping to data model names.
                 instr = header[key]
             except KeyError:

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -87,6 +87,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# ==============================================================================
+
 import re
 import fnmatch
 import sys
@@ -98,16 +100,15 @@ from pprint import pprint as pp
 
 # import numpy as np
 
-import crds
-from crds.core import log, utils, timestamp, config
+# ==============================================================================
 
-from crds.core.exceptions import (ValidationError, CrdsLookupError,
+from . import log, utils, timestamp, config, python23
+
+from .exceptions import (ValidationError, CrdsLookupError,
                                   AmbiguousMatchError, 
                                   MatchingError, UseAfterError,
                                   InvalidDatetimeError,
                                   VersionAfterError)
-from crds.core import python23
-
 # ==============================================================================
 
 def glob_list(value):

--- a/crds/core/substitutions.py
+++ b/crds/core/substitutions.py
@@ -28,8 +28,7 @@ from __future__ import absolute_import
 
 import os.path
 
-import crds
-from crds.core import log, utils, selectors
+from . import log, utils, selectors, heavy_client
 
 # ============================================================================
 
@@ -170,6 +169,6 @@ def expand_wildcards(rmapping, header):
 
 
 def validate_substitutions(pmap_name):
-    pmap = crds.get_symbolic_mapping(pmap_name)
+    pmap = heavy_client.get_symbolic_mapping(pmap_name)
     expanders = ReferenceHeaderExpanders.load(pmap.observatory)
     expanders.validate_expansions(pmap)

--- a/crds/core/substitutions.py
+++ b/crds/core/substitutions.py
@@ -28,7 +28,8 @@ from __future__ import absolute_import
 
 import os.path
 
-from . import log, utils, selectors, heavy_client
+from . import log, utils, selectors
+# from . import heavy_client (circular for rmap)
 
 # ============================================================================
 
@@ -169,6 +170,8 @@ def expand_wildcards(rmapping, header):
 
 
 def validate_substitutions(pmap_name):
+    """This is a unit test function."""
+    from . import heavy_client
     pmap = heavy_client.get_symbolic_mapping(pmap_name)
     expanders = ReferenceHeaderExpanders.load(pmap.observatory)
     expanders.validate_expansions(pmap)

--- a/crds/core/timestamp.py
+++ b/crds/core/timestamp.py
@@ -9,8 +9,8 @@ from __future__ import absolute_import
 import datetime
 import re
 
-import crds
-from crds.core import python23, config, exceptions, log
+from . import python23, config, exceptions, log
+from . import exceptions
 
 # =======================================================================
 
@@ -481,7 +481,7 @@ def is_datetime(datetime_str):
     try:
         parse_date(datetime_str)
     except ValueError as exc:
-        raise crds.CrdsError(str(exc))
+        raise exceptions.CrdsError(str(exc))
     return datetime_str
 
 

--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -25,9 +25,9 @@ import gc
 
 # ===================================================================
 
-from crds.core import log, config, pysh
-from crds.core.constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
-from crds.core.python23 import *
+from . import log, config, pysh
+from .constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
+from .python23 import *
 
 # ===================================================================
 


### PR DESCRIPTION
This refactoring continues the partitioning of the CRDS package into sub-packages,  primarily by making the mutual imports for the crds.core package relative and more self-contained,  reducing and eliminating circularities.   It does not directly address functional problems,  it is intended to preempt future problems by simplifying the import graph.   It is partial solution,  but a step in the right direction.  (Unfortunately crds.__init__ is still a kitchen sink import.  But this may facilitate eventually fixing that.)

