### PR TITLE
Added STRIPE and S1600A1 back as NIRSPEC SUBARRAY names 

### DIFF
--- a/crds/jwst/tpns/nirspec_all.tpn
+++ b/crds/jwst/tpns/nirspec_all.tpn
@@ -17,7 +17,7 @@ META.EXPOSURE.TYPE          H   C   O   NRS_AUTOFLAT,NRS_AUTOWAVE,NRS_BOTA,\
                                         NRS_TACQ,NRS_TASLIT,ANY,N/A       
 
 META.SUBARRAY.NAME          H   C   O   ALLSLITS,S200A1,S200A2,S200B1,S400A1,SUB1024A,SUB1024B,\
-                                        SUB512,SUB32,SUB512S,SUB2048,\
+                                        SUB512,SUB32,SUB512S,SUB2048,S1600A1,STRIPE,\
                                         FULL,GENERIC,ANY,N/A
 
 include nir_subarray_baseline.tpn

--- a/crds/jwst/tpns/nirspec_all_ld.tpn
+++ b/crds/jwst/tpns/nirspec_all_ld.tpn
@@ -17,7 +17,7 @@ META.EXPOSURE.TYPE          H   C   O   NRS_AUTOFLAT,NRS_AUTOWAVE,NRS_BOTA,\
                                         NRS_TACQ,NRS_TASLIT,ANY,N/A       
 
 META.SUBARRAY.NAME          H   C   O   ALLSLITS,S200A1,S200A2,S200B1,S400A1,SUB1024A,SUB1024B,\
-                                        SUB512,SUB32,SUB512S,SUB2048,\
+                                        SUB512,SUB32,SUB512S,SUB2048,S1600A1,STRIPE,\
                                         FULL,GENERIC,ANY,N/A
 
 include nir_subarray_baseline.tpn


### PR DESCRIPTION
To support old test data as directed in Jira-CRDS-154.