### PR TITLE
Cache locking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/conda-dev'
-        - CONDA_DEPENDENCIES='pytest jwst sphinx nose lxml requests fitsverify lockfile'
-        - CONDA_JWST_DEPENDENCIES='pytest jwst sphinx nose lxml requests fitsverify lockfile'
+        - CONDA_DEPENDENCIES='pytest jwst sphinx nose lxml requests fitsverify lockfile filelock'
+        - CONDA_JWST_DEPENDENCIES='pytest jwst sphinx nose lxml requests fitsverify lockfile filelock'
         - PIP_DEPENDENCIES='parsley coveralls'
         - CRDS_SERVER_URL='https://hst-crds.stsci.edu'
         - CRDS_TEST_ROOT=/tmp

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -171,13 +171,53 @@ class ConfigItem(object):
         os.environ.pop(self.env_var, None)
         
 class StrConfigItem(ConfigItem):
-    """Config item for a string value,  currently no difference from base ConfigItem."""
+    """Config item for a string value,  currently no difference from base ConfigItem.
+    
+    >>> CFG = StrConfigItem("CRDS_CFG", "something", "CRDS configuration",
+    ...       valid_values=["something","else","other"])
+    
+    >>> CFG.set("foo")
+    Traceback (most recent call last):
+    ...
+    AssertionError: Invalid value for 'CRDS_CFG' of 'foo' is not one of ['something', 'else', 'other']
+    
+    >>> CFG + "_foo"
+    'something_foo'
+    
+    >>> "foo_" + CFG
+    'foo_something'
+    
+    >>> CFG == 'something'
+    True
+    
+    >>> 'something' == CFG
+    True
+
+    >>> CFG == 'foo'
+    False
+
+    >>> 'foo' == CFG
+    False
+    
+    >>> str(CFG)
+    'something'
+    """
 
     def __str__(self):
+        """Return value of string config item."""
         return str(self.get())
 
     def __eq__(self, other):
+        """Test string value of config item for equality with `other`."""
         return str(self.get()) == other
