### PR TITLE
Enhanced crds.bestrefs log output

### DIFF
--- a/crds/bestrefs/bestrefs.py
+++ b/crds/bestrefs/bestrefs.py
@@ -646,12 +646,14 @@ amount of informational and debug output.
         """Compute bestrefs for datasets."""
         # Finish __init__() inside --pdb
         if self.complex_init():
-            for dataset in self.new_headers:
+            for i, dataset in enumerate(self.new_headers):
+                if i != 0 and i % 1000 == 0:
+                    log.verbose(self.get_stat("datasets"), "sources processed", verbosity=5)
                 self.process(dataset)
             self.post_processing()
         self.report_stats()
-        log.verbose(self.get_stat("datasets"), "sources processed", verbosity=30)
-        log.verbose(len(self.updates), "source updates", verbosity=30)
+        log.verbose(self.get_stat("datasets"), "sources processed", verbosity=5)
+        log.verbose(len(self.updates), "source updates", verbosity=5)
         log.standard_status()
         return log.errors()
 

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -2238,7 +2238,7 @@ Restore debug configuration.
                     appended = other
                     overwritten = own
                 log.verbose("Merge collision at", repr(appended.key), "using",
-                            repr(appended.choice), "not", overwritten.choice, verbosity=60)
+                            repr(appended.choice), "not", repr(overwritten.choice), verbosity=10)
             merge_selections.append(appended)
         merge_selections.extend(ownsel)
         merge_selections.extend(othersel)

--- a/crds/tests/test_table_effects.py
+++ b/crds/tests/test_table_effects.py
@@ -19,24 +19,26 @@ def dt_table_effects_default_always_reprocess():
 
     >>> doctest.ELLIPSIS_MARKER = '...'
     >>> BestrefsScript(argv="bestrefs.py -z  --verbosity 25 --old-context hst_0003.pmap  --new-context hst_0268.pmap --datasets O8EX02EFQ")() # doctest: +ELLIPSIS
-    CRDS - DEBUG - Using explicit new context 'hst_0268.pmap' for computing updated best references.
-    CRDS - DEBUG - Using explicit old context 'hst_0003.pmap'
-    CRDS - INFO - Dumping dataset parameters from CRDS server at 'https://...' for ['O8EX02EFQ']
-    CRDS - INFO - Dumped 1 of 1 datasets from CRDS server at 'https://...'
-    CRDS - INFO - Computing bestrefs for datasets ['O8EX02EFQ']
-    CRDS - DEBUG - ===> Processing O8EX02010:O8EX02EFQ
-    CRDS - DEBUG - Deep Reference examination between .../n7p1032ao_apt.fits and .../y2r1559to_apt.fits initiated.
-    CRDS - DEBUG - Instantiating rules for reference type stis_apertab.
-    CRDS - DEBUG - Rule DeepLook_STISaperture: Reprocessing is not required.
-    CRDS - DEBUG - Rule DeepLook_STISaperture: Selection rules have executed and the selected rows are the same.
-    CRDS - DEBUG - Removing table update for STIS apertab O8EX02010:O8EX02EFQ no effective change from reference 'N7P1032AO_APT.FITS' --> 'Y2R1559TO_APT.FITS'
-    CRDS - DEBUG - Deep Reference examination between .../q5417413o_pct.fits and .../y2r16006o_pct.fits initiated.
-    CRDS - DEBUG - Instantiating rules for reference type stis_pctab.
-    CRDS - DEBUG - Rule DeepLook_Default: Reprocessing is required.
-    CRDS - DEBUG - Rule DeepLook_Default: Reference type cannot be examined, by definition.
-    CRDS - INFO - 0 errors
-    CRDS - INFO - 0 warnings
-    CRDS - INFO - 3 infos
+    CRDS - DEBUG -  Using explicit new context 'hst_0268.pmap' for computing updated best references.
+    CRDS - DEBUG -  Using explicit old context 'hst_0003.pmap'
+    CRDS - INFO -  Dumping dataset parameters from CRDS server at 'https://...' for ['O8EX02EFQ']
+    CRDS - INFO -  Dumped 1 of 1 datasets from CRDS server at 'https://...'
+    CRDS - INFO -  Computing bestrefs for datasets ['O8EX02EFQ']
+    CRDS - DEBUG -  ===> Processing O8EX02010:O8EX02EFQ
+    CRDS - DEBUG -  Deep Reference examination between .../n7p1032ao_apt.fits and .../y2r1559to_apt.fits initiated.
+    CRDS - DEBUG -  Instantiating rules for reference type stis_apertab.
+    CRDS - DEBUG -  Rule DeepLook_STISaperture: Reprocessing is not required.
+    CRDS - DEBUG -  Rule DeepLook_STISaperture: Selection rules have executed and the selected rows are the same.
+    CRDS - DEBUG -  Removing table update for STIS apertab O8EX02010:O8EX02EFQ no effective change from reference 'N7P1032AO_APT.FITS' --> 'Y2R1559TO_APT.FITS'
+    CRDS - DEBUG -  Deep Reference examination between .../q5417413o_pct.fits and .../y2r16006o_pct.fits initiated.
+    CRDS - DEBUG -  Instantiating rules for reference type stis_pctab.
+    CRDS - DEBUG -  Rule DeepLook_Default: Reprocessing is required.
+    CRDS - DEBUG -  Rule DeepLook_Default: Reference type cannot be examined, by definition.
+    CRDS - DEBUG -  1 sources processed
+    CRDS - DEBUG -  1 source updates
+    CRDS - INFO -  0 errors
+    CRDS - INFO -  0 warnings
+    CRDS - INFO -  3 infos
     0
     
     >>> test_config.cleanup(old_state)
