### PR TITLE
Sync retries and config options

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -652,7 +652,7 @@ class FileCacher(object):
         remote_info = self.info_map[filename]
         local_length = os.stat(localpath).st_size
         original_length = long(remote_info["size"])
-        if original_length != local_length:
+        if original_length != local_length and config.get_length_flag():
             raise CrdsDownloadError("downloaded file size " + str(local_length) +
                                     " does not match server size " + str(original_length))
         if not config.get_checksum_flag():

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -568,7 +568,6 @@ class FileCacher(object):
         except Exception as exc:
             self.remove_file(localpath)
             raise CrdsDownloadError("Error fetching data for " + srepr(name) + 
-                                    " from context " + srepr(self.pipeline_context) + 
                                     " at CRDS server " + srepr(get_crds_server()) + 
                                     " with mode " + srepr(config.get_download_mode()) +
                                     " : " + str(exc))

--- a/crds/client/proxy.py
+++ b/crds/client/proxy.py
@@ -44,8 +44,8 @@ def apply_with_retries(func, *pars, **keys):
         try:
             return func(*pars, **keys)
         except Exception as exc:
-            log.verbose("FAILED: Attempt", str(retry+1), "of", retries, "with:", str(exc))
-            log.verbose("FAILED: Waiting for", delay, "seconds before retrying")  # waits after total fail...
+            log.verbose_warning("FAILED: Attempt", str(retry+1), "of", retries, "with:", str(exc))
+            log.verbose_warning("FAILED: Waiting for", delay, "seconds before retrying")  # waits after total fail...
             time.sleep(delay)
             exc2 = exc
     raise exc2

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -286,23 +286,25 @@ class IntConfigItem(ConfigItem):
 
     >>> INT = IntConfigItem(
     ...             "CRDS_INT_ITEM", '57', "Test int config item")
-    >>> if INT:
+    >>> if INT.get():
     ...    print("True")
     ... else:
     ...    print("False")
     True
 
     >>> os.environ["CRDS_INT_ITEM"] = "0"
-    >>> if INT:
+    >>> if INT.get():
     ...    print("True")
     ... else:
     ...    print("False")
     False
 
     >>> INT.get()
-    57
+    0
+
     >>> INT.set("42")  # .set() returns old value
-    57
+    0
+
     >>> INT.get()
     42
     """
@@ -313,7 +315,7 @@ class IntConfigItem(ConfigItem):
 
     def get(self):
         """Return the bool value of this config item."""
-        return env_to_int(self.env_var, self.default)
+        return int(super(IntConfigItem,self).get())
 
     def set(self, val):
         """Set the bool value of this config item to `val`,  coercing to bool.  Return old value."""


### PR DESCRIPTION
Extended CRDS cache syncing download configuration options so they show up under "crds list --config" and also so it's possible to override sha1sum and file length failures which force immediate deletion of bad downloaded files.  These were needed to help troubleshoot bad files which were somehow delivered into the B-string archive while being correctly represented on the B-string CRDS server;  the discrepancy made them impossible to download normally,  env vars can now be set to keep bad files for debug purposes.
