### PR TITLE
Updated JWST tpns to remove conditional XDIM constraint added to support

### DIFF
--- a/crds/jwst/tpns/fgs_flat.tpn
+++ b/crds/jwst/tpns/fgs_flat.tpn
@@ -1,7 +1,9 @@
-include nir_subarray.tpn
+# EXP_TYPE=FGS_ID-STACK weird XDIM makes these checks invalid
 
-include nir_sci_array.tpn
-include nir_err_array.tpn
-include nir_dq_array.tpn
-include nir_dq_def_array.tpn
+# include nir_subarray.tpn
+
+# include nir_sci_array.tpn
+# include nir_err_array.tpn
+# include nir_dq_array.tpn
+# include nir_dq_def_array.tpn
 

--- a/crds/jwst/tpns/fgs_mask.tpn
+++ b/crds/jwst/tpns/fgs_mask.tpn
@@ -1,4 +1,7 @@
-include nir_subarray.tpn
 
-include nir_dq_irs2_array.tpn
-include nir_dq_def_array.tpn
+# EXP_TYPE=FGS_ID-STACK weird XDIM makes these checks invalid
+
+# include nir_subarray.tpn
+
+# include nir_dq_irs2_array.tpn
+# include nir_dq_def_array.tpn

--- a/crds/jwst/tpns/nir_dq_array.tpn
+++ b/crds/jwst/tpns/nir_dq_array.tpn
@@ -9,8 +9,12 @@ DQ       A           X         R   (has_type(DQ_ARRAY,'INT'))
 
 DQ       X           X         (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (META_SUBARRAY_XSTART==1)
 DQ       X           X         (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (META_SUBARRAY_YSTART==1)
-DQ       A           X         (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (DQ_ARRAY.SHAPE[-2:]==(2048,nir_xdim(EXP_TYPE)))
-DQ       A           X         A   (1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=2048)
-DQ       A           X         A   (1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=nir_xdim(EXP_TYPE))
-DQ       A           X         S   (DQ_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+
+# Full width striping is an issue,  array may not match subarray size
+# DQ       A           X         (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (DQ_ARRAY.SHAPE[-2:]==(2048,2048))
+# DQ       A           X         A   (1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=2048)
+# DQ       A           X         A   (1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=2048)
+
+# has to handle full width stripes in array
+DQ       A           X         S   (DQ_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 

--- a/crds/jwst/tpns/nir_dq_irs2_array.tpn
+++ b/crds/jwst/tpns/nir_dq_irs2_array.tpn
@@ -2,12 +2,13 @@
 READPATT H           C         O
 
 # DQ       A           X         R              (array_exists(DQ_ARRAY))
-DQ       A           X         F              (DQ_ARRAY.SHAPE[-2:]==(irs2_dim(READPATT),2048))
 
-DQ       A           X         A              (1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=irs2_dim(READPATT))
-DQ       A           X         A              (1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=nir_xdim(EXP_TYPE))
+# Full width striping is an issue,  array may not match subarray size
+# DQ       A           X         F              (DQ_ARRAY.SHAPE[-2:]==(irs2_dim(READPATT),2048))
+# DQ       A           X         A              (1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=irs2_dim(READPATT))
+# DQ       A           X         A              (1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=2048)
 
-DQ       A           X         S              (DQ_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+DQ       A           X         S              (DQ_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 
 DQ       A           X         R              (is_image(DQ_ARRAY))
 DQ       A           X         R              (has_type(DQ_ARRAY,'INT'))

--- a/crds/jwst/tpns/nir_err_array.tpn
+++ b/crds/jwst/tpns/nir_err_array.tpn
@@ -5,8 +5,11 @@
 ERR       A           X         R    (is_image(ERR_ARRAY))
 ERR       A           X         R    (has_type(ERR_ARRAY,'FLOAT'))
 
-ERR       A           X         F    (ERR_ARRAY.SHAPE[-2:]==(2048,nir_xdim(EXP_TYPE)))
-ERR       A           X         A    (1<=META_SUBARRAY_YSTART+ERR_ARRAY.SHAPE[-2]-1<=2048)
-ERR       A           X         A    (1<=META_SUBARRAY_XSTART+ERR_ARRAY.SHAPE[-1]-1<=nir_xdim(EXP_TYPE))
-ERR       A           X         S    (ERR_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+
+# Full width striping is an issue,  array may not match subarray size
+# ERR       A           X         F    (ERR_ARRAY.SHAPE[-2:]==(2048,2048))
+# ERR       A           X         A    (1<=META_SUBARRAY_YSTART+ERR_ARRAY.SHAPE[-2]-1<=2048)
+# ERR       A           X         A    (1<=META_SUBARRAY_XSTART+ERR_ARRAY.SHAPE[-1]-1<=2048)
+
+ERR       A           X         S    (ERR_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 

--- a/crds/jwst/tpns/nir_sci_array.tpn
+++ b/crds/jwst/tpns/nir_sci_array.tpn
@@ -8,9 +8,14 @@
 SCI       A           X         R                           (array_exists(SCI_ARRAY))
 SCI       A           X         R                           (is_image(SCI_ARRAY))
 SCI       A           X         R                           (has_type(SCI_ARRAY,['FLOAT','INT']))
-SCI       A           X         F       (SCI_ARRAY.SHAPE[-2:]==(2048,nir_xdim(EXP_TYPE)))
 
-SCI       A           X         A       (1<=META_SUBARRAY_YSTART+SCI_ARRAY.SHAPE[-2]-1<=2048)
-SCI       A           X         A       (1<=META_SUBARRAY_XSTART+SCI_ARRAY.SHAPE[-1]-1<=nir_xdim(EXP_TYPE))
-SCI       A           X         S       (SCI_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+# Full width striping is an issue,  array may not match subarray size
+# SCI       A           X         F       (SCI_ARRAY.SHAPE[-2:]==(2048,2048))
+# SCI       A           X         A       (1<=META_SUBARRAY_YSTART+SCI_ARRAY.SHAPE[-2]-1<=2048)
+# SCI       A           X         A       (1<=META_SUBARRAY_XSTART+SCI_ARRAY.SHAPE[-1]-1<=4096)
+
+
+SUBARRAY_INBOUNDS_X         X   X   R   (1<=META_SUBARRAY_XSTART+META_SUBARRAY_XSIZE-1<=2048)
+SUBARRAY_INBOUNDS_Y         X   X   R   (1<=META_SUBARRAY_YSTART+META_SUBARRAY_YSIZE-1<=2048)
+SCI       A           X         S       (SCI_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 

--- a/crds/jwst/tpns/nir_subarray.tpn
+++ b/crds/jwst/tpns/nir_subarray.tpn
@@ -15,8 +15,6 @@ META.SUBARRAY.SLOWAXIS      H   I   (is_imaging_mode(EXP_TYPE))
 
 FULLFRAME_XSTART            X   X   (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (META_SUBARRAY_XSTART==1)
 FULLFRAME_YSTART            X   X   (is_full_frame(SUBARRAY)and(INSTRUME!='NIRSPEC'))   (META_SUBARRAY_YSTART==1)
-SUBARRAY_INBOUNDS_X         X   X   (is_imaging_mode(EXP_TYPE))   (1<=META_SUBARRAY_XSTART+META_SUBARRAY_XSIZE-1<=nir_xdim(EXP_TYPE))
-SUBARRAY_INBOUNDS_Y         X   X   (is_imaging_mode(EXP_TYPE))   (1<=META_SUBARRAY_YSTART+META_SUBARRAY_YSIZE-1<=2048)
 
 DETECTOR                    H   C   O
 NRCA1_AXIS                  X   X   (is_imaging_mode(EXP_TYPE)and(DETECTOR=='NRCA1'))    ((FASTAXIS==-1)and(SLOWAXIS==2))

--- a/crds/jwst/tpns/nirspec_err_array.tpn
+++ b/crds/jwst/tpns/nirspec_err_array.tpn
@@ -3,11 +3,13 @@
 # This file pertains to array properties and their relationships to header keywords.
 
 ERR   A    X         (nir_filter(INSTRUMENT,REFTYPE,EXP_TYPE))  (array_exists(ERR_ARRAY))
-ERR   A    X         (is_full_frame(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))   (ERR_ARRAY.SHAPE[-2:]==(2048,2048))
 
-ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_YSTART+ERR_ARRAY.SHAPE[-2]-1<=2048)
-ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_XSTART+ERR_ARRAY.SHAPE[-1]-1<=2048)
-ERR   A    X         (is_subarray(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))    (ERR_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+# Full width striping is an issue,  array may not match subarray size
+# ERR   A    X         (is_full_frame(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))   (ERR_ARRAY.SHAPE[-2:]==(2048,2048))
+# ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_YSTART+ERR_ARRAY.SHAPE[-2]-1<=2048)
+# ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_XSTART+ERR_ARRAY.SHAPE[-1]-1<=2048)
+
+ERR   A    X         (is_subarray(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))    (ERR_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 
 ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (is_image(ERR_ARRAY))
 ERR   A    X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (has_type(ERR_ARRAY,'FLOAT'))

--- a/crds/jwst/tpns/nirspec_sci_array.tpn
+++ b/crds/jwst/tpns/nirspec_sci_array.tpn
@@ -13,11 +13,13 @@ SUBARRAY_INBOUNDS_X         X   X   (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))     
 SUBARRAY_INBOUNDS_Y         X   X   (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                               (1<=META_SUBARRAY_YSTART+META_SUBARRAY_YSIZE-1<=2048)
 
 SCI       A           X         (nir_filter(INSTRUMENT,REFTYPE,EXP_TYPE))                             (array_exists(SCI_ARRAY))
-# SCI       A           X         (is_full_frame(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))   (SCI_ARRAY.SHAPE[-2:]==(2048,2048))
 
-SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_YSTART+SCI_ARRAY.SHAPE[-2]-1<=2048)
-SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_XSTART+SCI_ARRAY.SHAPE[-1]-1<=2048)
-SCI       A           X         (is_subarray(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))    (SCI_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
+# Full width striping is an issue,  array may not match subarray size
+# SCI       A           X         (is_full_frame(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))   (SCI_ARRAY.SHAPE[-2:]==(2048,2048))
+# SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_YSTART+SCI_ARRAY.SHAPE[-2]-1<=2048)
+# SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (1<=META_SUBARRAY_XSTART+SCI_ARRAY.SHAPE[-1]-1<=2048)
+
+SCI       A           X         (is_subarray(SUBARRAY)and(nir_filter(INSTRUME,REFTYPE,EXP_TYPE)))    (SCI_ARRAY.SHAPE[-2:]>=(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
 
 SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (is_image(SCI_ARRAY))
 SCI       A           X         (nir_filter(INSTRUME,REFTYPE,EXP_TYPE))                              (has_type(SCI_ARRAY,['INT','FLOAT']))


### PR DESCRIPTION
FGS_ID-STACK references.
Relaxed NIR array checks to handle SUBARRAY references that use stripes
instead of exact matches to SUBARRAY keyword dims.
Removed array checks on FGS flat and mask pending a new solution for FGS_ID-STACK.