### PR TITLE
Switched rmap.InstrumentContext.get_filekinds() values to lower case 

### DIFF
--- a/crds/core/rmap.py
+++ b/crds/core/rmap.py
@@ -814,7 +814,6 @@ class InstrumentContext(ContextMapping):
     def __init__(self, filename, header, selector, **keys):
         super(InstrumentContext, self).__init__(filename, header, selector, **keys)
         self.instrument = self.header["instrument"]
-        self._filekinds = [key.upper() for key in self.selections.keys()]
 
     def validate(self):
         """Perform InstrumentContext semantic checks which require can loading sub-mappings."""
@@ -945,7 +944,7 @@ class InstrumentContext(ContextMapping):
         the minimum set associated with `dataset`,  but initially all
         for dataset's instrument,  assumed to be self.instrument.
         """
-        return self._filekinds
+        return list(sorted(self.selections.keys()))
         
     def get_item_key(self, filename):
         """Given `filename` nominally to insert, return the filekind it corresponds to."""

--- a/crds/tests/test_refactor.py
+++ b/crds/tests/test_refactor.py
@@ -152,12 +152,6 @@ class TestRefactor(test_config.CRDSTestCase):
         with self.assertRaises(exceptions.CrdsUnknownInstrumentError):
             r.get_imap("foo")
 
-    def test_get_filekind(self):
-        r = rmap.get_cached_mapping("hst.pmap")
-        self.assertEqual(r.get_filekinds("data/j8bt05njq_raw.fits"),
-                         [ 'PCTETAB', 'CRREJTAB', 'DARKFILE', 'D2IMFILE', 'BPIXTAB', 'ATODTAB', 'BIASFILE',
-                           'SPOTTAB', 'MLINTAB', 'DGEOFILE', 'FLSHFILE', 'NPOLFILE', 'OSCNTAB', 'CCDTAB',
-                           'SHADFILE', 'IDCTAB', 'IMPHTTAB', 'PFLTFILE', 'DRKCFILE', 'CFLTFILE', 'MDRIZTAB'])
     '''
 
 # ==================================================================================

--- a/crds/tests/test_rmap.py
+++ b/crds/tests/test_rmap.py
@@ -510,9 +510,10 @@ class TestRmap(test_config.CRDSTestCase):
     def test_rmap_get_filekind(self):
         r = rmap.get_cached_mapping("hst.pmap")
         self.assertEqual(set(r.get_filekinds("data/j8bt05njq_raw.fits")),
-                         {'PCTETAB', 'CRREJTAB', 'DARKFILE', 'D2IMFILE', 'BPIXTAB', 'ATODTAB', 'BIASFILE',
-                              'SPOTTAB', 'MLINTAB', 'DGEOFILE', 'FLSHFILE', 'NPOLFILE', 'OSCNTAB', 'CCDTAB',
-                              'SHADFILE', 'IDCTAB', 'IMPHTTAB', 'PFLTFILE', 'DRKCFILE', 'CFLTFILE', 'MDRIZTAB'})
+                         {'atodtab','biasfile','bpixtab','ccdtab','cfltfile','crrejtab',
+                          'd2imfile','darkfile','dgeofile','drkcfile','flshfile','idctab',
+                          'imphttab','mdriztab','mlintab','npolfile','oscntab','pctetab',
+                          'pfltfile','shadfile','spottab'})
 
     def test_rmap_get_equivalent_mapping(self):
         i = rmap.get_cached_mapping("data/hst_acs_0002.imap")

--- a/crds/tests/test_uses.py
+++ b/crds/tests/test_uses.py
@@ -93,13 +93,6 @@ class TestUses(test_config.CRDSTestCase):
         r = rmap.get_cached_mapping("hst.pmap")
         with self.assertRaises(exceptions.CrdsUnknownInstrumentError):
             r.get_imap("foo")
-
-    def test_get_filekind(self):
-        r = rmap.get_cached_mapping("hst.pmap")
-        self.assertEqual(r.get_filekinds("data/j8bt05njq_raw.fits"),
-                         [ 'PCTETAB', 'CRREJTAB', 'DARKFILE', 'D2IMFILE', 'BPIXTAB', 'ATODTAB', 'BIASFILE',
-                           'SPOTTAB', 'MLINTAB', 'DGEOFILE', 'FLSHFILE', 'NPOLFILE', 'OSCNTAB', 'CCDTAB',
-                           'SHADFILE', 'IDCTAB', 'IMPHTTAB', 'PFLTFILE', 'DRKCFILE', 'CFLTFILE', 'MDRIZTAB'])
     '''
 
 # ==================================================================================


### PR DESCRIPTION
InstrumentContext.get_filekinds() was originally a test support method.  I later used it to implement "default type determination" for JWST needed by CRDS repro where CRDS is not being told directly by CAL what type is needed.   Because of a case mismatch with the values returned by crds.jwst.locate.header_to_reftypes(),  the default type determination for JWST getreferences() and getrecommendations() was basically "all types".   This case change makes the intersection between "types recommended by header_to_reftypes()" and "available types in this context" work correctly and request only the required subset of available types.    This prevents spurious bestrefs errors for unneeded types.

The original bug didn't affect JWST CAL or HST bestrefs.  It was limited to requesting too many types for CRDS server debug functions or direct calls to the library.  Even CRDS repro (based on bestrefs) worked correctly.   Because get_filekinds() is only used internally in CRDS testing,  I summarily corrected it to returning lower case like most other functions.   I also removed dead example code in tests which coincidentally used this method. 
