### PR TITLE
Restored fitsverify checksum warnings as CRDS errors

### DIFF
--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -563,8 +563,9 @@ class FitsCertifier(ReferenceCertifier):
 # -------------------------------------------------------------------------------------------------
 
 RECATEGORIZED_MESSAGE = {
-     'Unregistered XTENSION value' : log.info,
-     'checksum is not' : log.error,
+    'Unregistered XTENSION value' : log.info,
+    'checksum is not' : log.error,
+    'Invalid CHECKSUM' : log.error,
      }
 
 def interpret_fitsverify_output(status, output):


### PR DESCRIPTION
Changes to the fitsverify warning output broke the mapping in CRDS to from fitsverify warnings to CRDS ERROR messages that block deliveries.  This updates CRDS for the revised fitsverify warning message text.