### PR TITLE
Increased verbosity level of two debug messages

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -703,7 +703,7 @@ def dump_references3(pipeline_context, baserefs=None, ignore_cache=False, raise_
     baserefs = list(baserefs)
     for refname in baserefs:
         if "NOT FOUND" in refname:
-            log.verbose("Skipping " + srepr(refname))
+            log.verbose("Skipping " + srepr(refname), verbosity=70)
             baserefs.remove(refname)
     baserefs = sorted(set(baserefs))
     return FileCacher(pipeline_context, ignore_cache, raise_exceptions).get_local_files(baserefs)
@@ -781,7 +781,7 @@ def _get_cache_filelist_and_report_errors(bestrefs):
             if "NOT FOUND" in refname:
                 if "n/a" in refname.lower():
                     log.verbose("Reference type", srepr(filetype),
-                                "NOT FOUND.  Skipping reference caching/download.")
+                                "NOT FOUND.  Skipping reference caching/download.", verbosity=70)
                 else:
                     last_error = CrdsLookupError("Error determining best reference for",
                                                  srepr(filetype), " = ", str(refname)[len("NOT FOUND"):])

--- a/crds/core/rmap.py
+++ b/crds/core/rmap.py
@@ -829,10 +829,12 @@ class InstrumentContext(ContextMapping):
         if filekind not in self.selections:
             raise crexc.CrdsUnknownReftypeError("Unknown reference type", repr(filekind))
         if MappingSelectionsDict.is_na_value(self.selections[filekind]):
-            log.verbose("Reference type", repr(filekind), "is declared N/A at the instrument level for", repr(self.instrument))
+            log.verbose("Reference type", repr(filekind),
+                        "is declared N/A at the instrument level for", repr(self.instrument), verbosity=70)
             raise crexc.IrrelevantReferenceTypeError("Type", repr(filekind), "is N/A for", repr(self.instrument))
         if  MappingSelectionsDict.is_omit_value(self.selections[filekind]):
-            log.verbose("Reference type", repr(filekind), "is omitted at the instrument level for", repr(self.instrument))
+            log.verbose("Reference type", repr(filekind),
+                        "is omitted at the instrument level for", repr(self.instrument), verbosity=70)
             raise crexc.OmitReferenceTypeError("Type", repr(filekind), "is OMITTED for", repr(self.instrument))
         return self.selections[filekind]
 


### PR DESCRIPTION
Simplifies/removes logging for CRDS for DMS CAL runs for:
1. Message for reference type defined as N/A at instrument level
2. Message for skipping NOT FOUND reference file downloads