### PR TITLE
Radon simplify

### DIFF
--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -873,48 +873,22 @@ For more information on the checks being performed,  use --verbose or --verbosit
         if self.args.allow_schema_violations:
             config.ALLOW_SCHEMA_VIOLATIONS.set(True)
 
-        # String spellings of "none" are from command line,  None is the default which means "use operational context".
-        assert (self.args.comparison_context in [None, "none", "NONE", "None"]) or config.is_mapping_spec(self.args.comparison_context), \
-            "Specified --context file " + repr(self.args.comparison_context) + " is not a CRDS mapping."
-
-        assert (self.args.comparison_reference is None) or not config.is_mapping_spec(self.args.comparison_reference), \
-            "Specified --comparison-reference file " + repr(self.args.comparison_reference) + " is not a reference."
-            
-        if self.args.comparison_context and self.args.sync_files:
-            resolved_context = self.resolve_context(self.args.comparison_context)
-            self.sync_files([resolved_context])
-        if self.args.comparison_reference and self.args.sync_files:
-            self.sync_files([self.args.comparison_reference])
-            
+        self._sync_comparison_files()
+        
         if not self.args.dont_recurse_mappings:
             all_files = self.mapping_closure(self.files)
         else:
             all_files = set(self.files)
             
-        if not self.are_all_references(all_files) and not self.are_all_mappings(all_files):
-            if self.args.comparison_context is None and not self.args.comparison_reference:
-                log.info("Mixing references and mappings in one certify run skips any default comparison checks.")
-
-        if self.are_all_references(all_files):
-            # Change original default behavior of None to default operational context,  for references.
-            # For mappings / older contexts the default tends to be the wrong thing,  hence references only.
-            if self.args.comparison_context is None and not self.args.comparison_reference:
-                log.verbose("Defaulting comparison context to latest operational CRDS context.")
-                self.args.comparison_context = self.default_context
-        elif self.args.comparison_context is None and self.args.deep:
-            log.verbose("Defaulting comparison context to latest operational CRDS context because of --deep.")
-            self.args.comparison_context = self.default_context
-        elif self.args.comparison_context in [None, "none", "None", "NONE"]:
-            log.info("No comparison context specified or specified as 'none'.  No default context for all mappings or mixed types.")
-            self.args.comparison_context = None
-
+        comparison_context = self._get_comparison_context(all_files)
+        
         if self.args.comparison_reference:
             comparison_reference = config.locate_reference(self.args.comparison_reference, self.observatory)
         else:
             comparison_reference = None
             
         certify_files(sorted(all_files), 
-                      context=self.resolve_context(self.args.comparison_context),
+                      context=self.resolve_context(comparison_context),
                       comparison_reference=comparison_reference,
                       compare_old_reference=self.args.comparison_context or self.args.comparison_reference,
                       dump_provenance=self.args.dump_provenance, 
@@ -926,6 +900,53 @@ For more information on the checks being performed,  use --verbose or --verbosit
     
         self.dump_unique_errors()
         return log.errors()
+    
+    def _sync_comparison_files(self):
+        """Handle and --comparison-context or --comparison-reference switches,  resolving any symbolic names
+        like 'jwst-edit' and  syncing the comparison files to the local cache if --sync-files is specified.
+        """
+        # String spellings of "none" are from command line,  None is the default which means "use operational context".
+        assert (self.args.comparison_context in [None, "none", "NONE", "None"]) or config.is_mapping_spec(self.args.comparison_context), \
+            "Specified --context file " + repr(self.args.comparison_context) + " is not a CRDS mapping."
+        assert (self.args.comparison_reference is None) or not config.is_mapping_spec(self.args.comparison_reference), \
+            "Specified --comparison-reference file " + repr(self.args.comparison_reference) + " is not a reference."
+        if self.args.sync_files:    
+            if self.args.comparison_context:
+                resolved_context = self.resolve_context(self.args.comparison_context)
+                self.sync_files([resolved_context])
+            if self.args.comparison_reference:
+                self.sync_files([self.args.comparison_reference])
+    
+    def _get_comparison_context(self, all_files):
+        """Based on `all_files`,  --comparison-context, and --comparison-reference.
+        
+        Return any value for comparison_context (possibly defaulted to ops context) or None.
+        """
+        if self.args.comparison_context is None:  # no switch specified
+            comparison_context = self._get_default_comparison_context(all_files)
+        elif self.args.comparison_context.lower() == "none":    # switch specifies "none"
+            log.info("Comparison context explicitly specified as 'none',  no --comparison-context will be used.")
+            comparison_context = None
+        else:  # an explicit filename
+            comparison_context = self.args.comparison_context
+        return comparison_context
+    
+    def _get_default_comparison_context(self, all_files):
+        """Determine any reasonable commparison context when --comparison-context is not specified."""
+        if not self.args.comparison_reference:
+            if self.are_all_references(all_files):
+                log.info("Certifying only references,  defaulting --comparison-context to operational context.")
+                comparison_context = self.default_context
+            elif self.args.deep:
+                log.info("Certifying mappings with --deep,  defaulting --comparison-context to operational context.")
+                comparison_context = self.default_context
+            else:
+                log.info("Certification includes mappings but is not --deep, no --comparison-context is defined.")
+                comparison_context = None
+        else:
+            log.info("Certifying with --comparison-reference, no default --comparison-context defined.")
+            comparison_context = None
+        return comparison_context
     
     def log_and_track_error(self, filename, *args, **keys):
         """Override log_and_track_error() to compute instrument, filekind automatically."""

--- a/crds/refactoring/refactor2.py
+++ b/crds/refactoring/refactor2.py
@@ -308,7 +308,7 @@ def apply_rmap_fixers(rmapping, new_filename, fixers, *args, **keys):
 
 # ============================================================================
 
-class RefactorScript(cmdline.Script):
+class RefactorScript2(cmdline.Script):
     """Command line script for modifying .rmap files."""
 
     description = """
@@ -644,5 +644,5 @@ class RefactorScript(cmdline.Script):
         self.rmap_apply(insert_rmap_references, categorized=categorized)
             
 if __name__ == "__main__":
-    sys.exit(RefactorScript()())
+    sys.exit(RefactorScript2()())
 

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -25,6 +25,9 @@ To sync best references and rules for specific dataset ids:
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+
+# ============================================================================
+
 import sys
 import os
 import os.path
@@ -260,10 +263,52 @@ class SyncScript(cmdline.ContextsScript):
     def main(self):
         """Synchronize files."""
 
+        # clear any mutliprocessing locks associated with the CRDS cache.
         if self.args.clear_locks:
             crds_cache_locking.clear_cache_locks()
             return log.errors()
+
+        self.handle_misc_switches()   # simple side effects only
         
+        # if explicitly requested,  or the cache is suspect or being ignored,  clear
+        # cached context pickles.
+        if self.args.clear_pickles or self.args.ignore_cache or self.args.repair_files:
+            self.clear_pickles()
+
+        # utility to change cache structure, e.g. add instrument subdirs.
+        # do this before syncing anything under the current mode.
+        if self.args.organize:   
+            self.organize_references(self.args.organize)
+
+        # fetching and verifying files both require a server connection.
+        self.require_server_connection()
+
+        # primary sync'ing occurs here,  both mappings and references as well as odd-ball
+        # server sqlite3 database download.
+        verify_file_list = self.file_transfers()
+
+        # verification is relative to sync'ed files,  and can include file replacement if
+        # defects are found.
+        if self.args.check_files or self.args.check_sha1sum or self.args.repair_files:
+            self.verify_files(verify_file_list)
+            
+        # context pickles should only be (re)generated after mappings are fully sync'ed and verified
+        if self.args.save_pickles:
+            self.pickle_contexts(self.contexts)
+
+        # update CRDS cache config area,  including stored version of operational context.
+        # implement pipeline support functions of context update verify and echo
+        self.update_context()
+            
+        self.report_stats()
+        log.standard_status()
+        return log.errors()
+    # ------------------------------------------------------------------------------------------
+
+    def handle_misc_switches(self):
+        """Handle command line switches with simple side-effects that should precede
+        other sync operations.
+        """
         if self.args.dry_run:
             config.set_cache_readonly(True)
 
@@ -276,55 +321,64 @@ class SyncScript(cmdline.ContextsScript):
             os.environ["CRDS_CFGPATH_SINGLE"] = self.args.output_dir
             os.environ["CRDS_PICKLEPATH_SINGLE"] = self.args.output_dir
 
-        if self.args.clear_pickles or self.args.ignore_cache or self.args.repair_files:
-            self.clear_pickles()
-
-        if self.args.organize:   # do this before syncing anything under the current mode.
-            self.organize_references(self.args.organize)
-
-        self.require_server_connection()
-
         if self.readonly_cache:
             log.info("Syncing READONLY cache,  only checking functions are enabled.")
             log.info("All cached updates, context changes, and file downloads are inhibited.")
 
+    def file_transfers(self):
+        """Top level control for the primary function of downloading files specified as:
+        
+        --files ...      (explicit list of CRDS mappings or references)
+        --contexts ...   (many varieties of mapping specifier including --all, --range, etc.)
+        --fetch-sqlite-db ...  (Server catalog download as sqlite3 database file.
+        
+        Returns list of downloaded/cached files for later verification if requested.
+        """
         if self.args.files:
             self.sync_explicit_files()
             verify_file_list = self.files
         elif self.args.fetch_sqlite_db:
             self.fetch_sqlite_db()
+            verify_file_list = []
         elif self.contexts:
-            active_mappings = self.get_context_mappings()
-            verify_file_list = active_mappings
-            if self.args.fetch_references or self.args.purge_references:
-                if self.args.dataset_files or self.args.dataset_ids:
-                    active_references = self.sync_datasets()
-                else:
-                    active_references = self.get_context_references()
-                active_references = sorted(set(active_references + self.get_conjugates(active_references)))
-                if self.args.fetch_references:
-                    self.fetch_files(self.contexts[0], active_references)
-                    verify_file_list += active_references
-                if self.args.purge_references:
-                    self.purge_references(active_references)    
-            if self.args.purge_mappings:
-                self.purge_mappings()
+            verify_file_list = self.interpret_contexts()
         else:
             log.error("Define --all, --contexts, --last, --range, --files, or --fetch-sqlite-db to sync.")
             sys.exit(-1)
+        return verify_file_list
 
-        if self.args.check_files or self.args.check_sha1sum or self.args.repair_files:
-            self.verify_files(verify_file_list)
-            
-        if self.args.save_pickles:
-            self.pickle_contexts(self.contexts)
+    def interpret_contexts(self):
+        """Sync the mapping files associated with any context specifiers like 
+        --all, --contexts,  etc...
 
-        self.update_context()
-            
-        self.report_stats()
-        log.standard_status()
-        return log.errors()
-    # ------------------------------------------------------------------------------------------
+        If --fetch-references or --purge-references are specified, also fetch and/or
+        purge references with respect to the specified contexts.
+        """
+        active_mappings = self.get_context_mappings()
+        verify_file_list = active_mappings
+        if self.args.fetch_references or self.args.purge_references:
+            active_references = self.get_synced_references()
+            if self.args.fetch_references:
+                self.fetch_files(self.contexts[0], active_references)
+                verify_file_list += active_references
+            if self.args.purge_references:
+                self.purge_references(active_references)    
+        if self.args.purge_mappings:
+            self.purge_mappings()
+        return verify_file_list
+
+    def get_synced_references(self):
+        """Return the list of reference names associated with the specified dataset
+        files, dataset ids, or contexts, including any associated GEIS data
+        file names.
+        """
+        if self.args.dataset_files or self.args.dataset_ids:
+            active_references = self.sync_datasets()
+        else:
+            active_references = self.get_context_references()
+        # Handle GEIS paired data files
+        active_references = sorted(set(active_references + self.get_conjugates(active_references)))
+        return active_references
     
     def update_context(self):
         """Update the CRDS operational context in the cache.  Handle pipeline-specific
@@ -541,12 +595,13 @@ class SyncScript(cmdline.ContextsScript):
         if info["state"] not in ["archived", "operational"]:
             log.warning("File", repr(base), "has an unusual CRDS file state", repr(info["state"]))
         if info["rejected"] != "false":
-            log.verbose_warning("File", repr(base), "has been explicitly rejected.")
+            log.verbose_warning("File", repr(base), "has been explicitly rejected.", verbosity=60)
             if self.args.purge_rejected:
                 self.remove_files([path], "files")
             return
         if info["blacklisted"] != "false":
-            log.verbose_warning("File", repr(base), "has been blacklisted or is dependent on a blacklisted file.")
+            log.verbose_warning("File", repr(base), "has been blacklisted or is dependent on a blacklisted file.",
+                                verbosity=60)
             if self.args.purge_blacklisted:
                 self.remove_files([path], "files")
             return

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -265,7 +265,7 @@ def certify_missing_keyword():
 def certify_recursive():
     """
     >>> TestCertifyScript("crds.certify hst_cos.imap --exist --dont-parse")() # doctest: +ELLIPSIS
-    CRDS - INFO - No comparison context specified or specified as 'none'.  No default context for all mappings or mixed types.
+    CRDS - INFO -  Certification includes mappings but is not --deep, no --comparison-context is defined.
     CRDS - INFO - ########################################
     CRDS - INFO - Certifying '.../mappings/hst/hst_cos.imap' (1/19) as 'MAPPING' relative to context None
     CRDS - INFO - ########################################
@@ -348,6 +348,7 @@ def certify_table_comparison_context():
 def certify_table_comparison_reference():
     """
     >>> TestCertifyScript("crds.certify data/y951738kl_hv.fits --comparison-reference data/y9j16159l_hv.fits")()
+    CRDS - INFO -  Certifying with --comparison-reference, no default --comparison-context defined.
     CRDS - INFO -  ########################################
     CRDS - INFO -  Certifying 'data/y951738kl_hv.fits' (1/1) as 'FITS' relative to context None and comparison reference 'data/y9j16159l_hv.fits'
     CRDS - INFO -  Potential table unique row selection parameters are ['DATE']
@@ -370,13 +371,14 @@ def certify_table_comparison_reference():
     CRDS - INFO -  ########################################
     CRDS - INFO -  0 errors
     CRDS - INFO -  10 warnings
-    CRDS - INFO -  6 infos
+    CRDS - INFO -  7 infos
     0
     """
 
 def certify_comparison_context_none_all_references():
     """
     >>> TestCertifyScript("crds.certify data/y951738kl_hv.fits --comparison-context None")()
+    CRDS - INFO -  Comparison context explicitly specified as 'none',  no --comparison-context will be used.
     CRDS - INFO -  ########################################
     CRDS - INFO -  Certifying 'data/y951738kl_hv.fits' (1/1) as 'FITS' relative to context None
     CRDS - INFO -  Potential table unique row selection parameters are ['DATE']
@@ -386,14 +388,14 @@ def certify_comparison_context_none_all_references():
     CRDS - INFO -  ########################################
     CRDS - INFO -  0 errors
     CRDS - INFO -  1 warnings
-    CRDS - INFO -  6 infos
+    CRDS - INFO -  7 infos
     0
     """
 
 def certify_comparison_context_none_all_mappings():
     """
     >>> TestCertifyScript("crds.certify hst_cos_deadtab.rmap --comparison-context None")() # doctest: +ELLIPSIS
-    CRDS - INFO - No comparison context specified or specified as 'none'.  No default context for all mappings or mixed types.
+    CRDS - INFO -  Comparison context explicitly specified as 'none',  no --comparison-context will be used.
     CRDS - INFO - ########################################
     CRDS - INFO - Certifying '.../mappings/hst/hst_cos_deadtab.rmap' (1/1) as 'MAPPING' relative to context None
     CRDS - INFO - ########################################


### PR DESCRIPTION
Simplified complex main() methods in certify and sync based on cyclomatic complexity reported by Radon tool.  Definitely removed some convoluted logic and corner case bugs.