### PR TITLE
Updated docstrings for CRDS master script

### DIFF
--- a/crds/bestrefs/__main__.py
+++ b/crds/bestrefs/__main__.py
@@ -1,7 +1,7 @@
 """
 This module supports running crds.bestrefs from the command line using -m syntax:
 
-% python -m crds.bestrefs ...
+% crds bestrefs ...
 
 """
 from __future__ import print_function

--- a/crds/bestrefs/bestrefs.py
+++ b/crds/bestrefs/bestrefs.py
@@ -3,7 +3,7 @@ reference recommendations for a particular context and dataset files.
 
 For more details on the several modes of operations and command line parameters browse the source or run:   
 
-% python -m crds.bestrefs --help
+% crds bestrefs --help
 """
 from __future__ import print_function
 from __future__ import division
@@ -75,7 +75,7 @@ are the 3 main use cases for crds.bestrefs:
   --update-headers to fill in dataset FITS headers with recommended best
   references. 
 
-    % python -m crds.bestrefs --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits... --update-headers
+    % crds bestrefs --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits... --update-headers
 
   The outcome of this command is updating the best references in the FITS
   headers of the specified .fits files.
@@ -88,7 +88,7 @@ are the 3 main use cases for crds.bestrefs:
   mode is used to recommend reprocessing where the bestrefs differ between old
   and new contexts.
 
-    % python -m crds.bestrefs --old-context hst_0001.pmap --new-context hst_0002.pmap --affected-datasets
+    % crds bestrefs --old-context hst_0001.pmap --new-context hst_0002.pmap --affected-datasets
 
   The outcome of this command is to print the IDs of datasets affected by the
   transition from context 0001 to 0002.
@@ -112,14 +112,14 @@ are the 3 main use cases for crds.bestrefs:
   This sub-mode captures all parameter sets for an instrument updated with the
   best refs assigned by --new-context.
 
-    %  python -m crds.bestrefs --new-context hst_0002.pmap --instrument acs --update-bestrefs --update-pickle --save-pickle old-regression.json
+    %  crds bestrefs --new-context hst_0002.pmap --instrument acs --update-bestrefs --update-pickle --save-pickle old-regression.json
 
   b. Regression Test
 
   This sub-mode plays back captured datasets comparing captured prior results
   with the current result.
 
-    %  python -m crds.bestrefs --new-context hst_0002.pmap --compare-source-bestrefs --print-affected --load-pickles old-regression.json
+    %  crds bestrefs --new-context hst_0002.pmap --compare-source-bestrefs --print-affected --load-pickles old-regression.json
 
   Unlike reprocessing mode, this mode necessarily runs against all the datasets
   specified by the data source,  in this case a .json parameters file.
@@ -195,7 +195,7 @@ If --print-affected is specified, crds.bestrefs will print out the name of any
 file for which at least one update for one reference type was recommended.
 This is essentially a list of files to be reprocessed with new references.
 
-    % python -m crds.bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits \\
+    % crds bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits \\
         --compare-source-bestrefs --print-affected
     j8bt05njq_raw.fits
     j8bt06o6q_raw.fits
@@ -208,7 +208,7 @@ Update Modes
 crds.bestrefs initially supports one mode for updating the best reference
 recommendations recorded in data files:
 
-    % python -m crds.bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits \\
+    % crds bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits \\
         --compare-source-bestrefs --update-bestrefs
 
 ......................

--- a/crds/bestrefs/headers.py
+++ b/crds/bestrefs/headers.py
@@ -3,7 +3,7 @@ reference recommendations for a particular context and dataset files.
 
 For more details on the several modes of operations and command line parameters browse the source or run:   
 
-% python -m crds.bestrefs --help
+% crds bestrefs --help
 """
 from __future__ import print_function
 from __future__ import division

--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -811,7 +811,7 @@ Checks a CRDS reference or mapping file:
     
 To run crds.certify on a reference(s) to verify basic file format and parameter constraints:
 
-  % python -m crds.certify --comparison-context=hst_0027.pmap  ./some_reference.fits...
+  % crds certify --comparison-context=hst_0027.pmap  ./some_reference.fits...
 
 NOTE:  specifying ./ makes CRDS look in the current working directory instead of the CRDS cache.
 
@@ -819,14 +819,14 @@ If some_reference.fits is a table,  a comparison table will be found in the comp
 
 For recursively checking CRDS rules do this:
 
-  % python -m crds.certify hst_0311.pmap --comparison-context=hst_0312.pmap
+  % crds certify hst_0311.pmap --comparison-context=hst_0312.pmap
 
 If a comparison context is defined, checked mappings will be compared against their peers (if they exist) in
 the comparison context.  Many classes of mapping differences will result in warnings.
 
 For reference table checks,  a comparison reference can also be specified directly rather than inferred from context:
 
-  % python -m crds.certify ./some_reference.fits --comparison-reference=old_reference_version.fits
+  % crds certify ./some_reference.fits --comparison-reference=old_reference_version.fits
 
 For more information on the checks being performed,  use --verbose or --verbosity=N where N > 50.
     """

--- a/crds/jwst/gen_system_crdscfg.py
+++ b/crds/jwst/gen_system_crdscfg.py
@@ -1,7 +1,7 @@
 """This module is used to generate the SYSTEM CRDSCFG reference file.  The code
 is directly edited and the module itself is run to emit a new reference as in:
 