+    
+    def __add__(self, other):
+        """Add string value of config item to following parameter `other`."""
+        return str(self) + str(other)
+    
+    def __radd__(self, other):
+        """Add string value of config item to preceding parameter `other`."""
+        return str(other) + str(self)
 
 class BooleanConfigItem(ConfigItem):
     """Represents a boolean environment setting for CRDS.
@@ -862,6 +902,11 @@ CACHE_LOCK_PATH = StrConfigItem(
 USE_LOCKING = BooleanConfigItem("CRDS_USE_LOCKING", True,
     "Set to False to turn off CRDS cache locking.")
 
+LOCKING_MODE = StrConfigItem("CRDS_LOCKING_MODE",  "multiprocessing",
+    "Form of locking used by CRDS cache.", 
+    valid_values=["lockfile", "filelock", "multiprocessing"],
+    lower=True)
+
 def get_crds_lockpath(lock_filename):
     """Return the full path of `lock_filename` filename based on CRDS lock path configuration."""
     return os.path.join(CACHE_LOCK_PATH.get(), lock_filename)
@@ -888,10 +933,6 @@ def check_path(path):
     path = os.path.abspath(path)
     assert FILE_PATH_RE.match(path), "Invalid file path " + repr(path)
     return path
-
-# -------------------------------------------------------------------------------------
-
-
 
 # -------------------------------------------------------------------------------------
 

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -206,6 +206,10 @@ class StrConfigItem(ConfigItem):
     def __str__(self):
         """Return value of string config item."""
         return str(self.get())
+    
+    def __hash__(self):
+        """Use str() of StrConfigItem as hash()"""
+        return hash(str(self))
 
     def __eq__(self, other):
         """Test string value of config item for equality with `other`."""
@@ -1244,18 +1248,22 @@ def get_crds_state():
     """Capture the current CRDS configuration and return it as a dictionary.
     Intended for customizing state during self-tests and restoring during teardown.
     """
+    from .log import get_verbose
     env = { key : val for key, val in os.environ.items() if key.startswith("CRDS_") }
     env["CRDS_REF_SUBDIR_MODE"] = CRDS_REF_SUBDIR_MODE
     env["_CRDS_CACHE_READONLY"] = get_cache_readonly()
     env["PASS_INVALID_VALUES"] = PASS_INVALID_VALUES.get()
+    env["CRDS_VERBOSITY"] = get_verbose()
     return env
 
 def set_crds_state(old_state):
     """Restore the configuration of CRDS returned by get_crds_state()."""
     from crds.client import api   # deferred circular import
+    from .log import set_verbose
     # determination of observatory and server URL are intertwined
     global CRDS_REF_SUBDIR_MODE, _CRDS_CACHE_READONLY
     clear_crds_state()    
+    log.set_verbose(old_state["CRDS_VERBOSITY"])
     _CRDS_CACHE_READONLY = old_state.pop("_CRDS_CACHE_READONLY")
     CRDS_REF_SUBDIR_MODE = old_state["CRDS_REF_SUBDIR_MODE"]
     for key, val in old_state.items():

--- a/crds/core/crds_cache_locking.py
+++ b/crds/core/crds_cache_locking.py
@@ -2,28 +2,22 @@
 simultaneous writes.  This is principally motivated by the JWST association
 logic which may attempt to prefetch files for multiple images at the same time.
 
-This module is a thin wrapper around the "lockfile" package designed to handle
-import failure for lockfile as well as the readonly mode of the CRDS cache.
+CRDS locking wraps more primitive locking functionality such as that provided by
+the lockfile package or the multiprocessing module.
 
------------------------------------------------------------------------------
+A number of configuration env var settings control locking behavior:
 
-This test really just verifies that lockfile imports,  particularly under Travis:
-
->> from crds.tests import test_config
->> old_state = test_config.setup()
-
->> _ = log.set_verbose()
->> with get_cache_lock():
-...     pass
-
->> test_config.cleanup(old_state)
+CRDS_USE_LOCKING    boolean control setting turn locks on/off
+CRDS_LOCK_PATH      directory path for lock files  (must pre-exist)
+CRDS_LOCKING_MODE   (filelock, lockfile, or multiprocessing)
 """
 
 from __future__ import print_function, absolute_import
 
 # =========================================================================
 
-from . import log, config, utils
+import os
+import multiprocessing
 
 # =========================================================================
 
@@ -31,97 +25,186 @@ try:
     import lockfile
 except ImportError:
     lockfile = None
+    
+try:
+    import filelock
+except ImportError:
+    filelock = None
 
 # =========================================================================
 
-class CrdsFakeLockFile(object):
-        
+from . import log, config, utils
+
+# =========================================================================
+
+class CrdsAbstractLock(object):
+    """At a design level this also serves as an abstract class defining the API."""
+    
+    _lock = None  # normally overridden as attribute by subclass
+
     def __init__(self, lockpath):
         self._lockpath = lockpath
+        
+    def __repr__(self):
+        return self.__class__.__name__ + "('" + self._lockpath + "')"
 
     def acquire(self, *args, **keys):
