### PR TITLE
Updates for system crdscfg references, CRDS repro required types

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -21,7 +21,7 @@ sources:
 
 - $CRDS_TEST_ROOT/crds-cache-test           
   Dirty test cache with corrupted/hacked files, used by tests only.
-  Has the dangerous property of like-named files with different contents.
+  Has the dangerous property of like-named files (same as official names) with different contents.
 
 - $CRDS_TEST_ROOT/crds-cache-default-test    
   Used when CRDS_PATH not set,  replaces /grp/crds/cache with minimal reference files for testing
@@ -34,3 +34,29 @@ sources:
   Ad hoc test data files used with explicit paths
   CRDS/crds/test/data is normally omitted from source code distributions.
 
+Notes on crds-cache-default-test bootstrap file CRDS server setup:
+
+      This cache is initialized by setup_test_cache by first downloading a
+      bootstrap file from the HST OPS server.  Without the bootstrap file, the
+      cache setup for this will still occur normally but takes considerably
+      longer due to downloading files one-by-one.
+
+      The crds-cache-default-test download file, crds-cache-default-test.tar.bz2,
+      is constructed from the built-the-hard-way cache like this:
+
+      $ cd $CRDS_TEST_ROOT
+      $ tar jcf crds-cache-default-test.tar.bz2 crds-cache-default-test
+
+      The resulting bzip2 file is copied to the HST OPS VM at the
+      $CRDS/CRDS_server/sources/static directory where the source code of all the other
+      server static files resides.  This will cause it to be re-installed in the Apache
+      static directory whenever the server is re-installed.   Merely placing the bzip2
+      file in the Apache static directory will result in a file life expectancy of 1 day,
+      since it is continually deleted and reinitialized in the final installation dir.
+
+Other notes:
+
+      As files are added to CRDS,  a developer's test caches need to be continually updated
+      or unit test errors will occur.   This makes periodically re-running setup_test_cache
+      a requirement...  which is one reason optimizing the crds-cache-default-test setup
+      time is desirable.

--- a/crds/jwst/gen_system_crdscfg.py
+++ b/crds/jwst/gen_system_crdscfg.py
@@ -29,6 +29,7 @@ from jwst.stpipe import cmdline as jwst_cmdline
 
 # ----------------------------------------------------------------------------------------------
 
+import crds
 from crds.core import log, exceptions, utils, timestamp
 from crds.core.log import srepr
 