-$ python -m crds.jwst.gen_system_crdscfg  updated_inputs.yaml  >new_reference.yaml
+$ crds jwst.gen_system_crdscfg  updated_inputs.yaml  >new_reference.yaml
 
 Suggested approach for obtaining updated inputs is downloading the most current
 SYSTEM CRDSCFG reference file and updating MANUAL sections.

--- a/crds/list.py
+++ b/crds/list.py
@@ -51,7 +51,7 @@ and ids used for CRDS reprocessing recommendations.
     0. Configuration information governing the behavior of CRDS for simple
     configurations can be dumped:
 
-    % python -m crds.list --status
+    % crds list --status
     CRDS Version = '7.0.7, bump-version, 7432326'
     CRDS_MODE = 'auto'
     CRDS_PATH = '/Users/jmiller/crds_cache_ops'
@@ -65,7 +65,7 @@ and ids used for CRDS reprocessing recommendations.
     More comprehensive configuration information is also available for advanced
     configurations:
 
-    % python -m crds.list --config
+    % crds list --config
     ... lots of info ....
 
     --------------------------------------------------------------------------
@@ -79,21 +79,21 @@ and ids used for CRDS reprocessing recommendations.
 
     -- To list the references contained by several contexts
     
-    % python -m crds.list  --references --contexts hst_0001.pmap hst_0002.pmap ...
+    % crds list  --references --contexts hst_0001.pmap hst_0002.pmap ...
     vb41935ij_bia.fits 
     vb41935kj_bia.fits 
     ...
     
     -- To list the references in a numerical range of contexts
 
-    % python -m crds.list --references --range 1:2 --references
+    % crds list --references --range 1:2 --references
     vb41935lj_bia.fits 
     vb41935oj_bia.fits
     ...
 
     -- To list all mappings, even those not referenced by an imap or pmap
     
-    % python -m crds.list --mappings --all
+    % crds list --mappings --all
     hst.pmap 
     hst_0001.pmap 
     hst_0002.pmap 
@@ -108,10 +108,10 @@ and ids used for CRDS reprocessing recommendations.
     --------------------------------------------------------------------------
     2. Locally cached files (files already synced to your computer) can be listed:
     
-    % python -m crds.list --cached-mappings --full-path
+    % crds list --cached-mappings --full-path
     ...
 
-    % python -m crds.list --cached-references --full-path
+    % crds list --cached-references --full-path
     ...
 
     In both cases adding --full-path prints the path of the file within the CRDS cache.
@@ -122,7 +122,7 @@ and ids used for CRDS reprocessing recommendations.
     --------------------------------------------------------------------------
     3. The contents of cached mappings or references (header only) can be printed to stdout like this:
 