+        """Acquire delegate lock,  adding CRDS verbose logging."""
+        log.verbose("Acquiring lock", repr(self))
+        self._acquire(*args, **keys)
+        log.verbose("Lock acquired", repr(self))
+    
+    def release(self, *args, **keys):
+        """Release delegate lock,  adding CRDS verbose logging."""
+        log.verbose("Releasing lock", repr(self))
+        self._release(*args, **keys)
+        log.verbose("Lock released", repr(self))
+
+    def break_lock(self):
+        """Break delegate lock,  adding CRDS verbose logging."""
+        log.verbose("Breaking lock", repr(self))
+        self._break_lock()
+        log.verbose("Broke lock", repr(self))
+    
+    def __enter__(self, *args, **keys):
+        """Support context manager protocol, with...:"""
+        self.acquire(*args, **keys)
+        return self
+
+    def __exit__(self, *args, **keys):
+        """Support context manager protocol, with...:"""
+        self.release()
+
+    # ----------------------------------------------------
+        
+    def _acquire(self, *args, **keys):
+        """Delegates to self._lock's acquire,  override as needed."""
+        self._lock.acquire(*args, **keys)
+    
+    def _release(self, *args, **keys):
+        """Delegates to self._lock's release,  override as needed."""
+        self._lock.release(*args, **keys)
+
+    def _break_lock(self, *args, **keys):
+        """Noop,  override as needed."""
+        pass
+
+# =========================================================================
+
+# Always defined as fall back
+
+class CrdsFakeLock(CrdsAbstractLock):
+    """Placeholder dummy lock to do nothing."""
+
+    def acquire(self, *args, **keys):
+        """Silent dummy acquire."""
         pass
     
     def release(self, *args, **keys):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *_exc):
-        pass
-
-    def break_lock(self):
+        """Silent dummy release."""
         pass
     
-if lockfile is not None:
+    def break_lock(self):
+        """Silent dummy break."""
+        pass
+    
+# =========================================================================
 
-    class CrdsLockFile(lockfile.LockFile):
-        """Wrap LockFile to add CRDS log messages for acquire/release."""
+if config.LOCKING_MODE == "multiprocessing":
+
+    class CrdsMultiprocessingLock(CrdsAbstractLock):
+        """Wrap multiprocessing.Lock as locking basis."""
         
         def __init__(self, lockpath):
-            self._lockpath = lockpath
-            super(CrdsLockFile, self).__init__(self._lockpath)
+            self._lock = multiprocessing.Lock()
+            super(CrdsMultiprocessingLock, self).__init__(lockpath)
         
-        def acquire(self, *args, **keys):
-            log.verbose("Acquiring lock", repr(self))
-            result = super(CrdsLockFile, self).acquire(*args, **keys)
-            log.verbose("Lock acquired", repr(self))
-            return result
-        
-        def release(self, *args, **keys):
-            log.verbose("Releasing lock", repr(self))
-            result = super(CrdsLockFile, self).release(*args, **keys)
-            log.verbose("Lock released", repr(self))
-            return result
+    CrdsLock = CrdsMultiprocessingLock
+    
+elif config.LOCKING_MODE == "filelock":
 
-        def break_lock(self):
-            log.verbose("Breaking lock", repr(self))
-            result = super(CrdsLockFile, self).break_lock()
-            log.verbose("Broke lock", repr(self))
+    class CrdsFileLock(CrdsAbstractLock):
+        """Wrap filelock.FileLock as locking basis."""
+        
+        def __init__(self, lockpath):
+            if filelock is None:
+                raise RuntimeError("Locking package 'filelock' is not installed.")
+            self._lock = filelock.FileLock(lockpath)
+            super(CrdsFileLock, self).__init__(lockpath)
+            
+        def _break_lock(self, *args, **keys):
+            """Destroy lock regardless of who owns it."""
+            try:
+                os.remove(self._lockpath)
+            except Exception:
+                pass
+        
+    CrdsLock = CrdsFileLock
+
+elif config.LOCKING_MODE == "lockfile":
+
+    class CrdsLockFile(CrdsAbstractLock):
+        """Wrap lockfile.LockFile as locking basis."""
+        
+        def __init__(self, lockpath):
+            if filelock is None:
+                raise RuntimeError("Locking package 'lockfile' is not installed.")
+            self._lock = lockfile.LockFile(lockpath)
+            super(CrdsLockFile, self).__init__(lockpath)
+        
+        def _break_lock(self,  *args, **keys):
+            """Destroy lock regardless of who owns it."""
+            self._lock.break_lock(*args, **keys)
+            try:
+                os.remove(self._lockpath)
+            except Exception:
+                pass
+    
+    CrdsLock = CrdsLockFile
 
 else:
 