@@ -70,10 +71,13 @@ class CrdsCfgGenerator(object):
         """
         input_body = []
         for line in self.input_yaml.splitlines():
-            if line.strip().startswith("calibration_software_version:"):
+            line2 = line.strip()
+            if line2.startswith("calibration_software_version:"):
                 input_body += ["    calibration_software_version: " + CAL_VER]
-            elif line.strip().startswith("generation_date:"):
+            elif line2.startswith("generation_date:"):
                 input_body += ["    generation_date: " + GENERATION_DATE]
+            elif line2.startswith("crds_version:"):
+                input_body += ["    crds_version: " + crds.__version__]
             else:
                 input_body += [line]
         return "\n".join(input_body).split(REFERENCE_DIVIDER)[0] + "\n" + REFERENCE_DIVIDER + "\n"

--- a/crds/jwst/gen_system_crdscfg.py
+++ b/crds/jwst/gen_system_crdscfg.py
@@ -133,7 +133,7 @@ class CrdsCfgGenerator(object):
                 for exptype_pattern in exptypes:
                     if glob_match(exptype_pattern, exp_type):
                         return [pipeline]
-        log.error("Unhandled EXP_TYPE", srepr(exp_type))
+        log.error("Unhandled EXP_TYPE", srepr(exp_type), "for", srepr(level))
         return []
     
         # raise exceptions.CrdsPipelineCfgDeterminationError("Unhandled EXP_TYPE", srepr(exp_type))

--- a/crds/jwst/jwst_system_crdscfg_b7.1.1.yaml
+++ b/crds/jwst/jwst_system_crdscfg_b7.1.1.yaml
@@ -102,7 +102,7 @@ level_pipeline_exptypes:
                              FGS_IMAGE, FGS_FOCUS]
 
         - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NRS_AUTOWAVE, FGS_ACQ1, FGS_ACQ2,
-                        FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK]
+                        FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK, NIS_EXTCAL]
 
 # ----------------------------------------------------------------------------------------------
 #

--- a/crds/jwst/jwst_system_crdscfg_b7.1.1.yaml
+++ b/crds/jwst/jwst_system_crdscfg_b7.1.1.yaml
@@ -44,7 +44,7 @@ meta:
 # ----------------------------------------------------------------------------------------------
 
 pipeline_cfgs: [calwebb_dark.cfg, calwebb_detector1.cfg, calwebb_spec2.cfg, calwebb_image2.cfg,
-               calwebb_guider.cfg]
+                calwebb_guider.cfg, calwebb_tso1.cfg]
 
 # ----------------------------------------------------------------------------------------------
 # MANUAL UPDATE REQUIRED
@@ -57,7 +57,7 @@ exp_types: [FGS_ACQ1, FGS_ACQ2, FGS_DARK, FGS_FINEGUIDE, FGS_FOCUS,
               FGS_ID-IMAGE, FGS_ID-STACK, FGS_IMAGE, FGS_INTFLAT, FGS_SKYFLAT, FGS_TRACK,
               MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_LRS-FIXEDSLIT,
               MIR_LRS-SLITLESS, MIR_MRS, MIR_DARK, MIR_FLAT-IMAGE, MIR_FLATIMAGE,
-              MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK,
+              MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK, NIS_EXTCAL,
               NIS_FOCUS, NIS_IMAGE, NIS_LAMP, NIS_SOSS, NIS_TACQ, NIS_TACONFIRM,
               NIS_WFSS, NRC_IMAGE, NRC_GRISM, NRC_TACQ, NRC_CORON,
               NRC_FOCUS, NRC_DARK, NRC_FLAT, NRC_LED, NRC_WFSC, NRC_TACONFIRM,
@@ -86,11 +86,13 @@ level_pipeline_exptypes:
 
         - calwebb_guider.cfg: [FGS_ID-STACK, FGS_ID-IMAGE, FGS_ACQ1, FGS_ACQ2, FGS_TRACK, FGS_FINEGUIDE]
 
+        - calwebb_tso1.cfg: [MIRI_LRS-SLITLESS, NIS_SOSS, NRC_TSIMAGE, NRC_TSGRISM, NRS_BRIGHTOBJ]
+
         - calwebb_detector1.cfg: ["*"]
 
     level2b:
         - calwebb_spec2.cfg: [MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, MIR_MRS, NRS_FIXEDSLIT, 
-                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE, NIS_SOSS,
+                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE, NIS_SOSS, NIS_WFSS,
                              NRC_GRISM, NRC_TSGRISM]
 
         - calwebb_image2.cfg: [NRC_IMAGE, NRC_TACQ, NRC_CORON, NRC_FOCUS, NRC_WFSC, NRC_TACONFIRM, NRC_TSIMAGE,
@@ -99,7 +101,7 @@ level_pipeline_exptypes:
                              NRS_IMAGE, NRS_FOCUS, NRS_MIMF, NRS_BOTA, NRS_TACQ, NRS_TASLIT, NRS_TACONFIRM, NRS_CONFIRM,
                              FGS_IMAGE, FGS_FOCUS]
 
-        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NIS_WFSS, NRS_AUTOWAVE,  FGS_ACQ1, FGS_ACQ2,
+        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NRS_AUTOWAVE, FGS_ACQ1, FGS_ACQ2,
                         FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK]
 
 # ----------------------------------------------------------------------------------------------

--- a/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
+++ b/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
@@ -1,0 +1,467 @@
+#
+# This reference is used by the CRDS reprocessing recommendation system to define: 
+#
+# 1. The calibration code pipelines (.cfg files) nominally used for each EXP_TYPE for 
+# applicable levels of data.
+#
+# 2. The reference types required to process each EXP_TYPE.
+# 
+# This file contains a combination of MANUAL inputs used by the generation algorithms
+# to create the fields used at runtime:  exptypes_to_pipelines and exptypes_to_reftypes.
+#
+# Regeneration is performed by updating the MANUAL sections of a reference file
+# and installing applicable calibration code and then doing:
+#
+# $ python -m crds.jwst.gen_system_crdscfg  old_reference.yaml  > new_reference.yaml
+#
+# The update concept is to take the last good reference,  modify the MANUAL inputs
+# as appropriate,  then do the above to complete the regeneration process.
+#
+# HOWEVER:  If at some stage it becomes difficult to regenerate automatically,  the only
+# fields used functionally for reprocessing are exptypes_to_pipelines and exptypes_to_reftypes.
+# Thus it should be possible to substitute direct edits to those fields for automatic generation
+# if automatic generation becomes problematic.
+#
+
+meta:
+    author: CRDS
+    description: "Used to determine cal code pipeline sequences and reference types for CRDS reprocessing."
+    history: "Generated from calibration code .cfg files and EXP_TYPE/LEVEL mapping."
+    instrument: SYSTEM
+    pedigree: GROUND
+    reftype: CRDSCFG
+    telescope: JWST
+    useafter: 1900-01-01T00:00:00
+    calibration_software_version: 0.9.2
+    crds_version: 7.2.2
+    generation_date: 2018-04-16T14:14:11
+
+# ----------------------------------------------------------------------------------------------
+# MANUAL UPDATE REQUIRED
+#
+# Exhastive list of pipeline .cfg's to process for steps and reftypes during generation.
+#
+# ----------------------------------------------------------------------------------------------
+
+pipeline_cfgs: [calwebb_dark.cfg, calwebb_detector1.cfg, calwebb_spec2.cfg, calwebb_image2.cfg,
+               calwebb_guider.cfg]
+
+# ----------------------------------------------------------------------------------------------
+# MANUAL UPDATE REQUIRED
+#
+# Exhastive list of exp_type values
+#
+# ----------------------------------------------------------------------------------------------
+
+exp_types: [FGS_ACQ1, FGS_ACQ2, FGS_DARK, FGS_FINEGUIDE, FGS_FOCUS,
+              FGS_ID-IMAGE, FGS_ID-STACK, FGS_IMAGE, FGS_INTFLAT, FGS_SKYFLAT, FGS_TRACK,
+              MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_LRS-FIXEDSLIT,
+              MIR_LRS-SLITLESS, MIR_MRS, MIR_DARK, MIR_FLAT-IMAGE, MIR_FLATIMAGE,
+              MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK,
+              NIS_FOCUS, NIS_IMAGE, NIS_LAMP, NIS_SOSS, NIS_TACQ, NIS_TACONFIRM,
+              NIS_WFSS, NRC_IMAGE, NRC_GRISM, NRC_TACQ, NRC_CORON,
+              NRC_FOCUS, NRC_DARK, NRC_FLAT, NRC_LED, NRC_WFSC, NRC_TACONFIRM,
+              NRC_TSIMAGE, NRC_TSGRISM, NRS_AUTOFLAT, NRS_AUTOWAVE, NRS_BOTA,
+              NRS_BRIGHTOBJ, NRS_CONFIRM, NRS_DARK, NRS_FIXEDSLIT, NRS_FOCUS,
+              NRS_IFU, NRS_IMAGE, NRS_LAMP, NRS_MIMF, NRS_MSASPEC, NRS_TACONFIRM,
+              NRS_TACQ, NRS_TASLIT]
+
+# ----------------------------------------------------------------------------------------------
+# MANUAL UPDATE REQUIRED
+#
+# Order is important since the first pattern matching an exp_type in any given level wins.
+#
+# For each level, CRDS searches for a matching EXP_TYPE using glob matching,  searching
+# in order from top to bottom, using the first match only.   Each level will contribute one 
+# .cfg for a given EXP_TYPE.
+#
+# skip_2b.cfg is a placeholder with no steps.
+# ----------------------------------------------------------------------------------------------
+
+levels: [ level2a, level2b]
+
+level_pipeline_exptypes:
+    level2a:
+        - calwebb_dark.cfg: [FGS_DARK, MIR_DARK, NRC_DARK, NIS_DARK, NRS_DARK]
+
+        - calwebb_guider.cfg: [FGS_ID-STACK, FGS_ID-IMAGE, FGS_ACQ1, FGS_ACQ2, FGS_TRACK, FGS_FINEGUIDE]
+
+        - calwebb_detector1.cfg: ["*"]
+
+    level2b:
+        - calwebb_spec2.cfg: [MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, MIR_MRS, NRS_FIXEDSLIT, 
+                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE, NIS_SOSS,
+                             NRC_GRISM, NRC_TSGRISM]
+
+        - calwebb_image2.cfg: [NRC_IMAGE, NRC_TACQ, NRC_CORON, NRC_FOCUS, NRC_WFSC, NRC_TACONFIRM, NRC_TSIMAGE,
+                             MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_CORONCAL,
+                             NIS_IMAGE, NIS_FOCUS, NIS_AMI, NIS_TACQ, NIS_TACONFIRM, 
+                             NRS_IMAGE, NRS_FOCUS, NRS_MIMF, NRS_BOTA, NRS_TACQ, NRS_TASLIT, NRS_TACONFIRM, NRS_CONFIRM,
+                             FGS_IMAGE, FGS_FOCUS]
+
+        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NIS_WFSS, NRS_AUTOWAVE,  FGS_ACQ1, FGS_ACQ2,
+                        FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK]
+
+# ----------------------------------------------------------------------------------------------
+#
+# MANUAL UPDATE REQUIRED
+#
+# This section defines types for exceptional steps that do not use all of their defined types 
+# depending on EXP_TYPE.
+#
+# CRDS searches the cases top-to-bottom looking for an EXP_TYPE that glob-matches and 
+# returns the first match.  The return value is used instead of the value from steps_to_reftypes.
+#
+# ----------------------------------------------------------------------------------------------
+
+steps_to_reftypes_exceptions: []
+    # flat_field:
+        # - case1:
+        #     exp_types: [NRS_FIXEDSLIT, NRS_IFU, NRS_MSASPEC, NRS_BRIGHTOBJ]
+        #    reftypes: [dflat, fflat, sflat]
+        # - case2:
+        #     exp_types: ["NRS_*"]
+        #     reftypes: [flat, dflat, fflat,  sflat]
+        # - case3:
+        #     exp_types: ["*"]
+        #     reftypes: [flat]
+
+# ----------------------------------------------------------------------------------------------
+#
+# AUTOMATICALLY GENERATED (or... was anyway) from here down
+#
+# This section defines mappings generated by reflecting on the JWST cal code distribution
+#
+# ----------------------------------------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# vvvvvvvv GENERATED vvvvvvvv
+pipeline_cfgs_to_steps:
+  calwebb_dark.cfg: [dq_init, group_scale, ipc, lastframe, linearity, refpix, rscd,
+    saturation, superbias]
+  calwebb_detector1.cfg: [dark_current, dq_init, firstframe, gain_scale, group_scale,
+    ipc, jump, lastframe, linearity, persistence, ramp_fit, refpix, rscd, saturation,
+    superbias]
+  calwebb_guider.cfg: [dq_init, flat_field, guider_cds]
+  calwebb_image2.cfg: [assign_wcs, bkg_subtract, flat_field, photom, resample]
+  calwebb_spec2.cfg: [assign_wcs, barshadow, bkg_subtract, cube_build, extract_1d,
+    extract_2d, flat_field, fringe, imprint_subtract, msa_flagging, pathloss, photom,
+    resample_spec, srctype, straylight]
+  skip_2b.cfg: []
+
+steps_to_reftypes:
+  assign_wcs: [camera, collimator, disperser, distortion, filteroffset, fore, fpa,
+    ifufore, ifupost, ifuslicer, msa, ote, regions, specwcs, wavelengthrange]
+  barshadow: [barshadow]
+  bkg_subtract: []
+  cube_build: [cubepar, resol]
+  dark_current: [dark]
+  dq_init: [mask]
+  extract_1d: [extract1d]
+  extract_2d: [wavecorr, wavelengthrange]
+  firstframe: []
+  flat_field: [dflat, fflat, flat, sflat]
+  fringe: [fringe]
+  gain_scale: [gain]
+  group_scale: []
+  guider_cds: []
+  imprint_subtract: []
+  ipc: [ipc]
+  jump: [gain, readnoise]
+  lastframe: []
+  linearity: [linearity]
+  msa_flagging: [msaoper]
+  pathloss: [pathloss]
+  persistence: [persat, trapdensity, trappars]
+  photom: [area, photom]
+  ramp_fit: [gain, readnoise]
+  refpix: [refpix]
+  resample: [drizpars]
+  resample_spec: [drizpars]
+  rscd: [rscd]
+  saturation: [saturation]
+  srctype: []
+  straylight: [regions, straymask]
+  superbias: [superbias]
+
+exptypes_to_pipelines:
+  FGS_ACQ1: [calwebb_guider.cfg, skip_2b.cfg]
+  FGS_ACQ2: [calwebb_guider.cfg, skip_2b.cfg]
+  FGS_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  FGS_FINEGUIDE: [calwebb_guider.cfg, skip_2b.cfg]
+  FGS_FOCUS: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  FGS_ID-IMAGE: [calwebb_guider.cfg, skip_2b.cfg]
+  FGS_ID-STACK: [calwebb_guider.cfg, skip_2b.cfg]
+  FGS_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  FGS_INTFLAT: [calwebb_detector1.cfg, skip_2b.cfg]
+  FGS_SKYFLAT: [calwebb_detector1.cfg, skip_2b.cfg]
+  FGS_TRACK: [calwebb_guider.cfg, skip_2b.cfg]
+  MIR_4QPM: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  MIR_CORONCAL: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  MIR_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  MIR_FLAT-IMAGE: [calwebb_detector1.cfg, skip_2b.cfg]
+  MIR_FLAT-MRS: [calwebb_detector1.cfg, skip_2b.cfg]
+  MIR_FLATIMAGE: [calwebb_detector1.cfg, skip_2b.cfg]
+  MIR_FLATMRS: [calwebb_detector1.cfg, skip_2b.cfg]
+  MIR_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  MIR_LRS-FIXEDSLIT: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  MIR_LRS-SLITLESS: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  MIR_LYOT: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  MIR_MRS: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  MIR_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_AMI: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  NIS_FOCUS: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_LAMP: [calwebb_detector1.cfg, skip_2b.cfg]
+  NIS_SOSS: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NIS_TACONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NIS_WFSS: [calwebb_detector1.cfg, skip_2b.cfg]
+  NRC_CORON: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  NRC_FLAT: [calwebb_detector1.cfg, skip_2b.cfg]
+  NRC_FOCUS: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_GRISM: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRC_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_LED: [calwebb_detector1.cfg, skip_2b.cfg]
+  NRC_TACONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_TSGRISM: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRC_TSIMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_WFSC: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_AUTOFLAT: [calwebb_detector1.cfg, skip_2b.cfg]
+  NRS_AUTOWAVE: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_BOTA: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_BRIGHTOBJ: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_CONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  NRS_FIXEDSLIT: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_FOCUS: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_IFU: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_LAMP: [calwebb_detector1.cfg, skip_2b.cfg]
+  NRS_MIMF: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_MSASPEC: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_TACONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRS_TASLIT: [calwebb_detector1.cfg, calwebb_image2.cfg]
+
+exptypes_to_reftypes:
+  FGS_ACQ1: [dflat, fflat, flat, mask, sflat]
+  FGS_ACQ2: [dflat, fflat, flat, mask, sflat]
+  FGS_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  FGS_FINEGUIDE: [dflat, fflat, flat, mask, sflat]
+  FGS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  FGS_ID-IMAGE: [dflat, fflat, flat, mask, sflat]
+  FGS_ID-STACK: [dflat, fflat, flat, mask, sflat]
+  FGS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  FGS_INTFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  FGS_SKYFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  FGS_TRACK: [dflat, fflat, flat, mask, sflat]
+  MIR_4QPM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  MIR_CORONCAL: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  MIR_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  MIR_FLAT-IMAGE: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  MIR_FLAT-MRS: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  MIR_FLATIMAGE: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  MIR_FLATMRS: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  MIR_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  MIR_LRS-FIXEDSLIT: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  MIR_LRS-SLITLESS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  MIR_LYOT: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  MIR_MRS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  MIR_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_AMI: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  NIS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_LAMP: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
+    superbias, trapdensity, trappars]
+  NIS_SOSS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NIS_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NIS_WFSS: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
+    superbias, trapdensity, trappars]
+  NRC_CORON: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  NRC_FLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
+    superbias, trapdensity, trappars]
+  NRC_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_GRISM: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRC_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_LED: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
+    superbias, trapdensity, trappars]
+  NRC_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_TSGRISM: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRC_TSIMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRC_WFSC: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_AUTOFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
+  NRS_AUTOWAVE: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRS_BOTA: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_BRIGHTOBJ: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRS_CONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  NRS_FIXEDSLIT: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_IFU: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_LAMP: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
+    superbias, trapdensity, trappars]
+  NRS_MIMF: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_MSASPEC: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+  NRS_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+  NRS_TASLIT: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
+    fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
+    linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+
+

--- a/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
+++ b/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
@@ -33,8 +33,8 @@ meta:
     telescope: JWST
     useafter: 1900-01-01T00:00:00
     calibration_software_version: 0.9.3
-    crds_version: 7.1.5
-    generation_date: 2018-04-27T10:38:25
+    crds_version: 7.2.2
+    generation_date: 2018-04-27T11:15:27
 
 # ----------------------------------------------------------------------------------------------
 # MANUAL UPDATE REQUIRED

--- a/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
+++ b/crds/jwst/jwst_system_crdscfg_b7.1.3.yaml
@@ -32,9 +32,9 @@ meta:
     reftype: CRDSCFG
     telescope: JWST
     useafter: 1900-01-01T00:00:00
-    calibration_software_version: 0.9.2
-    crds_version: 7.2.2
-    generation_date: 2018-04-16T14:14:11
+    calibration_software_version: 0.9.3
+    crds_version: 7.1.5
+    generation_date: 2018-04-27T10:38:25
 
 # ----------------------------------------------------------------------------------------------
 # MANUAL UPDATE REQUIRED
@@ -44,7 +44,7 @@ meta:
 # ----------------------------------------------------------------------------------------------
 
 pipeline_cfgs: [calwebb_dark.cfg, calwebb_detector1.cfg, calwebb_spec2.cfg, calwebb_image2.cfg,
-               calwebb_guider.cfg]
+                calwebb_guider.cfg, calwebb_tso1.cfg]
 
 # ----------------------------------------------------------------------------------------------
 # MANUAL UPDATE REQUIRED
@@ -57,7 +57,7 @@ exp_types: [FGS_ACQ1, FGS_ACQ2, FGS_DARK, FGS_FINEGUIDE, FGS_FOCUS,
               FGS_ID-IMAGE, FGS_ID-STACK, FGS_IMAGE, FGS_INTFLAT, FGS_SKYFLAT, FGS_TRACK,
               MIR_IMAGE, MIR_TACQ, MIR_LYOT, MIR_4QPM, MIR_LRS-FIXEDSLIT,
               MIR_LRS-SLITLESS, MIR_MRS, MIR_DARK, MIR_FLAT-IMAGE, MIR_FLATIMAGE,
-              MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK,
+              MIR_FLAT-MRS, MIR_FLATMRS, MIR_CORONCAL, NIS_AMI, NIS_DARK, NIS_EXTCAL,
               NIS_FOCUS, NIS_IMAGE, NIS_LAMP, NIS_SOSS, NIS_TACQ, NIS_TACONFIRM,
               NIS_WFSS, NRC_IMAGE, NRC_GRISM, NRC_TACQ, NRC_CORON,
               NRC_FOCUS, NRC_DARK, NRC_FLAT, NRC_LED, NRC_WFSC, NRC_TACONFIRM,
@@ -86,11 +86,13 @@ level_pipeline_exptypes:
 
         - calwebb_guider.cfg: [FGS_ID-STACK, FGS_ID-IMAGE, FGS_ACQ1, FGS_ACQ2, FGS_TRACK, FGS_FINEGUIDE]
 
+        - calwebb_tso1.cfg: [MIRI_LRS-SLITLESS, NIS_SOSS, NRC_TSIMAGE, NRC_TSGRISM, NRS_BRIGHTOBJ]
+
         - calwebb_detector1.cfg: ["*"]
 
     level2b:
         - calwebb_spec2.cfg: [MIR_LRS-FIXEDSLIT, MIR_LRS-SLITLESS, MIR_MRS, NRS_FIXEDSLIT, 
-                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE, NIS_SOSS,
+                             NRS_MSASPEC, NRS_IFU, NRS_BRIGHTOBJ, NRS_AUTOWAVE, NIS_SOSS, NIS_WFSS,
                              NRC_GRISM, NRC_TSGRISM]
 
         - calwebb_image2.cfg: [NRC_IMAGE, NRC_TACQ, NRC_CORON, NRC_FOCUS, NRC_WFSC, NRC_TACONFIRM, NRC_TSIMAGE,
@@ -99,8 +101,8 @@ level_pipeline_exptypes:
                              NRS_IMAGE, NRS_FOCUS, NRS_MIMF, NRS_BOTA, NRS_TACQ, NRS_TASLIT, NRS_TACONFIRM, NRS_CONFIRM,
                              FGS_IMAGE, FGS_FOCUS]
 
-        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NIS_WFSS, NRS_AUTOWAVE,  FGS_ACQ1, FGS_ACQ2,
-                        FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK]
+        - skip_2b.cfg: ["*DARK*", "*FLAT*", "*LED*", "*LAMP*", NRS_AUTOWAVE, FGS_ACQ1, FGS_ACQ2,
+                        FGS_FINEGUIDE, FGS_ID-IMAGE, FGS_ID-STACK, FGS_TRACK, NIS_EXTCAL]
 
 # ----------------------------------------------------------------------------------------------
 #
@@ -164,13 +166,15 @@ pipeline_cfgs_to_steps:
   calwebb_spec2.cfg: [assign_wcs, barshadow, bkg_subtract, cube_build, extract_1d,
     extract_2d, flat_field, fringe, imprint_subtract, msa_flagging, pathloss, photom,
     resample_spec, srctype, straylight]
+  calwebb_tso1.cfg: [dark_current, dq_init, firstframe, gain_scale, group_scale, ipc,
+    jump, lastframe, linearity, persistence, ramp_fit, refpix, rscd, saturation, superbias]
   skip_2b.cfg: []
 
 steps_to_reftypes:
   assign_wcs: [camera, collimator, disperser, distortion, filteroffset, fore, fpa,
     ifufore, ifupost, ifuslicer, msa, ote, regions, specwcs, wavelengthrange]
   barshadow: [barshadow]
-  bkg_subtract: []
+  bkg_subtract: [wavelengthrange, wfssbkg]
   cube_build: [cubepar, resol]
   dark_current: [dark]
   dq_init: [mask]
@@ -228,13 +232,14 @@ exptypes_to_pipelines:
   MIR_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NIS_AMI: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NIS_DARK: [calwebb_dark.cfg, skip_2b.cfg]
+  NIS_EXTCAL: [calwebb_detector1.cfg, skip_2b.cfg]
   NIS_FOCUS: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NIS_IMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NIS_LAMP: [calwebb_detector1.cfg, skip_2b.cfg]
-  NIS_SOSS: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NIS_SOSS: [calwebb_tso1.cfg, calwebb_spec2.cfg]
   NIS_TACONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NIS_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
-  NIS_WFSS: [calwebb_detector1.cfg, skip_2b.cfg]
+  NIS_WFSS: [calwebb_detector1.cfg, calwebb_spec2.cfg]
   NRC_CORON: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NRC_DARK: [calwebb_dark.cfg, skip_2b.cfg]
   NRC_FLAT: [calwebb_detector1.cfg, skip_2b.cfg]
@@ -244,13 +249,13 @@ exptypes_to_pipelines:
   NRC_LED: [calwebb_detector1.cfg, skip_2b.cfg]
   NRC_TACONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NRC_TACQ: [calwebb_detector1.cfg, calwebb_image2.cfg]
-  NRC_TSGRISM: [calwebb_detector1.cfg, calwebb_spec2.cfg]
-  NRC_TSIMAGE: [calwebb_detector1.cfg, calwebb_image2.cfg]
+  NRC_TSGRISM: [calwebb_tso1.cfg, calwebb_spec2.cfg]
+  NRC_TSIMAGE: [calwebb_tso1.cfg, calwebb_image2.cfg]
   NRC_WFSC: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NRS_AUTOFLAT: [calwebb_detector1.cfg, skip_2b.cfg]
   NRS_AUTOWAVE: [calwebb_detector1.cfg, calwebb_spec2.cfg]
   NRS_BOTA: [calwebb_detector1.cfg, calwebb_image2.cfg]
-  NRS_BRIGHTOBJ: [calwebb_detector1.cfg, calwebb_spec2.cfg]
+  NRS_BRIGHTOBJ: [calwebb_tso1.cfg, calwebb_spec2.cfg]
   NRS_CONFIRM: [calwebb_detector1.cfg, calwebb_image2.cfg]
   NRS_DARK: [calwebb_dark.cfg, skip_2b.cfg]
   NRS_FIXEDSLIT: [calwebb_detector1.cfg, calwebb_spec2.cfg]
@@ -272,13 +277,13 @@ exptypes_to_reftypes:
   FGS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   FGS_ID-IMAGE: [dflat, fflat, flat, mask, sflat]
   FGS_ID-STACK: [dflat, fflat, flat, mask, sflat]
   FGS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   FGS_INTFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
     saturation, superbias, trapdensity, trappars]
   FGS_SKYFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
@@ -287,11 +292,11 @@ exptypes_to_reftypes:
   MIR_4QPM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   MIR_CORONCAL: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   MIR_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
   MIR_FLAT-IMAGE: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
     saturation, superbias, trapdensity, trappars]
@@ -304,164 +309,169 @@ exptypes_to_reftypes:
   MIR_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   MIR_LRS-FIXEDSLIT: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   MIR_LRS-SLITLESS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   MIR_LYOT: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   MIR_MRS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   MIR_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NIS_AMI: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NIS_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
+  NIS_EXTCAL: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
+    saturation, superbias, trapdensity, trappars]
   NIS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NIS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NIS_LAMP: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
     superbias, trapdensity, trappars]
   NIS_SOSS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NIS_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NIS_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
-  NIS_WFSS: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
-    superbias, trapdensity, trappars]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
+  NIS_WFSS: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
+    distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
+    gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
+    persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRC_CORON: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
   NRC_FLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
     superbias, trapdensity, trappars]
   NRC_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_GRISM: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRC_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_LED: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
     superbias, trapdensity, trappars]
   NRC_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_TSGRISM: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRC_TSIMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRC_WFSC: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_AUTOFLAT: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd,
     saturation, superbias, trapdensity, trappars]
   NRS_AUTOWAVE: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRS_BOTA: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_BRIGHTOBJ: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRS_CONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_DARK: [ipc, linearity, mask, refpix, rscd, saturation, superbias]
   NRS_FIXEDSLIT: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRS_FOCUS: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_IFU: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRS_IMAGE: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_LAMP: [dark, gain, ipc, linearity, mask, persat, readnoise, refpix, rscd, saturation,
     superbias, trapdensity, trappars]
   NRS_MIMF: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_MSASPEC: [area, barshadow, camera, collimator, cubepar, dark, dflat, disperser,
     distortion, drizpars, extract1d, fflat, filteroffset, flat, fore, fpa, fringe,
     gain, ifufore, ifupost, ifuslicer, ipc, linearity, mask, msa, msaoper, ote, pathloss,
     persat, photom, readnoise, refpix, regions, resol, rscd, saturation, sflat, specwcs,
-    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange]
+    straymask, superbias, trapdensity, trappars, wavecorr, wavelengthrange, wfssbkg]
   NRS_TACONFIRM: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_TACQ: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
   NRS_TASLIT: [area, camera, collimator, dark, dflat, disperser, distortion, drizpars,
     fflat, filteroffset, flat, fore, fpa, gain, ifufore, ifupost, ifuslicer, ipc,
     linearity, mask, msa, ote, persat, photom, readnoise, refpix, regions, rscd, saturation,
-    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange]
+    sflat, specwcs, superbias, trapdensity, trappars, wavelengthrange, wfssbkg]
 
 

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -42,6 +42,11 @@ True
 >>> _get_missing_context('jwst_0341.pmap')
 'jwst_0341.pmap'
 
+>>> os.path.basename(_get_config_refpath("jwst_0552.pmap", "0.9.3"))
+'jwst_system_crdscfg_b7.1.3.yaml'
+
+>>> os.path.basename(_get_config_refpath("jwst_0552.pmap", "0.9.7"))
+'jwst_system_crdscfg_b7.1.3.yaml'
 """
 
 from __future__ import print_function
