### PR TITLE
Restore import setuptools,  Enable get_object() crds_server

### DIFF
--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -733,7 +733,7 @@ def organize_files(observatory, files):
 
 # ===================================================================
 
-MODULE_PATH_RE = re.compile(r"^crds(\.\w{1,64}){0,10}$")
+MODULE_PATH_RE = re.compile(r"^crds(_server)?(\.\w{1,64}){0,10}$")
 
 @cached
 def get_object(*args):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import glob
 
 from distutils.core import setup
 
+import setuptools
+
 setup_pars = {
     "packages" : [
         'crds',


### PR DESCRIPTION
Adding import setuptools caused problems with installing the crds.server sub-package.  Consequently,  the sub-package was moved to a standalone crds_server package.  The utils.get_object() function was modified to permit crds_server as a leading path.   These changes are required in lock step to support the renamed server package.
