### PR TITLE
Add sync file size check

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -127,7 +127,7 @@ def list_references(observatory=None, glob_pattern="*"):
     return [str(x) for x in S.list_references(observatory, glob_pattern)]
 
 def get_mapping_url(pipeline_context, mapping):
-    """Returns a URL for the specified pmap, imap, or rmap file.
+    """Returns a URL for the specified pmap, imap, or rmap file.   DEPRECATED
     """
     return S.get_mapping_url(pipeline_context, mapping)
 
@@ -147,13 +147,26 @@ def get_mapping_names(pipeline_context):
     return [str(x) for x in S.get_mapping_names(pipeline_context)]
 
 def get_reference_url(pipeline_context, reference):
-    """Returns a URL for the specified reference file.
+    """Returns a URL for the specified reference file.    DEPRECATED
     """
     return S.get_reference_url(pipeline_context, reference)
     
 def get_url(pipeline_context, filename):
-    """Return the URL for a CRDS reference or mapping file."""
+    """Return the URL for a CRDS reference or mapping file.   DEPRECATED"""
     return S.get_url(pipeline_context, filename)
+
+def get_root_url(filename):
+    """Based on the server info,  return the base URL the server indicates
+    should be used to download `filename`.
+    """
+    info = get_server_info()
+    if config.is_mapping(filename):
+        url = info["mapping_url"][self.observatory]
+    else:
+        url = info["reference_url"][self.observatory]
+    if not url.endswith("/"):
+            url += "/"
+    return url
 
 def get_file_info(pipeline_context, filename):
     """Return a dictionary of CRDS information about `filename`."""
@@ -637,14 +650,7 @@ class FileCacher(object):
 
     def get_url(self, filename):
         """Return the URL used to fetch `filename` of `pipeline_context`."""
-        info = get_server_info()
-        if config.is_mapping(filename):
-            url = info["mapping_url"][self.observatory]
-        else:
-            url = info["reference_url"][self.observatory]
-        if not url.endswith("/"):
-            url += "/"
-        return url + filename
+        return get_root_url(filename) + filename
 
     def verify_file(self, filename, localpath):
         """Check that the size and checksum of downloaded `filename` match the server."""

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -155,15 +155,17 @@ def get_url(pipeline_context, filename):
     """Return the URL for a CRDS reference or mapping file.   DEPRECATED"""
     return S.get_url(pipeline_context, filename)
 
-def get_root_url(filename):
+def get_root_url(filename, observatory=None):
     """Based on the server info,  return the base URL the server indicates
     should be used to download `filename`.
     """
+    if observatory is None:
+        observatory = get_default_observatory()
     info = get_server_info()
     if config.is_mapping(filename):
-        url = info["mapping_url"][self.observatory]
+        url = info["mapping_url"][observatory]
     else:
-        url = info["reference_url"][self.observatory]
+        url = info["reference_url"][observatory]
     if not url.endswith("/"):
             url += "/"
     return url
@@ -650,7 +652,7 @@ class FileCacher(object):
 
     def get_url(self, filename):
         """Return the URL used to fetch `filename` of `pipeline_context`."""
-        return get_root_url(filename) + filename
+        return get_root_url(filename, self.observatory) + filename
 
     def verify_file(self, filename, localpath):
         """Check that the size and checksum of downloaded `filename` match the server."""

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -603,8 +603,8 @@ class SyncScript(cmdline.ContextsScript):
         if int(info["size"]) != size:
             self.error_and_repair(path, "File", repr(base), "length mismatch LOCAL size=" + srepr(size), 
                                   "CRDS size=" + srepr(info["size"]))
-        elif self.args.check_sha1sum:
-            log.verbose("Computing checksum for", repr(base), "of size", repr(size), verbosity=100)
+        elif self.args.check_sha1sum or config.is_mapping(base):
+            log.verbose("Computing checksum for", repr(base), "of size", repr(size), verbosity=60)
             sha1sum = utils.checksum(path)
             if info["sha1sum"] == "none":
                 log.warning("CRDS doesn't know the checksum for", repr(base))
@@ -633,7 +633,7 @@ class SyncScript(cmdline.ContextsScript):
         """Issue an error message and repair `file` if requested by command line args."""
         log.error(*args, **keys)
         if self.args.repair_files:
-            if config.writable_cache_or_info("Skipping remove and dump of", repr(file)):
+            if config.writable_cache_or_info("Skipping remove and re-download of", repr(file)):
                 log.info("Repairing file", repr(file))
                 utils.remove(file, observatory=self.observatory)
                 self.dump_files(self.default_context, [file]) 

--- a/scripts/crds_repair_cache
+++ b/scripts/crds_repair_cache
@@ -2,7 +2,9 @@
 #
 # usage:
 #