@@ -174,6 +179,7 @@ REFPATHS = [
     ('0.7.7', "jwst_system_crdscfg_b7.yaml"),
     ('0.9.0', "jwst_system_crdscfg_b7.1.yaml"),
     ('0.9.1', "jwst_system_crdscfg_b7.1.1.yaml"),
+    ('0.9.3', "jwst_system_crdscfg_b7.1.3.yaml"),
     ('9.9.9', "jwst_system_crdscfg_b7.1.3.yaml"),   # latest backstop
 ]
     
@@ -182,7 +188,7 @@ def _get_config_refpath(context, cal_ver):
     SYSTEM CRDSCFG reference file, cache it, and return the file path.
     """
     i = 0
-    while i < len(REFPATHS) and cal_ver[:6] > REFPATHS[i][0]:
+    while i < len(REFPATHS) and cal_ver[:5] > REFPATHS[i][0]:
         i += 1
     refpath = os.path.join(HERE, REFPATHS[i][1])
     try:  # Use a normal try/except because exceptions are expected.

--- a/crds/jwst/pipeline.py
+++ b/crds/jwst/pipeline.py
@@ -80,14 +80,6 @@ def test_header(calver, exp_type):
 
 # --------------------------------------------------------------------------------------
 
-HERE = os.path.dirname(__file__) or "."
-
-SYSTEM_CRDSCFG_B7_PATH = os.path.join(HERE, "jwst_system_crdscfg_b7.yaml")
-SYSTEM_CRDSCFG_B7_1_PATH = os.path.join(HERE, "jwst_system_crdscfg_b7.1.yaml")
-SYSTEM_CRDSCFG_B7_1_1_PATH = os.path.join(HERE, "jwst_system_crdscfg_b7.1.1.yaml")
-
-# --------------------------------------------------------------------------------------
-
 def _get_missing_calver(cal_ver=None):
     """If `cal_ver` is None, return the calibration software version for 
     the installed version of calibration code.  Otherwise return `cal_ver`
