### PR TITLE
Jira CRDS-175 nirspec gainfact

### DIFF
--- a/crds/jwst/tpns/nirspec_all.tpn
+++ b/crds/jwst/tpns/nirspec_all.tpn
@@ -27,7 +27,7 @@ META.EXPOSURE.READPATT      H   C   O  NRSRAPID,NRS,NRSN8R2,NRSN16R4,NRSN32R8,\
                                        NRSIRS2,NRSIRS2RAPID,NRSSLOW,\
                                        ALLIRS2,ANY,N/A
 
-META.EXPOSURE.GAIN_FACT     H   C   O  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   O  1.0:10.0
 
 META.SUBARRAY.NAME          H   C   O  ALLSLITS,SUBS200A1,SUBS200A2,SUBS200B1,\
                                        SUBS400A1,SUB1024A,SUB1024B,\

--- a/crds/jwst/tpns/nirspec_all_ld.tpn
+++ b/crds/jwst/tpns/nirspec_all_ld.tpn
@@ -27,7 +27,7 @@ META.EXPOSURE.READPATT      H   C   O  NRSRAPID,NRS,NRSN8R2,NRSN16R4,NRSN32R8,\
                                        NRSIRS2,NRSIRS2RAPID,NRSSLOW,\
                                        ALLIRS2,ANY,N/A
 
-META.EXPOSURE.GAIN_FACT     H   C   O  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   O  1.0:10.0
 
 META.SUBARRAY.NAME          H   C   O  ALLSLITS,SUBS200A1,SUBS200A2,SUBS200B1,\
                                        SUBS400A1,SUB1024A,SUB1024B,\

--- a/crds/jwst/tpns/nirspec_dark.tpn
+++ b/crds/jwst/tpns/nirspec_dark.tpn
@@ -5,4 +5,4 @@ include nir_err_array.tpn
 include nir_dq_array.tpn
 include nir_dq_def_array.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_dark.tpn
+++ b/crds/jwst/tpns/nirspec_dark.tpn
@@ -5,4 +5,4 @@ include nir_err_array.tpn
 include nir_dq_array.tpn
 include nir_dq_def_array.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_gain.tpn
+++ b/crds/jwst/tpns/nirspec_gain.tpn
@@ -4,5 +4,5 @@ include nirspec_sci_array.tpn
 
 SCI    A    X    R   (len(SCI_ARRAY.SHAPE)==2)
 
-META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   R  1.0:10.0
 

--- a/crds/jwst/tpns/nirspec_gain.tpn
+++ b/crds/jwst/tpns/nirspec_gain.tpn
@@ -4,3 +4,5 @@ include nirspec_sci_array.tpn
 
 SCI    A    X    R   (len(SCI_ARRAY.SHAPE)==2)
 
+META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+

--- a/crds/jwst/tpns/nirspec_linearity.tpn
+++ b/crds/jwst/tpns/nirspec_linearity.tpn
@@ -5,4 +5,4 @@ include nirspec_opt_err_array.tpn
 include nirspec_dq_array.tpn
 include nir_dq_def_array.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_linearity.tpn
+++ b/crds/jwst/tpns/nirspec_linearity.tpn
@@ -5,4 +5,4 @@ include nirspec_opt_err_array.tpn
 include nirspec_dq_array.tpn
 include nir_dq_def_array.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_readnoise.tpn
+++ b/crds/jwst/tpns/nirspec_readnoise.tpn
@@ -6,3 +6,5 @@ BUNIT    H   C    W   DN,ADU
 
 SCI    A    X    R   (len(SCI_ARRAY.SHAPE)==2)
 
+META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+

--- a/crds/jwst/tpns/nirspec_readnoise.tpn
+++ b/crds/jwst/tpns/nirspec_readnoise.tpn
@@ -6,5 +6,5 @@ BUNIT    H   C    W   DN,ADU
 
 SCI    A    X    R   (len(SCI_ARRAY.SHAPE)==2)
 
-META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0
 

--- a/crds/jwst/tpns/nirspec_saturation.tpn
+++ b/crds/jwst/tpns/nirspec_saturation.tpn
@@ -7,4 +7,4 @@ include nir_dq_def_array.tpn
 SCI   A   X    R  (len(SCI_ARRAY.SHAPE)==2)
 DQ    A   X    R  (len(DQ_ARRAY.SHAPE)==2)
 
-META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_saturation.tpn
+++ b/crds/jwst/tpns/nirspec_saturation.tpn
@@ -7,4 +7,4 @@ include nir_dq_def_array.tpn
 SCI   A   X    R  (len(SCI_ARRAY.SHAPE)==2)
 DQ    A   X    R  (len(DQ_ARRAY.SHAPE)==2)
 
-META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_superbias.tpn
+++ b/crds/jwst/tpns/nirspec_superbias.tpn
@@ -1,3 +1,3 @@
 include nir_superbias_arrays.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0
+META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_superbias.tpn
+++ b/crds/jwst/tpns/nirspec_superbias.tpn
@@ -1,3 +1,3 @@
 include nir_superbias_arrays.tpn
 
-META.EXPOSURE.GAIN_FACT     H   C   R  1.0:10.0
+META.EXPOSURE.GAIN_FACT     H   C   W  1.0:10.0


### PR DESCRIPTION
Modified the NIRSPEC constraints for GAINFACT so that:

1. GAINFACT is required for the GAIN reftype
2. GAINFACT is recommended for documentation, with a warning when absent, for several other types
3. GAINFACT is a R (real)
4. The model path is META.EXPOSURE.GAIN_FACTOR