-    % python -m crds.list --contexts jwst-fgs-linearity-edit jwst-nirspec-linearity-edit --cat --add-filename | grep parkey
+    % crds list --contexts jwst-fgs-linearity-edit jwst-nirspec-linearity-edit --cat --add-filename | grep parkey
     CRDS - INFO - Symbolic context 'jwst-fgs-linearity-edit' resolves to 'jwst_fgs_linearity_0008.rmap'
     CRDS - INFO - Symbolic context 'jwst-nirspec-linearity-edit' resolves to 'jwst_nirspec_linearity_0009.rmap'
     /cache/path/mappings/jwst/jwst_fgs_linearity_0008.rmap:     'parkey' : (('META.INSTRUMENT.DETECTOR', 'META.SUBARRAY.NAME'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
@@ -140,7 +140,7 @@ and ids used for CRDS reprocessing recommendations.
     References need to be catted explicitly by name,  but the list can come from the --references command
     explained above:
 
-    % python -m crds.list --cat jwst_nirspec_dark_0036.fits
+    % crds list --cat jwst_nirspec_dark_0036.fits
     CRDS - INFO - Symbolic context 'jwst-operational' resolves to 'jwst_0167.pmap'
     ##########################################################################################
     File:  '/grp/crds/jwst/references/jwst/jwst_nirspec_dark_0036.fits'
@@ -154,7 +154,7 @@ and ids used for CRDS reprocessing recommendations.
    4. Information about the dataset IDs and their associated parameters used
    for CRDS reprocessing can be printed:
 
-    % python -m crds.list --dataset-headers jcl403010 --first-id --minimize-header
+    % crds list --dataset-headers jcl403010 --first-id --minimize-header
     CRDS - INFO - Symbolic context 'hst-operational' resolves to 'hst_0462.pmap'
     CRDS - INFO - Dataset pars for 'JCL403010:JCL403ECQ' with respect to 'hst_0462.pmap':
     {'APERTURE': 'WFC1',
@@ -196,7 +196,7 @@ and ids used for CRDS reprocessing recommendations.
 
     Sometimes it's desirable to know the individual exposures CRDS associates with a product id:
 
-    % python -m crds.list --dataset-headers jcl403010 --id-expansions-only
+    % crds list --dataset-headers jcl403010 --id-expansions-only
     CRDS - INFO - Symbolic context 'hst-operational' resolves to 'hst_0462.pmap'
     JCL403010:JCL403ECQ
     JCL403010:JCL403EEQ

--- a/crds/matches.py
+++ b/crds/matches.py
@@ -1,7 +1,7 @@
 """This module is a command line script which lists the match tuples associated
 with a reference file.
 
-% python -m crds.matches  --contexts hst_0001.pmap --files lc41311jj_pfl.fits
+% crds matches  --contexts hst_0001.pmap --files lc41311jj_pfl.fits
 lc41311jj_pfl.fits : ACS PFLTFILE DETECTOR='WFC' CCDAMP='A|ABCD|AC|AD|B|BC|BD|C|D' FILTER1='F625W' FILTER2='POL0V' OBSTYPE='IMAGING' FW1OFFST='N/A' FW2OFFST='N/A' FWSOFFST='N/A' DATE-OBS='1997-01-01' TIME-OBS='00:00:00'
 
 A number of command line switches control output formatting.
@@ -179,24 +179,24 @@ or all dataset ids for an instrument, according to the appropriate archive catal
     epilog = """
 ** crds.matches can dump reference file match cases with respect to particular contexts:
 
-% python -m crds.matches  --contexts hst_0001.pmap --files lc41311jj_pfl.fits
+% crds matches  --contexts hst_0001.pmap --files lc41311jj_pfl.fits
 lc41311jj_pfl.fits : ACS PFLTFILE DETECTOR='WFC' CCDAMP='A|ABCD|AC|AD|B|BC|BD|C|D' FILTER1='F625W' FILTER2='POL0V' DATE-OBS='1997-01-01' TIME-OBS='00:00:00'
 
-% python -m crds.matches --contexts hst.pmap --files lc41311jj_pfl.fits --omit-parameter-names --brief-paths
+% crds matches --contexts hst.pmap --files lc41311jj_pfl.fits --omit-parameter-names --brief-paths
 lc41311jj_pfl.fits :  'WFC' 'A|ABCD|AC|AD|B|BC|BD|C|D' 'F625W' 'POL0V' '1997-01-01' '00:00:00'
 
-% python -m crds.matches --contexts hst.pmap --files lc41311jj_pfl.fits --tuple-format
+% crds matches --contexts hst.pmap --files lc41311jj_pfl.fits --tuple-format
 lc41311jj_pfl.fits : (('OBSERVATORY', 'HST'), ('INSTRUMENT', 'ACS'), ('FILEKIND', 'PFLTFILE'), ('DETECTOR', 'WFC'), ('CCDAMP', 'A|ABCD|AC|AD|B|BC|BD|C|D'), ('FILTER1', 'F625W'), ('FILTER2', 'POL0V'), ('DATE-OBS', '1997-01-01'), ('TIME-OBS', '00:00:00'))
 
 ** crds.matches can dump database matching parameters for specified datasets with respect to specified contexts:
 
-% python -m crds.matches --datasets JBANJOF3Q --minimize-headers --contexts hst_0048.pmap hst_0044.pmap
+% crds matches --datasets JBANJOF3Q --minimize-headers --contexts hst_0048.pmap hst_0044.pmap
 JBANJOF3Q : hst_0044.pmap : APERTURE='WFC1-2K' ATODCORR='NONE' BIASCORR='NONE' CCDAMP='B' CCDCHIP='1.0' CCDGAIN='2.0' CRCORR='NONE' DARKCORR='NONE' DATE-OBS='2010-01-31' DETECTOR='WFC' DQICORR='NONE' DRIZCORR='NONE' FILTER1='F502N' FILTER2='F660N' FLASHCUR='OFF' FLATCORR='NONE' FLSHCORR='NONE' FW1OFFST='0.0' FW2OFFST='0.0' FWSOFFST='0.0' GLINCORR='NONE' INSTRUME='ACS' LTV1='-2048.0' LTV2='-1.0' NUMCOLS='UNDEFINED' NUMROWS='UNDEFINED' OBSTYPE='INTERNAL' PCTECORR='NONE' PHOTCORR='NONE' REFTYPE='UNDEFINED' SHADCORR='NONE' SHUTRPOS='B' TIME-OBS='01:07:14.960000' XCORNER='1.0' YCORNER='2072.0'
 JBANJOF3Q : hst_0048.pmap : APERTURE='WFC1-2K' ATODCORR='NONE' BIASCORR='NONE' CCDAMP='B' CCDCHIP='1.0' CCDGAIN='2.0' CRCORR='NONE' DARKCORR='NONE' DATE-OBS='2010-01-31' DETECTOR='WFC' DQICORR='NONE' DRIZCORR='NONE' FILTER1='F502N' FILTER2='F660N' FLASHCUR='OFF' FLATCORR='NONE' FLSHCORR='NONE' FW1OFFST='0.0' FW2OFFST='0.0' FWSOFFST='0.0' GLINCORR='NONE' INSTRUME='ACS' LTV1='-2048.0' LTV2='-1.0' NAXIS1='2070.0' NAXIS2='2046.0' OBSTYPE='INTERNAL' PCTECORR='NONE' PHOTCORR='NONE' REFTYPE='UNDEFINED' SHADCORR='NONE' SHUTRPOS='B' TIME-OBS='01:07:14.960000' XCORNER='1.0' YCORNER='2072.0'
 
 ** crds.matches can list all references which satisfy any filter constraints relevant to their bestref lookup.
 
-% python -m crds.matches --contexts jwst-niriss-operational --files-from-contexts --filters META.INSTRUMENT.FILTER='F480M' --brief
+% crds matches --contexts jwst-niriss-operational --files-from-contexts --filters META.INSTRUMENT.FILTER='F480M' --brief
 CRDS - INFO - Symbolic context 'jwst-niriss-operational' resolves to 'jwst_niriss_0028.imap'
 jwst_niriss_dark_0005.fits :  META.INSTRUMENT.DETECTOR='NIS' META.SUBARRAY.NAME='FULL'
 jwst_niriss_gain_0001.fits :  META.INSTRUMENT.DETECTOR='NIS'

--- a/crds/misc/check_archive.py
+++ b/crds/misc/check_archive.py
@@ -33,7 +33,7 @@ all contexts, do this:
 
     % setenv CRDS_SERVER_URL https://jwst-crds.stsci.edu
     % setenv CRDS_PATH $HOME/crds_cache_ops
-    % python -m crds.list --all --mappings --references >files.b6
+    % crds list --all --mappings --references >files.b6
 
 This captures the file list with respect to the CRDS OPS server which
 during the development period directly distributes files and is a
@@ -43,7 +43,7 @@ complete "reference" copy.
 
     % setenv CRDS_SERVER_URL https://jwst-crds-b6it.stsci.edu
     % setenv CRDS_PATH $HOME/crds_cache_b6it
-    % python -m crds.misc.check_archive --files @files.b6 --dump-good-files --stats > all.b6it.archive
+    % crds misc.check_archive --files @files.b6 --dump-good-files --stats > all.b6it.archive
 
 This checks the file list in files.b6 against the CRDS B6 server
 database and whatever archive URL that server is configured to use,
@@ -62,7 +62,7 @@ ERROR messages for each problem (missing or length) are printed to stderr
 
 3. Once the archive is looking good,  sync all the CRDS rules to a local cache:
     
-    % python -m crds.sync --all --stats --check-sha1sum
+    % crds sync --all --stats --check-sha1sum
 
 which will verify rules download, loadability, and exact contents with respect to 
 the CRDS server database.

--- a/crds/misc/sql.py
+++ b/crds/misc/sql.py
@@ -31,18 +31,18 @@ class CrdsSqlQueryScript(cmdline.Script):
     epilog = """
 * Dumping the table names supported can be done as follows:
 
-% python -m crds.misc.sql --list-tables
+% crds misc.sql --list-tables
 crds_hst_catalog
 crds_hst_context_history
 
 * Dumping the columns of a table can be done as follows:
 
-% python -m crds.misc.sql --list-columns
+% crds misc.sql --list-columns
 id, name, blob, state, blacklisted, rejected, observatory, instrument, filekind, type, derived_from, sha1sum, delivery_date, activation_date, useafter_date, change_level, pedigree, reference_file_type, size, uploaded_as, creator_name, deliverer_user, deliverer_email, description, catalog_link, replaced_by_filename, comment, aperture
 
 * Executing a SQL query can be done as follows:
 
-% python -m crds.misc.sql "select name, state, pedigree from crds_hst_catalog"
+% crds misc.sql "select name, state, pedigree from crds_hst_catalog"
 ('h230851po_pfl.fits', 'operational', 'GROUND')
 ('h230851qo_pfl.fits', 'operational', 'GROUND')
 ('h230851so_pfl.fits', 'operational', 'GROUND')

--- a/crds/misc/uniqname.py
+++ b/crds/misc/uniqname.py
@@ -29,7 +29,7 @@ enhanced CDBS-style names with modified timestamps valid after 2016-01-01.
 
 The CRDS uniqame is nominally run as follows:
 
-    % python -m crds.misc.uniqname --files s7g1700gl_dead.fits --brief --standard
+    % crds misc.uniqname --files s7g1700gl_dead.fits --brief --standard
     CRDS - INFO - Rewriting 's7g1700gl_dead.fits' --> 'zc52141pl_dead.fits'
 
 If -s or --standard is added then routinely used switches are added as a

--- a/crds/refactoring/checksum.py
+++ b/crds/refactoring/checksum.py
@@ -1,7 +1,7 @@
 """This script updates the checksums of all the mapping files passed in as 
 command line parameters:
 
-% python -m crds.checksum  hst.pmap
+% crds checksum  hst.pmap
 
 will rewrite the sha1sum of hst.pmap.   
 """

--- a/crds/refactoring/newcontext.py
+++ b/crds/refactoring/newcontext.py
@@ -175,7 +175,7 @@ def update_header_names(name_map):
 # ============================================================================
 
 class NewContextScript(cmdline.Script):
-    """Defines the command line handler for python -m crds.newcontext."""
+    """Defines the command line handler for crds newcontext."""
     
     description = """Based on `old_pmap`,  generate a new .pmap and .imaps as
 needed in order to support `new_rmaps`.   Currently generated contexts have 

--- a/crds/refactoring/refactor2.py
+++ b/crds/refactoring/refactor2.py
@@ -322,11 +322,11 @@ class RefactorScript(cmdline.Script):
 
     1. Insert reference files A B C D... into rmap X creating rmap Y.
 
-    % python -m crds.refactoring.refactor2 insert_reference --old-rmap X --new-rmap Y  --references A B C D...
+    % crds refactoring.refactor2 insert_reference --old-rmap X --new-rmap Y  --references A B C D...
 
     2. Delete references A B C D ... from rmap X creating rmap Y.
 
-    % python -m crds.refactoring.refactor2 delete_reference --old-rmap Y --new-rmap Y  --references A B C D...
+    % crds refactoring.refactor2 delete_reference --old-rmap Y --new-rmap Y  --references A B C D...
 
     The set_header, del_header, del_parameter, set_parkey, and replace commands operate on
     the set of rmaps found under a source context which correspond to the specified instruments and types.
@@ -334,26 +334,26 @@ class RefactorScript(cmdline.Script):
     3. Set header key K to value V in rmap X creating rmap Y.
     source context C (e.g. jwst-edit) for types A B C... of instruments X Y Z...
 
-    % python -m crds.refactoring.refactor2 set_header --header-key K --header-value V
+    % crds refactoring.refactor2 set_header --header-key K --header-value V
 
     4. Delete header key K (e.g. description) in all the rmaps found under
     source context C (e.g. jwst-edit) for types A B C... of instruments X Y Z...
 
-    % python -m crds.refactoring.refactor2 del_header --header-key K \\
+    % crds refactoring.refactor2 del_header --header-key K \\
            --source-context C --instruments X Y Z ... --types A B C ...
 
     5. Remove single parameter name N (e.g. META.SUBARRAY.NAME) in all the rmaps found under
     source context C (e.g. jwst-edit) for types A B C... of instruments X Y Z...
     This incudes modifying both parkey and all corresponding selector matching patterns.
 
-    % python -m crds.refactoring.refactor2 del_parameter --parameter-name N \\
+    % crds refactoring.refactor2 del_parameter --parameter-name N \\
            --source-context C --instruments X Y Z ... --types A B C ...
 
     6. Set complete parkey in all rmaps found under
     source context C (e.g. jwst-edit) for types A B C... of instruments X Y Z...
     This removes all the existing references and re-inserts them under the new parkey approach.
 
-    % python -m crds.refactoring.refactor2 set_parkey --parkey "(('META.INSTRUMENT.DETECTOR','META.SUBARRAY.NAME',))" \\
+    % crds refactoring.refactor2 set_parkey --parkey "(('META.INSTRUMENT.DETECTOR','META.SUBARRAY.NAME',))" \\
             --source-context jwst-edit --instruments X Y Z ... --types A B C ... \\
             --fixers FGS1:GUIDER1 FGS2:GUIDER2 ANY:GENERIC FULL:GENERIC
      
@@ -361,7 +361,7 @@ class RefactorScript(cmdline.Script):
     source context C (e.g. jwst-edit) for types A B C... of instruments X Y Z...
     This is a simple text substitution.
 
-    % python -m crds.refactoring.refactor2 replace_text --old-text P1  --new-text P2 \\
+    % crds refactoring.refactor2 replace_text --old-text P1  --new-text P2 \\
             --source-context jwst-edit --instruments X Y Z ... --types A B C ...
 
     8. Add an unconditional load-time parameter value substitution to the rmap header.  For this example,
@@ -369,7 +369,7 @@ class RefactorScript(cmdline.Script):
     that match tuples in the rmap are transparently altered at load-time, and SUBARRAY values of GENERIC
     are re-interpreted as N/A for the purposes of matching.
 
-    % python -m crds.refactoring.refactor2 set_substitution --parameter-name META.SUBARRAY.NAME  --old-text GENERIC  --new-text N/A \\
+    % crds refactoring.refactor2 set_substitution --parameter-name META.SUBARRAY.NAME  --old-text GENERIC  --new-text N/A \\
             --source-context jwst-edit --instruments X Y Z ... --types A B C ...
 
     IOW,  this command adds/updates something similar to the following to the specified rmaps:
@@ -381,12 +381,12 @@ class RefactorScript(cmdline.Script):
     9. All of the above commands which elaborate rmaps to refactor based on --source-context can also be
     driven by a direct specification of .rmap names using --rmaps:
     
-    % python -m crds.refactoring.refactor2 set_substitution --parameter-name META.SUBARRAY.NAME  --old-text GENERIC  --new-text N/A \\
+    % crds refactoring.refactor2 set_substitution --parameter-name META.SUBARRAY.NAME  --old-text GENERIC  --new-text N/A \\
             --rmaps jwst_miri_dark_0007.rmap
 
     10. Add the nested UseAfter selector to early JWST rmaps based on Match-only.
 
-    % python -m crds.refactoring.refactor2 add_useafter --rmaps jwst_miri_dark_0007.rmap
+    % crds refactoring.refactor2 add_useafter --rmaps jwst_miri_dark_0007.rmap
 
     11. Mass reference insertion for rehearsing large file deliveries based on --source-context
 
@@ -399,7 +399,7 @@ class RefactorScript(cmdline.Script):
     the baseline rmap for each type.  By falling back to the type declaration specs as baseline rmaps, it 
     supports reference insertion into rmaps not yet officially added to the --source-context.
 
-    % python -m crds.refactoring.refactor2 insert_reference --references ./*.asdf --verbose --certify --diff
+    % crds refactoring.refactor2 insert_reference --references ./*.asdf --verbose --certify --diff
 
     ---------------------------------------------------------------------------------------------------------
 

--- a/crds/rowdiff.py
+++ b/crds/rowdiff.py
@@ -811,7 +811,7 @@ class RowDiffScript(cmdline.Script):
 
     An example:
 
-    % python -m crds.rowdiff s9m1329lu_off.fits s9518396u_off.fits
+    % crds rowdiff s9m1329lu_off.fits s9518396u_off.fits
     Row differences for HDU extension #1
 
         Summary:

--- a/crds/submit/monitor.py
+++ b/crds/submit/monitor.py
@@ -29,7 +29,7 @@ class MonitorScript(cmdline.Script):
     epilog = """Monitoring is done with respect to a submission id/key and currently
 polls the server for new messages at some periodic rate in seconds:
 
-% python -m crds.monitor --poll-delay 3.0 --key 81323850-9517-416c-ae88-e6481de10a71
+% crds monitor --poll-delay 3.0 --key 81323850-9517-416c-ae88-e6481de10a71
 """
 
     def __init__(self, *args, **keys):

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -4,22 +4,22 @@ mappings required to support a set of contexts from the CRDS server:
 Old references and mappings which are no longer needed can be automatically
 removed by specifying --purge-mappings or --purge-references:
 
-  % python -m crds.sync --range 1:2 --purge-mappings --purge-references
+  % crds sync --range 1:2 --purge-mappings --purge-references
 
 will remove references or mappings not required by hst_0001.pmap or 
 hst_0002.pmap in addition to downloading the required files.
 
 Or explicitly list the files you want cached:
 
-  % python -m crds.sync --files <references or mappings to cache>
+  % crds sync --files <references or mappings to cache>
 
 To sync best references and rules for specific dataset FITS files:
 
-  % python -m crds.sync --contexts hst_0001.pmap hst_0002.pmap --dataset-files *.fits --fetch-references
+  % crds sync --contexts hst_0001.pmap hst_0002.pmap --dataset-files *.fits --fetch-references
 
 To sync best references and rules for specific dataset ids:
 
-  % python -m crds.sync --contexts hst_0001.pmap hst_0002.pmap --dataset-ids J6M915030 --fetch-references
+  % crds sync --contexts hst_0001.pmap hst_0002.pmap --dataset-ids J6M915030 --fetch-references
 
 """
 from __future__ import print_function
@@ -64,7 +64,7 @@ class SyncScript(cmdline.ContextsScript):
     
         Downloading an explicit list of files can be done by like this::
         
-        % python -m crds.sync  --files hst_0001.pmap hst_acs_darkfile_0037.fits
+        % crds sync  --files hst_0001.pmap hst_acs_darkfile_0037.fits
     
         this will download only those two files.
         
@@ -74,19 +74,19 @@ class SyncScript(cmdline.ContextsScript):
         
         Synced contexts can be explicitly listed::
         
-            % python -m crds.sync  --contexts hst_0001.pmap hst_0002.pmap
+            % crds sync  --contexts hst_0001.pmap hst_0002.pmap
           
         this will recursively download all the mappings referred to by .pmaps 0001 and 0002.
         
         Synced contexts can be specified as a numerical range::
         
-            % python -m crds.sync --range 1:3
+            % crds sync --range 1:3
         
         this will also recursively download all the mappings referred to by .pmaps 0001, 002, 0003.
         
         Synced contexts can be specified as --all contexts::
         
-            % python -m crds.sync --all
+            % crds sync --all
         
         this will recursively download all CRDS mappings for all time.
     
@@ -95,7 +95,7 @@ class SyncScript(cmdline.ContextsScript):
         Because complete reference downloads can be enormous,  you must explicitly specify when
         you wish to fetch the references which are enumerated in particular CRDS rules::
               
-            % python -m crds.sync  --contexts hst_0001.pmap hst_0002.pmap  --fetch-references
+            % crds sync  --contexts hst_0001.pmap hst_0002.pmap  --fetch-references
         
         will download all the references mentioned by contexts 0001 and 0002.   
     
@@ -109,11 +109,11 @@ class SyncScript(cmdline.ContextsScript):
               
         CRDS rules from **unspecified** contexts can be removed like this::
         
-            % python -m crds.sync  --contexts hst_0004.pmap hst_0005.pmap --purge-mappings
+            % crds sync  --contexts hst_0004.pmap hst_0005.pmap --purge-mappings
         
         while this would remove references which are *not* in contexts 4 or 5::
         
-            % python -m crds.sync  --contexts hst_0004.pmap hst_0005.pmap --purge-references
+            % crds sync  --contexts hst_0004.pmap hst_0005.pmap --purge-references
             
         Again, both of these commands remove cached files which are not specified or implied.
     
@@ -121,7 +121,7 @@ class SyncScript(cmdline.ContextsScript):
     
         References required by particular dataset files can be cached like this::
                 
-            % python -m crds.sync  --contexts hst_0001.pmap hst_0002.pmap --dataset-files  <dataset_files...> e.g. acs_J8D219010.fits
+            % crds sync  --contexts hst_0001.pmap hst_0002.pmap --dataset-files  <dataset_files...> e.g. acs_J8D219010.fits
         
         This will fetch all the references required to support the listed datasets for contexts 0001 and 0002.
         
@@ -131,7 +131,7 @@ class SyncScript(cmdline.ContextsScript):
     
         References for particular dataset ids can be cached like this::
                 
-            % python -m crds.sync  --contexts hst_0001.pmap hst_0002.pmap --dataset-ids  <ids...>  e.g. J6M915030
+            % crds sync  --contexts hst_0001.pmap hst_0002.pmap --dataset-ids  <ids...>  e.g. J6M915030
         
         This will fetch all the references required to support the listed dataset ids for contexts 0001 and 0002.
               
@@ -139,7 +139,7 @@ class SyncScript(cmdline.ContextsScript):
     
         Large Institutional caches can be checked and/or repaired like this::
         
-            % python -m crds.sync --contexts hst_0001.pmap --fetch-references --check-sha1sum --repair-files
+            % crds sync --contexts hst_0001.pmap --fetch-references --check-sha1sum --repair-files
         
         will download all the files in hst_0001.pmap not already present.
         
@@ -158,11 +158,11 @@ class SyncScript(cmdline.ContextsScript):
         after making temporary modifications to cached files to return to the archived version::
         
            % rm -rf $CRDS_PATH
-           % python -m crds.sync  -- ...  # repeat whatever syncs you did to cache files of interest
+           % crds sync  -- ...  # repeat whatever syncs you did to cache files of interest
         
         A more complicated but also more precise approach can operate only on files already in the CRDS cache::
             
-           % python -m crds.sync --repair-files --check-sha1sum --files `python -m crds.list --all --cached-mappings --cached-references`
+           % crds sync --repair-files --check-sha1sum --files `crds list --all --cached-mappings --cached-references`
            
         This approach works by using the crds.list command to dump the file names of all files in the CRDS cache
         and then using the crds.sync command to check exactly those files.
@@ -177,7 +177,7 @@ class SyncScript(cmdline.ContextsScript):
     
         crds.sync can be used to remove the files from specific contexts which have been marked as "bad".
               
-          % python -m crds.sync --contexts hst_0001.pmap --fetch-references --check-files --purge-rejected --purge-blacklisted
+          % crds sync --contexts hst_0001.pmap --fetch-references --check-files --purge-rejected --purge-blacklisted
         
         would first sync the cache downloading all the files in hst_0001.pmap.  Both mappings and references would then
         be checked for correct length.   Files reported as rejected or blacklisted by the server would be removed.
@@ -191,11 +191,11 @@ class SyncScript(cmdline.ContextsScript):
         Newly created caches will default to the *instrument* organization.  To migrate a legacy cache with a flat single
         directory layout to the new structure,  sync with --organize=instrument::  
         
-           % python -m crds.sync --organize=instrument --verbose
+           % crds sync --organize=instrument --verbose
            
         To migrate to the flat structure,  use --organize=flat::
             
-           % python -m crds.sync --organize=flat --verbose
+           % crds sync --organize=flat --verbose
            
         While reorganizing, if CRDS makes note of "junk files" in your cache which are
         obstructing the process of reorganizing, you can allow CRDS to delete the junk

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -33,21 +33,21 @@ The options --files, --datasets, --instruments, and --all determine the source o
 
 1. To find best references for a list of files do something like this:
 
-    % python -m crds.bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits
+    % crds bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits
 
 the first parameter, hst.pmap,  is the context with respect to which best references are determined.
 
 2. To find best references for a list of catalog dataset ids do something like this:
 
-    % python -m crds.bestrefs --new-context hst.pmap --datasets j8bt05njq j8bt06o6q j8bt09jcq
+    % crds bestrefs --new-context hst.pmap --datasets j8bt05njq j8bt06o6q j8bt09jcq
 
 3. To do mass scale testing for all cataloged datasets for a particular instrument(s) do:
 
-    % python -m crds.bestrefs --new-context hst.pmap --instruments acs
+    % crds bestrefs --new-context hst.pmap --instruments acs
 
 4. To do mass scale testing for all supported instruments for all cataloged datasets do:
 
-    % python -m crds.bestrefs --new-context hst.pmap --all
+    % crds bestrefs --new-context hst.pmap --all
 
 ----------------
 COMPARISON MODES
@@ -87,7 +87,7 @@ crds.bestrefs supports several output modes for bestrefs and comparison results.
 If --print-affected is specified,  crds.bestrefs will print out the name of any file (or dataset id) for which at least one update for
 one reference type was recommended.   This is essentially a list of files to be reprocessed with new references.
 
-    % python -m crds.bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits --compare-source-bestrefs --print-affected
+    % crds bestrefs --new-context hst.pmap --files j8bt05njq_raw.fits j8bt06o6q_raw.fits j8bt09jcq_raw.fits --compare-source-bestrefs --print-affected
     j8bt05njq_raw.fits
     j8bt06o6q_raw.fits
     j8bt09jcq_raw.fits

--- a/crds/tests/test_diff.py
+++ b/crds/tests/test_diff.py
@@ -48,7 +48,7 @@ in the logical differences between two mappings.
     
 For example:
     
-    % python -m crds.diff hst_0001.pmap  hst_0005.pmap  --mapping-text-diffs --primitive-diffs
+    % crds diff hst_0001.pmap  hst_0005.pmap  --mapping-text-diffs --primitive-diffs
     
 Will recursively produce logical, textual, and FITS diffs for all changes between the two contexts.
     

--- a/crds/tests/test_list.py
+++ b/crds/tests/test_list.py
@@ -97,7 +97,7 @@ optional arguments:
     0. Configuration information governing the behavior of CRDS for simple
     configurations can be dumped:
 
-    % python -m crds.list --status
+    % crds list --status
     CRDS Version = '7.0.7, bump-version, 7432326'
     CRDS_MODE = 'auto'
     CRDS_PATH = '/Users/jmiller/crds_cache_ops'
@@ -111,7 +111,7 @@ optional arguments:
     More comprehensive configuration information is also available for advanced
     configurations:
 
-    % python -m crds.list --config
+    % crds list --config
     ... lots of info ....
 
     --------------------------------------------------------------------------
@@ -125,21 +125,21 @@ optional arguments:
 
     -- To list the references contained by several contexts
     
-    % python -m crds.list  --references --contexts hst_0001.pmap hst_0002.pmap ...
+    % crds list  --references --contexts hst_0001.pmap hst_0002.pmap ...
     vb41935ij_bia.fits 
     vb41935kj_bia.fits 
     ...
     
     -- To list the references in a numerical range of contexts
 
-    % python -m crds.list --references --range 1:2 --references
+    % crds list --references --range 1:2 --references
     vb41935lj_bia.fits 
     vb41935oj_bia.fits
     ...
 
     -- To list all mappings, even those not referenced by an imap or pmap
     
-    % python -m crds.list --mappings --all
+    % crds list --mappings --all
     hst.pmap 
     hst_0001.pmap 
     hst_0002.pmap 
@@ -154,10 +154,10 @@ optional arguments:
     --------------------------------------------------------------------------
     2. Locally cached files (files already synced to your computer) can be listed:
     
-    % python -m crds.list --cached-mappings --full-path
+    % crds list --cached-mappings --full-path
     ...
 
-    % python -m crds.list --cached-references --full-path
+    % crds list --cached-references --full-path
     ...
 
     In both cases adding --full-path prints the path of the file within the CRDS cache.
@@ -168,7 +168,7 @@ optional arguments:
     --------------------------------------------------------------------------
     3. The contents of cached mappings or references (header only) can be printed to stdout like this:
 
-    % python -m crds.list --contexts jwst-fgs-linearity-edit jwst-nirspec-linearity-edit --cat --add-filename | grep parkey
+    % crds list --contexts jwst-fgs-linearity-edit jwst-nirspec-linearity-edit --cat --add-filename | grep parkey
     CRDS - INFO - Symbolic context 'jwst-fgs-linearity-edit' resolves to 'jwst_fgs_linearity_0008.rmap'
     CRDS - INFO - Symbolic context 'jwst-nirspec-linearity-edit' resolves to 'jwst_nirspec_linearity_0009.rmap'
     /cache/path/mappings/jwst/jwst_fgs_linearity_0008.rmap:     'parkey' : (('META.INSTRUMENT.DETECTOR', 'META.SUBARRAY.NAME'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
@@ -186,7 +186,7 @@ optional arguments:
     References need to be catted explicitly by name,  but the list can come from the --references command
     explained above:
 
-    % python -m crds.list --cat jwst_nirspec_dark_0036.fits
+    % crds list --cat jwst_nirspec_dark_0036.fits
     CRDS - INFO - Symbolic context 'jwst-operational' resolves to 'jwst_0167.pmap'
     ##########################################################################################
     File:  '.../references/jwst/jwst_nirspec_dark_0036.fits'
@@ -200,7 +200,7 @@ optional arguments:
    4. Information about the dataset IDs and their associated parameters used
    for CRDS reprocessing can be printed:
 
-    % python -m crds.list --dataset-headers jcl403010 --first-id --minimize-header
+    % crds list --dataset-headers jcl403010 --first-id --minimize-header
     CRDS - INFO - Symbolic context 'hst-operational' resolves to 'hst_0462.pmap'
     CRDS - INFO - Dataset pars for 'JCL403010:JCL403ECQ' with respect to 'hst_0462.pmap':
     {'APERTURE': 'WFC1',
@@ -242,7 +242,7 @@ optional arguments:
 
     Sometimes it's desirable to know the individual exposures CRDS associates with a product id:
 
-    % python -m crds.list --dataset-headers jcl403010 --id-expansions-only
+    % crds list --dataset-headers jcl403010 --id-expansions-only
     CRDS - INFO - Symbolic context 'hst-operational' resolves to 'hst_0462.pmap'
     JCL403010:JCL403ECQ
     JCL403010:JCL403EEQ

--- a/crds/uses.py
+++ b/crds/uses.py
@@ -122,7 +122,7 @@ IMPORTANT:
     epilog = """
 crds.uses can be invoked like this:
 
-% python -m crds.uses --files n3o1022ij_drk.fits --hst
+% crds uses --files n3o1022ij_drk.fits --hst
 hst.pmap
 hst_0001.pmap
 hst_0002.pmap


### PR DESCRIPTION
Changes docs like "python -m crds.list" to "crds list",  where the latter master script hides internal CRDS package structure.