@@ -174,18 +166,25 @@ def _load_refpath(context, refpath):
         crdscfg =  yaml.load(opened)
     return CrdsCfgManager(context, refpath, crdscfg)
 
+# --------------------------------------------------------------------------------------
+
+HERE = os.path.dirname(__file__) or "."
+
+REFPATHS = [
+    ('0.7.7', "jwst_system_crdscfg_b7.yaml"),
+    ('0.9.0', "jwst_system_crdscfg_b7.1.yaml"),
+    ('0.9.1', "jwst_system_crdscfg_b7.1.1.yaml"),
+    ('9.9.9', "jwst_system_crdscfg_b7.1.3.yaml"),   # latest backstop
+]
+    
 def _get_config_refpath(context, cal_ver):
     """Given CRDS `context` and calibration s/w version `cal_ver`,  identify the applicable
     SYSTEM CRDSCFG reference file, cache it, and return the file path.
     """
-    # default enables running if system calver is never delivered as reference file.
-    # and for B7 and earlier.
-    if cal_ver < '0.7.7':
-        refpath = SYSTEM_CRDSCFG_B7_PATH
-    elif cal_ver < '0.9.0':
-        refpath = SYSTEM_CRDSCFG_B7_1_PATH
-    else:
-        refpath = SYSTEM_CRDSCFG_B7_1_1_PATH        
+    i = 0
+    while i < len(REFPATHS) and cal_ver[:6] > REFPATHS[i][0]:
+        i += 1
+    refpath = os.path.join(HERE, REFPATHS[i][1])
     try:  # Use a normal try/except because exceptions are expected.
         header = {
             "META.INSTRUMENT.NAME" : "SYSTEM", 


### PR DESCRIPTION
This pull applies to CCD-39 and CCD-40,  tickets associated with updating CRDS repro required types handling for JWST B7.1.3.    Updates included consideration of the TSO pipeline and handling for NIS_WFSS,  as well as changes in CAL Step reference file usage in a few places.

This scheme remains a placeholder preceding the "better world" in which rmaps are smart enough that it is no longer needed.   For now,  it is feasible to update rapidly without CRDS deliveries,  but has the significant flaw that CAL and CRDS repro handle required REFTYPEs differently.

This pull also includes some unrelated docs on TEST cache maintenance.

The commit trail reflects some badly done git rebasing,  but manual review of the diffs looks good and unit tests pass.