-    CrdsLockFile = CrdsFakeLockFile
+    CrdsLock = CrdsFakeLock
  
 # =========================================================================
 
-DEFAULT_LOCK_FILENAME = "crds.cache.lock"   # filename only
+DEFAULT_LOCK_FILENAME = "crds.cache"   # filename only
 
-def get_cache_lock(lock_filename=DEFAULT_LOCK_FILENAME):
-    """Return a file lock context manager to guard the CRDS cache against
-    concurrent writes.
-    """
-    lockpath = config.get_crds_lockpath(lock_filename)
-    
+LOCKS = {}   #  { lockpath : CrdsAbstractLockSubclass, ... }
+
+def get_cache_lock(lockname=DEFAULT_LOCK_FILENAME):
+    """Create, remember, and return the lock object globally referred to by string `lockname`."""
+    if lockname in LOCKS:
+        lock = LOCKS[lockname]
+    else:
+        lock = LOCKS[lockname] = create_cache_lock(lockname)
+    return lock
+
+def create_cache_lock(lockname=DEFAULT_LOCK_FILENAME):
+    """Return a lock context manager to guard the CRDS cache against concurrent writes."""
+    lockpath = config.get_crds_lockpath(lockname)
     if not config.USE_LOCKING.get():
-        return _fake_lock_verbose(lockpath, "CRDS_USE_LOCKING = False.")
-
-    if config.get_cache_readonly():
-        return _fake_lock_verbose(lockpath, "CRDS_READONLY_CACHE = True.")
-
-    if not utils.is_writable(lockpath):
-        return _fake_lock_verbose(lockpath, "CACHE LOCK not writable.")
-        
-    if lockfile is None:
-        return _fake_lock_verbose(lockpath, "Failed importing 'lockfile' package.")
-        
-    try:
-        # XXXX lock dir creation turns into a locking issue,  use pre-existing path.
-        # Either initialize cache using "crds sync --last 1" or set CRDS_CACHE_LOCK_PATH
-        # utils.ensure_dir_exists(lockpath)
-        return CrdsLockFile(lockpath)
-    except Exception as exc:
-        log.warning("Failed creating CRDS cache lock file:", str(exc))
-        return _fake_lock_verbose(lockpath, "Failed creating CRDS cache lock")
+        lock = _fake_lock_verbose(lockpath, "CRDS_USE_LOCKING = False.")
+    elif config.get_cache_readonly():
+        lock = _fake_lock_verbose(lockpath, "CRDS_READONLY_CACHE = True.")
+    elif not utils.is_writable(lockpath):
+        lock = _fake_lock_verbose(lockpath, "CACHE LOCK not writable.")
+    else:
+        try:
+            lock = CrdsLock(lockpath)
+        except Exception as exc:
+            lock = _fake_lock_verbose(lockpath, "Failed creating CRDS cache lock: " + str(exc))
+    return lock
 
 def _fake_lock_verbose(lockpath, explain):
-    log.verbose(explain + " Cannot support downloading files while multiprocessing.")
-    return CrdsFakeLockFile(lockpath)
-                    
+    """Issue a verbose log message based on `explain` indicating why fake 
+    locks are being used.
     
-# =========================================================================
-
+    Returns a fake lock for `lockpath`.
+    """
+    log.verbose(explain + " Cannot support downloading files while multiprocessing.")
+    return CrdsFakeLock(lockpath)
+    
 def clear_cache_lock(lock_filename=DEFAULT_LOCK_FILENAME):
     """Make sure that `lock_filename` does not exist."""
     lockpath = config.get_crds_lockpath(lock_filename)
@@ -131,22 +214,35 @@ def clear_cache_lock(lock_filename=DEFAULT_LOCK_FILENAME):
 
 def clear_cache_locks():
     """Clear all CRDS cache file locks."""
