### PR TITLE
Added "import setuptools" to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import glob
 
 from distutils.core import setup
 
+import setuptools
+
 setup_pars = {
     "packages" : [
         'crds',


### PR DESCRIPTION
Eliminates warnings about install_requires, extras_require, tests_require.