### PR TITLE
Improved crds.list matching parameter capture

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -333,24 +333,24 @@ def get_required_parkeys(context):
     return S.get_required_parkeys(context)
 
 def get_dataset_headers_by_instrument(context, instrument, datasets_since=None):
-    """Return { dataset_id : { header } } for `instrument`."""
+    """return { dataset_id:header, ...} for every `dataset_id` for `instrument`."""
     log.verbose("Dumping datasets for", repr(instrument))
     ids = get_dataset_ids(context, instrument, datasets_since)
-    return get_dataset_headers_unlimited(context, ids)
+    return dict(get_dataset_headers_unlimited(context, ids))
 
 def get_dataset_headers_unlimited(context, ids):
-    """Return { dataset_id : { header } } for `ids`,  potentially more
-    ids than can be serviced with a single JSONRPC request, looping 
-    internally.
+    """Generate (dataset_id, header) for `ids`,  potentially more
+    `ids` than can be serviced with a single JSONRPC request.
+     If there is a failure fetching parameters for dataset_id,
+    `header` will be returned as a string / error message.
     """
     max_ids_per_rpc = get_server_info().get("max_headers_per_rpc", 5000)
-    headers = {}
     for i in range(0, len(ids), max_ids_per_rpc):
         log.verbose("Dumping dataset headers", i , "of", len(ids), verbosity=20)
         id_slice = ids[i : i + max_ids_per_rpc]
         header_slice = get_dataset_headers_by_id(context, id_slice)
-        headers.update(header_slice)
-    return headers
+        for item in header_slice.items():
+            yield item
 
 def get_affected_datasets(observatory, old_context=None, new_context=None):
     """Return a structure describing the ids affected by the last context change."""

--- a/scripts/crds_dataset_capture
+++ b/scripts/crds_dataset_capture
@@ -1,0 +1,48 @@
+#! /usr/bin/env python
+
+# ===================================================================
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+# ===================================================================
+
+import sys
+import os
+
+# ===================================================================
+
+from crds.core import timestamp, log
+from crds.core.pysh import *
+
+# ===================================================================
+
+usage("<instruments...>", 1, help="""
+
+crds_dataset_capture interacts with the CRDS server to dump dataset
+matching parameters for the instruments specified on the command 
+line.  It's a convenience wrapper that automates more primitive
+features in 'crds list'.
+""")
+
+instruments = sys.argv[1:]
+
+now = timestamp.now("T").replace(":","-").split(".")[0]
+capture_dir = "capture-" + now
+
+log.info("Capturing", repr(instruments), "to", repr(capture_dir))
+sh("mkdir ${capture_dir}")
+os.chdir(capture_dir)
+
+for instrument in instruments:
+    ids_file = instrument + ".ids." + now + ".txt"
+    log.info("Capturing", repr(ids_file))
+    sh("crds list --dataset-ids ${instrument} >${ids_file}")
+
+for instrument in instruments:
+    ids_file     = instrument + ".ids." + now + ".txt"
+    headers_file = instrument + ".headers." + now + ".json"
+    log.info("Capturing", repr(ids_file), "to", repr(headers_file))
+    sh("crds list --dataset-headers @${ids_file} --json >${headers_file}")
+


### PR DESCRIPTION
Modified crds.list to avoid N^2 algorithm caused by differences between 'requested' and 'returned' IDs which can expand to include all exposures for a product;  now just operates on returned ids.
Added crds_datasets_capture script to automate crds.list dumps more without totally rewriting.
Modified client API to generate headers rather than return massive dictionaries.