-    clear_cache_lock(DEFAULT_LOCK_FILENAME)   # XXXX needs to be expanded if non-default locks are used.
-
-# =========================================================================
-
+    lock_names = list(LOCKS.keys())
+    for name in lock_names:
+        clear_cache_lock(name)
+        del LOCKS[name]
+        
 def _locking_enabled():
     """Return True IFF almalgum of all config settings enable locking."""
     lock = get_cache_lock()
-    return not isinstance(lock, CrdsFakeLockFile)
+    return not isinstance(lock, CrdsFakeLock)
             
 def status():
     """Return configured/actual ability of CRDS to lock the cache."""
-    return "enabled" if _locking_enabled() else "disabled"
+    val = "enabled" if _locking_enabled() else "disabled"
+    val += ", " + config.LOCKING_MODE
+    return val
+
+# =========================================================================
+
+# To avoid a race condition creating a multiprocessing lock,  at a minimum
+# the default CRDS cache lock needs to be created at import time.
+
+_LOCKPATH = config.get_crds_lockpath(DEFAULT_LOCK_FILENAME)
+with log.warn_on_exception("Failed creating CRDS cache lock", repr(_LOCKPATH)):
+    get_cache_lock(DEFAULT_LOCK_FILENAME)
 
 # =========================================================================
 
 def test():
+    """Run module doctests."""
     import doctest
     from crds.core import crds_cache_locking
     return doctest.testmod(crds_cache_locking)

--- a/crds/core/crds_cache_locking.py
+++ b/crds/core/crds_cache_locking.py
@@ -5,11 +5,8 @@ logic which may attempt to prefetch files for multiple images at the same time.
 CRDS locking wraps more primitive locking functionality such as that provided by
 the lockfile package or the multiprocessing module.
 