@@ -50,19 +52,21 @@ def dt_table_effects_reprocess_test():
     
     >>> doctest.ELLIPSIS_MARKER = '...'
     >>> BestrefsScript(argv="bestrefs.py -z  --verbosity 25 --old-context hst_0018.pmap  --new-context hst_0024.pmap --datasets LB6M01030")() # doctest: +ELLIPSIS
-    CRDS - DEBUG - Using explicit new context 'hst_0024.pmap' for computing updated best references.
-    CRDS - DEBUG - Using explicit old context 'hst_0018.pmap'
-    CRDS - INFO - Dumping dataset parameters from CRDS server at 'https://...' for ['LB6M01030']
-    CRDS - INFO - Dumped 1 of 1 datasets from CRDS server at 'https://...'
-    CRDS - INFO - Computing bestrefs for datasets ['LB6M01030']
-    CRDS - DEBUG - ===> Processing LB6M01030:LB6M01AVQ
-    CRDS - DEBUG - Deep Reference examination between .../x2i1559gl_wcp.fits and .../xaf1429el_wcp.fits initiated.
-    CRDS - DEBUG - Instantiating rules for reference type cos_wcptab.
-    CRDS - DEBUG - Rule DeepLook_COSOpt_elem: Reprocessing is required.
-    CRDS - DEBUG - Rule DeepLook_COSOpt_elem: Selection rules have executed and the selected rows are different.
-    CRDS - INFO - 0 errors
-    CRDS - INFO - 0 warnings
-    CRDS - INFO - 3 infos
+    CRDS - DEBUG -  Using explicit new context 'hst_0024.pmap' for computing updated best references.
+    CRDS - DEBUG -  Using explicit old context 'hst_0018.pmap'
+    CRDS - INFO -  Dumping dataset parameters from CRDS server at 'https://...' for ['LB6M01030']
+    CRDS - INFO -  Dumped 1 of 1 datasets from CRDS server at 'https://...'
+    CRDS - INFO -  Computing bestrefs for datasets ['LB6M01030']
+    CRDS - DEBUG -  ===> Processing LB6M01030:LB6M01AVQ
+    CRDS - DEBUG -  Deep Reference examination between .../x2i1559gl_wcp.fits and .../xaf1429el_wcp.fits initiated.
+    CRDS - DEBUG -  Instantiating rules for reference type cos_wcptab.
+    CRDS - DEBUG -  Rule DeepLook_COSOpt_elem: Reprocessing is required.
+    CRDS - DEBUG -  Rule DeepLook_COSOpt_elem: Selection rules have executed and the selected rows are different.
+    CRDS - DEBUG -  1 sources processed
+    CRDS - DEBUG -  1 source updates
+    CRDS - INFO -  0 errors
+    CRDS - INFO -  0 warnings
+    CRDS - INFO -  3 infos
     0
     
     >>> test_config.cleanup(old_state)
