### PR TITLE
Simplify clear pickles

### DIFF
--- a/crds/sync.py
+++ b/crds/sync.py
@@ -275,7 +275,7 @@ class SyncScript(cmdline.ContextsScript):
             os.environ["CRDS_PICKLEPATH_SINGLE"] = self.args.output_dir
 
         if self.args.clear_pickles or self.args.ignore_cache or self.args.repair_files:
-            self.clear_pickles(self.contexts)
+            self.clear_pickles()
 
         if self.args.organize:   # do this before syncing anything under the current mode.
             self.organize_references(self.args.organize)
@@ -333,10 +333,10 @@ class SyncScript(cmdline.ContextsScript):
         return log.errors()
     # ------------------------------------------------------------------------------------------
 
-    def clear_pickles(self, contexts):
-        """Remove pickles specified by `contexts`."""
-        for context in contexts:
-            path = config.locate_pickle(context)
+    def clear_pickles(self):
+        """Remove all pickles."""
+        log.info("Removing all context pickles.  Use --save-pickles to recreate for specified contexts.")
+        for path in rmap.list_pickles("*.pmap", self.observatory, full_path=True):
             if os.path.exists(path):
                 utils.remove(path, self.observatory)
 

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -245,7 +245,7 @@ class SyncScript(cmdline.ContextsScript):
         self.add_argument("--push-context", metavar="KEY", type=str,
                           help="Push the name of the final cached context to the server for the pipeline identified by KEY.")
         self.add_argument("--clear-pickles", action="store_true",
-                          help="Remove the pickles for the sync'ed contexts from the CRDS cache. Can precede --save-pickles.")
+                          help="Remove all context pickles from the CRDS cache. Can precede --save-pickles.")
         self.add_argument("--save-pickles", action="store_true",
                           help="Save pre-compiled versions of the sync'ed contexts in the CRDS cache.  Keep pre-existing pickles.")
         self.add_argument("--output-dir", type=str, default=None,


### PR DESCRIPTION
Simplified --clear-pickles in the crds.sync command line tool to wipe out all context pickles instead of only those implied by the contexts specified.   This is better for server mirroring and/or debugging with end users.