-# % crds_repair_cache [--all | --last N | --range M:N | --up-to-context <ctx> | --after-context <ctx> | --files <specific files...>] [--readonly-cache] [--check-sha1sum] [--purge-references]
+# % crds_repair_cache [--all | --up-to-context <ctx>] [--readonly-cache] [--check-sha1sum] [--purge-references (with great care, see below)]
+#
+# --------------------------------------------------------------------------
 #
 # This script is one approach for refreshing a CRDS cache (most likely TEST
 # pipeline CRDS cache) to make it consistent with the CRDS server cache and
@@ -19,10 +21,10 @@
 #    to TEST with names identical to OPS.  The TEST pipeline CRDS cache will
 #    likewise diverge from the OPS pipeline CRDS cache.
 #
-# 3. At a later time, the CRDS TEST server is refreshed / rebaselined from OPS
-#    to support more current file regressions.  The TEST pipeline's CRDS cache
-#    is then out of sync with the CRDS TEST server, possibly with like named
-#    rules files with different contents and behavior.
+# 3. At a later time, the CRDS TEST server is refreshed / mirrored from OPS to
+#    support more current file regressions.  The TEST pipeline's CRDS cache is
+#    then out of sync with the CRDS TEST server, possibly with like named rules
+#    files with different contents and behavior.
 #
 # 4. This script is run to resynchronize the TEST pipeline's CRDS cache to match
 #    the current contents of the CRDS TEST server (and OPS server).
@@ -31,6 +33,15 @@
 #    to create appropriate default group permissions.  Users should nominally
 #    specify "umask 2" in their interactive shell to cause synced files to be
 #    created with user and group rwx permissions. 
+#
+# Without experimentation, the files/contexts should probably be selected using
+# --all which will guarantee considering all cached files.  Another untested
+# possibility would be to use --up-to-context <context> where <context> is
+# chosen as the last official context mirrored into the TEST string; this
+# should work well with --purge-mappings and --purge-references where the
+# selected contexts are used to define the files to *keep*, not purge.
+# --purge-references should be used with extreme care since it will wipe out
+# the references of every context which is *not* specified.
 #
 # --------------------------------------------------------------------------
 #
@@ -50,6 +61,14 @@ cron_sync --check-sha1sum --repair-files --purge-mappings $*
 # --check-sha1sum so it is possible that residual files from the last
 # TEST cycle will go uncorrected.
 
+# --purge-references is a potential command line option below, but considered
+# to be risky for large pipeline caches.  if specified, the actual repair
+# should be preceded by a dry run using --dry-run or --readonly-cache to get
+# some estimation of what CRDS is going to do before doing it.   Note that
+# if crds_repair_cache is run without an explicit context or file selection,
+# the context will default to the current operational context and when purging,
+# all archived references would be deleted.
+
 cron_sync --repair-files --fetch-references $*
 
 # 
@@ -57,9 +76,4 @@ cron_sync --repair-files --fetch-references $*
 # suspect files,  perhaps all mappings and config,  and then to resynchronize
 # using cron_sync.   The downside of this approach is that it maskes assumptions
 # about cache design and behavior
-#
-# Yet another approach is to use cron_sync only with respect to particular
-# reference files by specifying --files instead of --all or --last N.   This can
-# enable using --check-sha1sum on suspect references within a reasonable amount
-# of time.
 #

--- a/scripts/cron_sync
+++ b/scripts/cron_sync
@@ -2,7 +2,7 @@
 
 # usage:  cron_sync
 #
-#    options:  --check-files --check-sha1sum --fetch-references [context selection]
+#    options:  --check-sha1sum --fetch-references [context selection]
 #
 #    example context selections:
 #        nothing ==  hst-operational
@@ -10,29 +10,37 @@
 #        --last 20
 #        --all
 #
+#   nominal extra switches:    --all --fetch-references --verbose
+#
 #   requires:  
 #        CRDS_PATH        (cache directory)
 #        CRDS_SERVER_URL  (server synced from)
 #        CRDS_LOCKS       (locks directory)
 #
-# This script is intended to be run in a cron job at a relatively high
-# rate, say once every 30 minutes.  
+# The cron_sync script wraps the crds sync tool with a file lock designed to
+# keep multiple cron_sync jobs from updating a CRDS cache at the same time.  It
+# was designed as a cron job, but based on conservative pipeline operations, is
+# run manually in the pipeline by an operator.  cron_sync is further wrapped in
+# the pipeline with shim shell script to configure the environment and Python
+# stack.
 #
-# The contexts which are selected for syncing should be a sufficiently large recent
-# group of contexts that cron_sync is guaranteed to be run between the last and any
-# other preceding context in the group,  i.e.  Set Context is called twice for that
-# group of contexts,  guaranteeing that no new files are missed.   --all is the safest
-# absolute setting but becomes slower as more contexts are created.   --last 20 seemed
-# like a good fixed lenth worst case setting which has constant run time.
+# The fundamental task performed by CRDS syncs is to download new rules and
+# reference files to a local cache.  CRDS sync further maintains a few cached
+# configuration properties like knowledge of bad files and the default
+# contexts.  Because deliveries can range up to 50G of files (at this time),
+# downloads can take lengthy intervals and can exceed the period of a
+# reasonable cron job...  creating the need to block concurrent syncs with the
+# lock.  A cron_sync which fails to obtain the lock just exits.
 #
 # --fetch-references is required to download references to the CRDS cache.
 # Omitting --fetch-references, rapid --check-sha1sum is possible for only the