@@ -76,20 +80,22 @@ def dt_table_effects_reprocess_no():
 
     >>> doctest.ELLIPSIS_MARKER = '...'
     >>> BestrefsScript(argv="bestrefs.py -z  --verbosity 25 --old-context hst_0018.pmap  --new-context hst_0024.pmap --datasets LBK617YRQ")() # doctest: +ELLIPSIS
-    CRDS - DEBUG - Using explicit new context 'hst_0024.pmap' for computing updated best references.
-    CRDS - DEBUG - Using explicit old context 'hst_0018.pmap'
-    CRDS - INFO - Dumping dataset parameters from CRDS server at 'https://...' for ['LBK617YRQ']
-    CRDS - INFO - Dumped 1 of 1 datasets from CRDS server at 'https://...'
-    CRDS - INFO - Computing bestrefs for datasets ['LBK617YRQ']
-    CRDS - DEBUG - ===> Processing LBK617010:LBK617YRQ
-    CRDS - DEBUG - Deep Reference examination between .../x2i1559gl_wcp.fits and .../xaf1429el_wcp.fits initiated.
-    CRDS - DEBUG - Instantiating rules for reference type cos_wcptab.
-    CRDS - DEBUG - Rule DeepLook_COSOpt_elem: Reprocessing is not required.
-    CRDS - DEBUG - Rule DeepLook_COSOpt_elem: Selection rules have executed and the selected rows are the same.
-    CRDS - DEBUG - Removing table update for COS wcptab LBK617010:LBK617YRQ no effective change from reference 'X2I1559GL_WCP.FITS' --> 'XAF1429EL_WCP.FITS'
-    CRDS - INFO - 0 errors
-    CRDS - INFO - 0 warnings
-    CRDS - INFO - 3 infos
+    CRDS - DEBUG -  Using explicit new context 'hst_0024.pmap' for computing updated best references.
+    CRDS - DEBUG -  Using explicit old context 'hst_0018.pmap'
+    CRDS - INFO -  Dumping dataset parameters from CRDS server at 'https://...' for ['LBK617YRQ']
+    CRDS - INFO -  Dumped 1 of 1 datasets from CRDS server at 'https://...'
+    CRDS - INFO -  Computing bestrefs for datasets ['LBK617YRQ']
+    CRDS - DEBUG -  ===> Processing LBK617010:LBK617YRQ
+    CRDS - DEBUG -  Deep Reference examination between .../x2i1559gl_wcp.fits and .../xaf1429el_wcp.fits initiated.
+    CRDS - DEBUG -  Instantiating rules for reference type cos_wcptab.
+    CRDS - DEBUG -  Rule DeepLook_COSOpt_elem: Reprocessing is not required.
+    CRDS - DEBUG -  Rule DeepLook_COSOpt_elem: Selection rules have executed and the selected rows are the same.
+    CRDS - DEBUG -  Removing table update for COS wcptab LBK617010:LBK617YRQ no effective change from reference 'X2I1559GL_WCP.FITS' --> 'XAF1429EL_WCP.FITS'
+    CRDS - DEBUG -  1 sources processed
+    CRDS - DEBUG -  0 source updates
+    CRDS - INFO -  0 errors
+    CRDS - INFO -  0 warnings
+    CRDS - INFO -  3 infos
     0
 
     >>> test_config.cleanup(old_state)


### PR DESCRIPTION
Added progress messages every 1000 datasets at verbosity=5
Modified selectors.py to issue UseAfter merge debug output at verbosity=10.
Updated unit tests affected by additional debug output.