### PR TITLE
Added code to normalize JWST dataset ID format to fileSetName.Detector

### DIFF
--- a/crds/bestrefs/headers.py
+++ b/crds/bestrefs/headers.py
@@ -243,7 +243,7 @@ class DatasetHeaderGenerator(HeaderGenerator):
         matching_two_part_id(<unassociated>)                 -->  <unassociated> : <unassociated>
         matching_two_part_id(<unassociated>:<unassociated>)  -->  <unassociated> : <unassociated>
         """
-        parts = source.split(":")
+        parts = [_normalize_jwst_id_part(part) for part in source.split(":")]
         assert 1 <= len(parts) <= 2, "Invalid dataset id " + repr(source)
         try:    # when specifying datasets with 1-part id, return first of "associated ids"
                 # when specifying datasets with 2-part id,
@@ -254,6 +254,18 @@ class DatasetHeaderGenerator(HeaderGenerator):
         except Exception:
             return source
 
+def _normalize_jwst_id_part(part):
+    """Converts jw88600071001_02101_00001_nrs1  --> jw88600071001_02101_00001.nrs.   The former is
+    common notation for most dataset usages,  the latter is the official form for the web API to
+    the archive parameter service for JWST.
+    """
+    if "_" in part and "." not in part:  # not HST and common JWST parlance
+        bits = part.split("_")
+        fileSetName = "_".join(bits[:-1])
+        detector = bits[-1]
+        return fileSetName + "." + detector   # Formal archive API
+    else:
+        return part
 
 class InstrumentHeaderGenerator(HeaderGenerator):
     """Generates lookup parameters and historical best references from a list of instrument names.  Server/DB based."""


### PR DESCRIPTION
The JWST archive parameter web service returns an odd abstract form of dataset ID to name reprocessing or debug parameters:

    fileSetName.Detector

Unfortunately users gravitate to:

    fileSetName_Detector

which is both a very subtle difference and normal everywhere else.

Hence CRDS attempts to support both forms of ID.

CRDS bestrefs issues a warning if it requests but does not receive parameters for some ID.  It is a direct check independent of parameter service error handling.

Because headers are returned in the canonical fileSetName.Detector form,  but the command line value used fileSetName_Detector,  the warning check failed and was issued spuriously when parameter data was returned normally.

This tweak fixes that.