### PR TITLE
Fixed bug for rare rmap update case

### DIFF
--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -893,7 +893,7 @@ class Selector(object):
                 else:
                     log.verbose("Selector replaces terminal at", repr(key), "adding new selector.")
                     new_value = self._create_path(header, value, parkey[1:], classes[1:])
-                    self._add_item(old_key, new_value)
+                    self._replace_item(old_key, new_value)
         else:  # add or replace primitive result
             if i is None:
                 log.verbose("Modify couldn't find", repr(key), "adding new value", repr(value))


### PR DESCRIPTION
Rmap code doing updates replacing degenerate syntax 'N/A' with a nested UseAfter selector containing a real file was using add_item instead of replace_item.