-A number of configuration env var settings control locking behavior:
-
-CRDS_USE_LOCKING    boolean control setting turn locks on/off
-CRDS_LOCK_PATH      directory path for lock files  (must pre-exist)
-CRDS_LOCKING_MODE   (filelock, lockfile, or multiprocessing)
+A number of configuration env var settings control locking behavior, see
+crds.core.config for more info.
 """
 
 from __future__ import print_function, absolute_import

--- a/crds/tests/test_list.py
+++ b/crds/tests/test_list.py
@@ -605,7 +605,7 @@ def dt_list_status():
     CRDS_MODE = 'auto'
     CRDS_PATH = '...'
     CRDS_SERVER_URL = 'https://....stsci.edu'
-    Cache Locking = 'enabled'
+    Cache Locking = 'enabled, multiprocessing'
     Effective Context = 'hst_....pmap'
     Last Synced = '...'
     Python Executable = '...'

--- a/crds/tests/test_locking.py
+++ b/crds/tests/test_locking.py
@@ -1,0 +1,136 @@
+"""
+Tests for crds.core.crds_cache_locking which is nominally used to synchronize
+access to the CRDS cache but is actually general purpose locking integrated
+with
+"""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+# ===================================================================
+
+import random
+import time
+import multiprocessing
+import logging
+
+# ===================================================================
+
+from crds.core import log, config, crds_cache_locking
+
+# ===================================================================
+
+from . import test_config
+
+# ===================================================================
+
+def multiprocessing_instance(nothing):
+    """Pretend to do something generic."""
+    with crds_cache_locking.get_cache_lock():
+        log.info("Doing something.")
+        time.sleep(random.random()*1)
+
+def try_multiprocessing():
+    """Run some test functions using multiprocessing."""
+    pool = multiprocessing.Pool(5)
+    pool.map(multiprocessing_instance, [None]*5)
+    pool.close()
+
+def dt_default_locking():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> crds_cache_locking.init_locks()
+    >>> _ = log.set_verbose()
+    >>> crds_cache_locking.status()
+    'enabled, multiprocessing'
+    >>> try_multiprocessing()
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_multiprocessing_locking():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> _ = config.LOCKING_MODE.set("multiprocessing")
+    >>> crds_cache_locking.init_locks()
+    >>> _ = log.set_verbose()
+    >>> crds_cache_locking.status()
+    'enabled, multiprocessing'
+    >>> try_multiprocessing()
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_filelock_locking():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> _ = config.LOCKING_MODE.set("filelock")
+    >>> crds_cache_locking.init_locks()
+    >>> _ = log.set_verbose()
+    >>> crds_cache_locking.status()
+    'enabled, filelock'
+    >>> crds_cache_locking.get_cache_lock()
+    CrdsFileLock('/tmp/crds.cache')
+    >>> try_multiprocessing()
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_lockfile_locking():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> _ = config.LOCKING_MODE.set("lockfile")
+    >>> crds_cache_locking.init_locks()
+    >>> _ = log.set_verbose()
+    >>> crds_cache_locking.status()
+    'enabled, lockfile'
+    >>> crds_cache_locking.get_cache_lock()
+    CrdsLockFile('/tmp/crds.cache')
+    >>> try_multiprocessing()
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_default_disabled():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> _ = config.USE_LOCKING.set(False)
+    >>> crds_cache_locking.init_locks()
+    CRDS - WARNING -  CRDS_USE_LOCKING = False. Cannot support downloading files while multiprocessing.
+    CRDS - WARNING -  CRDS_USE_LOCKING = False. Cannot support downloading files while multiprocessing.
+    >>> crds_cache_locking.status()
+    'disabled, multiprocessing'
+    >>> test_config.cleanup(old_state)
+    """
+
+def dt_default_readonly():
+    """
+    Default locking configuration, enabled.
+
+    >>> old_state = test_config.setup()
+    >>> _ = config.set_cache_readonly()
+    >>> crds_cache_locking.init_locks()
+    CRDS - WARNING -  CRDS_READONLY_CACHE = True. Cannot support downloading files while multiprocessing.
+    CRDS - WARNING -  CRDS_READONLY_CACHE = True. Cannot support downloading files while multiprocessing.
+    >>> crds_cache_locking.status()
+    'disabled, multiprocessing'
+    >>> test_config.cleanup(old_state)
+    """
+
+# ==================================================================================
+
+def main():
+    """Run module tests,  for now just doctests only."""
+    from crds.tests import test_locking, tstmod
+    return tstmod(test_locking)
+
+if __name__ == "__main__":
+    print(main())
+

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ setup(name="crds",
       author_email="jmiller@stsci.edu",
       url="https://hst-crds.stsci.edu",
       license="BSD",
-      requires=["numpy", "astropy", "filelock"],  # for HST or JWST, absolutely required
-      # JWST cal code support:      jwst, lockfile
+      requires=["numpy", "astropy", "filelock", "lockfile"],  # for HST or JWST, absolutely required
+      # JWST cal code support:      jwst, lockfile, filelock
       # File submission support:    requests, lxml, parsley, fitsverify
       # Testing:                    nose
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name="crds",
       author_email="jmiller@stsci.edu",
       url="https://hst-crds.stsci.edu",
       license="BSD",
-      requires=["numpy", "astropy", "lockfile"],  # for HST or JWST, absolutely required
+      requires=["numpy", "astropy", "filelock"],  # for HST or JWST, absolutely required
       # JWST cal code support:      jwst, lockfile
       # File submission support:    requests, lxml, parsley, fitsverify
       # Testing:                    nose


### PR DESCRIPTION
Revisions to cache locking to add support for filelock and multiprocessing locks,  as well as unit tests to demonstrate locks synchronizing or not synchronizing 5 processes depending on the CRDS configuration.  multiprocessing locks are now the default because they require no third party dependencies.  The lockfile module is still supported in CRDS should it prove workable in some context and be needed, however,  multiprocessing unit tests demonstrated that it doesn't work for that use case.  Both filelock (preferred) and lockfile (deprecated) are CRDS dependencies in setup.py and supported by conda as verified by Travis.  CRDS_LOCKING_MODE=filelock is necessary for multiple terminal windows / process trees.   The pipeline is still configured without locking,  running the cache readonly during calibrations and read/write during syncs which can co-exist with calibrations.
