### PR TITLE
Added cleaner heavy_client.get_context_name() function

### DIFF
--- a/crds/__init__.py
+++ b/crds/__init__.py
@@ -32,6 +32,7 @@ from .core.constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
 
 from .core.heavy_client import getreferences, getrecommendations
 from .core.heavy_client import get_symbolic_mapping, get_pickled_mapping
+from .core.heavy_client import get_context_name
 
 from crds.client import api
 from crds.client import get_default_context

--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -452,7 +452,7 @@ class Script(object):
             return None
         if not config.is_date_based_mapping_spec(context):
             return context           
-        _mode, final_context = heavy_client.get_processing_mode(self.observatory, context)
+        final_context = heavy_client.get_context_name(self.observatory, context)
         if self.show_context_resolution:
             log.info("Symbolic context", repr(context), "resolves to", repr(final_context))
         return final_context

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -46,7 +46,7 @@ from crds.client import api
 __all__ = [
     "getreferences", "getrecommendations",
     "get_config_info", "update_config_info", "load_server_info",
-    "get_processing_mode",
+    "get_processing_mode", "get_context_name",
     "version_info",
     "get_bad_mappings_in_context", "list_mappings",
 ]
@@ -369,6 +369,20 @@ def get_processing_mode(observatory, context=None):
     final_context = get_final_context(info, context)
 
     return info.effective_mode, final_context
+
+@utils.cached
+def get_context_name(observatory, context=None):
+    """Return the .pmap name of the default context based on:
+
+    1. literal definitiion in `context` (jwst_0001.pmap)
+    2. symbolic definition in `context` (jwst-operational or jwst-edit)
+    3. date-based definition in `context` (jwst-2017-01-15T00:05:00)
+    4. CRDS_CONTEXT env var override
+
+    Symbolic and date-based contexts may require definition of CRDS_SERVER_URL
+    to enable server-side translations of the symbolic names.
+    """
+    return get_processing_mode(observatory, context)[1]
 
 def get_final_context(info, context):
     """Based on env CRDS_CONTEXT, the `context` parameter, and the server's reported,

--- a/crds/jwst/schema.py
+++ b/crds/jwst/schema.py
@@ -66,7 +66,7 @@ def refpath_to_parkeys(refpath):
     from . import locate
     keys = []
     with log.verbose_warning_on_exception("Can't determine parkeys for", repr(refpath)):
-        _mode, context  = heavy_client.get_processing_mode("jwst")
+        context  = heavy_client.get_context_name("jwst")
         p = crds.get_pickled_mapping(context)   # reviewed
         instrument, filekind = locate.get_file_properties(refpath)
         keys = p.get_imap(instrument).get_rmap(filekind).get_required_parkeys()

--- a/crds/list.py
+++ b/crds/list.py
@@ -554,7 +554,7 @@ and ids used for CRDS reprocessing recommendations.
                 "server_url" : current_server_url, 
                 "cache_subdir_mode": cache_subdir_mode,
                 "readonly_cache": self.readonly_cache,
-                "effective_context": heavy_client.get_processing_mode(self.observatory)[1],
+                "effective_context": heavy_client.get_context_name(self.observatory),
                 "crds" : repr(crds),
                 "version": heavy_client.version_info() 
                 })
@@ -579,7 +579,7 @@ and ids used for CRDS reprocessing recommendations.
              ("CRDS_MODE", info["CRDS_MODE"]),
              ("Readonly Cache", self.readonly_cache),
              ("Cache Locking", crds_cache_locking.status()),
-             ("Effective Context", heavy_client.get_processing_mode(self.observatory)[1]),
+             ("Effective Context", heavy_client.get_context_name(self.observatory)),
              ("Last Synced", server.last_synced),
              ("CRDS Version", heavy_client.version_info()),
              ("Python Version", pyinfo["Python Version"]),

--- a/crds/tests/test_heavy_client.py
+++ b/crds/tests/test_heavy_client.py
@@ -26,7 +26,7 @@ from nose.tools import assert_raises, assert_true
 # ==================================================================================
 
 def dt_getreferences_rmap_na():
-    """
+    """ 
     >>> old_state = test_config.setup(cache=None, url="https://jwst-crds.stsci.edu")
     >>> os.environ["CRDS_MAPPATH_SINGLE"] = test_config.TEST_DATA
 
@@ -104,6 +104,34 @@ def dt_cache_references_multiple_bad_files():
     >>> test_config.cleanup(old_state)
     
     """
+
+def dt_get_context_name_literal():
+    """
+    >>> old_state = test_config.setup(url="https://jwst-crds-serverless.stsci.edu", observatory="jwst")
+    >>> heavy_client.get_context_name("jwst", "jwst_0341.pmap")
+    'jwst_0341.pmap'
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_get_context_name_crds_context():
+    """
+    >>> old_state = test_config.setup(url="https://jwst-crds-serverless.stsci.edu", observatory="jwst")
+    >>> os.environ["CRDS_CONTEXT"] = "jwst_0399.pmap"
+    >>> heavy_client.get_context_name("jwst")
+    'jwst_0399.pmap'
+    >>> del os.environ["CRDS_CONTEXT"]
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_get_context_name_symbolic():
+    """
+    >>> old_state = test_config.setup()
+    >>> old_state = test_config.setup(url="https://jwst-crds-serverless.stsci.edu", observatory="jwst")
+    >>> heavy_client.get_context_name("jwst", "jwst-operational")  # doctest: +ELLIPSIS
+    'jwst_...pmap'
+    >>> test_config.cleanup(old_state)
+    """
+
 
 # ==================================================================================
 


### PR DESCRIPTION
One stop shopping for CRDS context definition vs. multiple input forms like CRDS_CONTEXT.