-# selected contexts / rules, not all their references.  It is not uncommon for
-# different versions of rules to have different contents but identical lengths.
+# selected contexts / rules and not all their references.  It is not uncommon
+# for different versions of rules to have different contents but identical
+# lengths.
 #
-# --check-files is a good idea, it checks length, file status (bad file,
-# undelivered, etc) and file existence in cache.  --verbose, not mentioned,
-# is optional but will produce checking output for 20k+ files.
+# --check-files checks length, file status (bad file, undelivered, etc) and
+# file existence in cache.  --verbose, not mentioned, is optional but will
+# produce checking output for 20k+ files.
 #
 # --check-sha1sum is only suitable for periodic cache checks or without
 # --fetch-references, it requires around 8 hours to check all the references.
@@ -57,7 +65,12 @@ export CRDS_READONLY_CACHE=0
 # Use a plugin downloader,  defaults to wget
 export CRDS_DOWNLOAD_MODE=plugin
 
-#
+# For download errors, wait 10 seconds and try again, up to 60 times.
+# This is primarily designed to support 10 minute server outages without
+# sync failures.
+export CRDS_CLIENT_RETRY_COUNT=60
+export CRDS_CLIENT_RETRY_DELAY_SECONDS=10
+
 # CUSTOM PLUGINS: CRDS will run another program like this filling in for
 # ${SOURCE_URL} and ${OUTPUT_PATH}.  Use that syntax exactly.   You could
 # e.g. use axel instead of wget providing your own command line template.
@@ -65,6 +78,29 @@ export CRDS_DOWNLOAD_MODE=plugin
 # export CRDS_DOWNLOAD_PLUGIN="/usr/bin/wget --no-check-certificate --quiet ${SOURCE_URL}  -O ${OUTPUT_PATH}"
 #
 
+# -------------------------------------------------------------------------
+#
+# NOTE: to ensure atomic mutually supporting updates, multiple cache sync
+# operations should preformed inside a single locking critical region
+# implemented here.  In general, if an operational context is synced into the
+# pipeline, supporting reference files should be synced first to ensure that
+# they're available as soon as the pipeline starts using the new context.
+#
+# A potential pitfall in this regard would be to call cron_sync after updating
+# the operational context on the server but without --fetch-references.  In
+# that instance, CRDS will sync the required rules files but any new supporting
+# references will not be available in the pipeline CRDS cache.
+#
+# There are two work arounds for the pitfall:
+#
+# 1. Only run one sync, and use --fetch-references.  crds sync updates context last.
+#
+# 2. Do a pre-sync,  select a new context on the CRDS server,  do a post-sync.
+#
+# This customizable behavior is done this way to support downloading partial
+# sets of reference files (e.g. demand based on data) supported by complete
+# sets of mappings which are much faster to download or check.
+#
 # -------------------------------------------------------------------------
 ( flock --exclusive --nonblock 200 # --nonblock means fail on unavailable locks,  cron collision
 
@@ -74,13 +110,7 @@ export CRDS_DOWNLOAD_MODE=plugin
     exit 1
   else
      echo "cron_sync: INFO: obtained crds.sync.lock"
-    
-     # sync doesn't block bestrefs, syncs rules and references,  doesn't update context / config
-     export CRDS_CLIENT_RETRY_COUNT=60
-     export CRDS_CLIENT_RETRY_DELAY_SECONDS=10
-     # override pipeline global readonly setting.
-     export CRDS_READONLY_CACHE=0
-     crds sync $* --stats # nominally --last 10 --fetch-references
+     crds sync $* --check-files --stats # nominally --all --fetch-references --verbose
      exit $?
   fi
     
@@ -93,7 +123,7 @@ exit $status
 #   Summarizing overall design of sync + bestrefs in pipelines:
 #
 #   crds.sync.lock ensures that no two cron_syncs run concurrently.
-#
+#   cron_sync blocks other instances of itself
 #   cron_sync does not block bestrefs
 #   bestrefs does not block bestrefs
 #   sync transfers files then updates the config area last

--- a/scripts/pipeline_bestref
+++ b/scripts/pipeline_bestref
@@ -13,6 +13,8 @@ pysh.usage("""[-d] [-v] [-h] [--print-affected] <crds_context> <dataset_file(s)>
 -h                     help,  print this help
 --print-affected       print files with updated bestrefs
 
+NOTE:   DEPRECATED,  see safe_bestrefs instead
+
 Updates dataset FITS files with best references recommended by <crds_context>.
 
 <crds_context> is a CRDS context file, explicitly named e.g. hst_0004.pmap


### PR DESCRIPTION
Added --check-files back into cron_sync and added automatic mapping --check-sha1sum.  Automatic repairs are not implemented,  --repair-files and/or crds_repair_cache are still required as a hedge against pipeline disasters.