### PR TITLE
Certify2 constraint updates

### DIFF
--- a/crds/jwst/tpns/all_photom.tpn
+++ b/crds/jwst/tpns/all_photom.tpn
@@ -2,8 +2,8 @@ REFTYPE    H      C      R      PHOTOM
 
 EXP_TYPE    H     C      O
 
-PIXAR_SR    H     R      R
-PIXAR_A2    H     R      R
+PIXAR_SR    H     R      O
+PIXAR_A2    H     R      O
 
 # PHOTOM     A      X      (not('IFU')in(DETECTOR))                             (is_table(PHOTOM_ARRAY))
 # PHOTOM     A      X      (not('IFU')in(DETECTOR))                             (has_column_type(PHOTOM_ARRAY,'PHOTMJSR','FLOAT'))

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -580,13 +580,37 @@ def certify_jwst_bad_fits():
     CRDS - ERROR -  In 'niriss_ref_photom_bad.fits' : Checking 'META.INSTRUMENT.DETECTOR' : Value 'FOO' is not one of ['ANY', 'N/A', 'NIS']
     CRDS - WARNING -  Missing suggested keyword 'META.MODEL_TYPE'
     CRDS - WARNING -  Non-compliant date format 'Jan 01 2015 00:00:00' for 'META.USEAFTER' should be 'YYYY-MM-DDTHH:MM:SS'
-    CRDS - ERROR -  In 'niriss_ref_photom_bad.fits' : Checking 'PIXAR_A2' : Missing required keyword 'PIXAR_A2'
-    CRDS - ERROR -  In 'niriss_ref_photom_bad.fits' : Checking 'PIXAR_SR' : Missing required keyword 'PIXAR_SR'
     CRDS - WARNING -  No comparison reference for 'niriss_ref_photom_bad.fits' in context None. Skipping tables comparison.
     CRDS - INFO -  Checking JWST datamodels.
     CRDS - ERROR -  data/niriss_ref_photom_bad.fits Validation error : JWST Data Models: 'FOO' is not one of ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCALONG', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4', 'NRCBLONG', 'NRS1', 'NRS2', 'ANY', 'MIRIMAGE', 'MIRIFULONG', 'MIRIFUSHORT', 'NIS', 'GUIDER1', 'GUIDER2', 'N/A']
     <BLANKLINE>
-    -ignore-
+    Failed validating 'enum' in schema:
+        {'$schema': 'http://stsci.edu/schemas/asdf-schema/0.1.0/asdf-schema',
+         'description': 'Detector name.',
+         'enum': ['NRCA1',
+                  'NRCA2',
+                  'NRCA3',
+                  'NRCA4',
+                  'NRCALONG',
+                  'NRCB1',
+                  'NRCB2',
+                  'NRCB3',
+                  'NRCB4',
+                  'NRCBLONG',
+                  'NRS1',
+                  'NRS2',
+                  'ANY',
+                  'MIRIMAGE',
+                  'MIRIFULONG',
+                  'MIRIFUSHORT',
+                  'NIS',
+                  'GUIDER1',
+                  'GUIDER2',
+                  'N/A'],
+         'fits_keyword': 'DETECTOR',
+         'title': 'Name of detector used to acquire the data',
+         'type': 'string'}
+    <BLANKLINE>
     On instance:
         'FOO'
     >>> doctest.ELLIPSIS_MARKER = '...'


### PR DESCRIPTION
Made PIXAR_SR and PIXAR_A2 optional for all JWST PHOTOM references.

Also includes  code to prefix output of crds list --cat with filename of file being catted making more of the output suitable for grep'ing etc.

Updated unit test for JWST CAL  data models validation errors.