### PR TITLE
Updated path handling for command line tools

### DIFF
--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -914,10 +914,9 @@ For more information on the checks being performed,  use --verbose or --verbosit
         
         cmdline.UniqueErrorsMixin.add_args(self)
         
-    # For files on the command line to default to normal UNIX syntax, no path is CWD,
-    # uncomment following statement.   Add crds:// for cache paths.
-
-    # locate_file = cmdline.Script.locate_file_outside_cache
+    # For files on the command line to default to normal UNIX syntax, no path
+    # is CWD, uncomment following statement.  Add crds:// for cache paths.
+    locate_file = cmdline.Script.locate_file_outside_cache
 
     def main(self):
         if self.args.deep:

--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -403,10 +403,14 @@ class Script:
         """
         filename2 = config.pop_crds_uri(filename)   # nominally crds://
         filename2 = self.resolve_context(filename2) # e.g. hst-operational -->  hst_0320.pmap
-        if filename != filename2:  # Had crds:// or was date based copnt
+        if filename != filename2:  # Had crds:// or was date based
             return config.locate_file(filename2, self.observatory)
         else:
-            return os.path.abspath(filename2)
+            if not os.path.dirname(filename2):
+                return "./" + filename2
+            else:
+                return filename2
+            # return os.path.abspath(filename2)
     
     def _profile(self):
         """Run _main() under the Python profiler."""

--- a/crds/diff.py
+++ b/crds/diff.py
@@ -806,6 +806,8 @@ Mutually Exclusive Modes
         self.old_file = None
         self.new_file = None
     
+    locate_file = cmdline.Script.locate_file_outside_cache
+    
     def add_args(self):
         """Add diff-specific command line parameters."""
         self.add_argument("old_file",  help="Prior file of difference.""")
@@ -859,8 +861,6 @@ Mutually Exclusive Modes
             help="Simplify formatting of difference results (remove tuple notations)")
         self.add_argument("-F", "--brief", dest="brief", action="store_true",
             help="Switch alias for --lowest-mapping-only --remove-paths --hide-boring-diffs --include-headers")
-
-    # locate_file = cmdline.Script.locate_file_outside_cache
 
     def main(self):
         """Perform the differencing."""

--- a/crds/refactoring/checksum.py
+++ b/crds/refactoring/checksum.py
@@ -112,6 +112,8 @@ class ChecksumScript(cmdline.Script):
     
     epilog = """    
     """
+
+    locate_file = cmdline.Script.locate_file_outside_cache
     
     def add_args(self):
         self.add_argument(

--- a/crds/rowdiff.py
+++ b/crds/rowdiff.py
@@ -912,13 +912,15 @@ class RowDiffScript(cmdline.Script):
                           help="List of fields to do a mode compare",
                           type=str)
 
+    locate_file = cmdline.Script.locate_file_outside_cache
+
     # Main program
     def main(self):
         """Perform the differencing"""
 
         # Get the path to the fits files.
-        tableA_path = rmap.locate_file(self.args.tableA, self.observatory)
-        tableB_path = rmap.locate_file(self.args.tableB, self.observatory)
+        tableA_path = self.locate_file(self.args.tableA)
+        tableB_path = self.locate_file(self.args.tableB)
 
         # Expand out the input field lists.
         fields = []

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -431,7 +431,7 @@ def certify_missing_keyword():
 
 def certify_recursive():
     """
-    >>> TestCertifyScript("crds.certify hst_cos.imap --exist --dont-parse")() # doctest: +ELLIPSIS
+    >>> TestCertifyScript("crds.certify crds://hst_cos.imap --exist --dont-parse")() # doctest: +ELLIPSIS
     CRDS - INFO -  Certification includes mappings but is not --deep, no --comparison-context is defined.
     CRDS - INFO - ########################################
     CRDS - INFO - Certifying '.../mappings/hst/hst_cos.imap' (1/19) as 'MAPPING' relative to context None
@@ -482,7 +482,7 @@ def certify_table_comparison_context():
     """
     >>> old_state = test_config.setup()
 
-    >>> TestCertifyScript("crds.certify y951738kl_hv.fits --comparison-context hst_0294.pmap")() # doctest: +ELLIPSIS
+    >>> TestCertifyScript("crds.certify crds://y951738kl_hv.fits --comparison-context hst_0294.pmap")() # doctest: +ELLIPSIS
     CRDS - INFO -  ########################################
     CRDS - INFO -  Certifying '.../references/hst/y951738kl_hv.fits' (1/1) as 'FITS' relative to context 'hst_0294.pmap'
     CRDS - INFO -  FITS file 'y951738kl_hv.fits' conforms to FITS standards.
@@ -585,7 +585,7 @@ def certify_comparison_context_none_all_references():
 
 def certify_comparison_context_none_all_mappings():
     """
-    >>> TestCertifyScript("crds.certify hst_cos_deadtab.rmap --comparison-context None")() # doctest: +ELLIPSIS
+    >>> TestCertifyScript("crds.certify crds://hst_cos_deadtab.rmap --comparison-context None")() # doctest: +ELLIPSIS
     CRDS - INFO -  Comparison context explicitly specified as 'none',  no --comparison-context will be used.
     CRDS - INFO - ########################################
     CRDS - INFO - Certifying '.../mappings/hst/hst_cos_deadtab.rmap' (1/1) as 'MAPPING' relative to context None

--- a/crds/tests/test_cmdline.py
+++ b/crds/tests/test_cmdline.py
@@ -283,7 +283,7 @@ class TestCmdline(test_config.CRDSTestCase):
     def test_file_outside_cache_pathless(self):
         s = Script("cmdline.Script")
         path = s.locate_file_outside_cache("hst_0001.pmap")
-        assert path.endswith('crds/tests/hst_0001.pmap'), path
+        assert path.endswith('./hst_0001.pmap'), path
 
     def test_file_outside_cache_uri(self):
         """Explicit crds:// notation for files inside cache."""

--- a/crds/tests/test_diff.py
+++ b/crds/tests/test_diff.py
@@ -581,7 +581,7 @@ def dt_diff_recurse_added_deleted_na():
     Changed two COS FLATFILE references to OMIT and N/A
 
     >>> old_state = test_config.setup()
-    >>> DiffScript("crds.diff hst.pmap data/hst.pmap --recurse-added-deleted")()  # doctest: +ELLIPSIS
+    >>> DiffScript("crds.diff crds://hst.pmap data/hst.pmap --recurse-added-deleted")()  # doctest: +ELLIPSIS
     (('.../mappings/hst/hst.pmap', 'data/hst.pmap'), ('hst_cos.imap',), 'data/hst_cos_twozxtab_0262.rmap', ('FUV', 'SPECTROSCOPIC', '3.0'), ('2009-05-11', '00:00:00'), 'added terminal z2d1925ql_2zx.fits')
     (('.../mappings/hst/hst.pmap', 'data/hst.pmap'), ('hst_cos.imap',), 'hst_cos_fluxtab.rmap', ('FUV', 'SPECTROSCOPIC'), ('1996-10-01', '00:00:00'), 'deleted terminal s7g1700kl_phot.fits')
     (('.../mappings/hst/hst.pmap', 'data/hst.pmap'), ('hst_cos.imap',), 'hst_cos_fluxtab.rmap', ('FUV', 'SPECTROSCOPIC'), ('2009-05-11', '00:00:00'), 'deleted terminal u8k1433ql_phot.fits')

--- a/crds/tests/test_uniqname.py
+++ b/crds/tests/test_uniqname.py
@@ -81,7 +81,7 @@ def dt_synphot_uniqname():
 
     >>> old_state = test_config.setup()
     >>> name = UniqnameScript("crds.misc.uniqname --dry-run --files data/16n1832tm_tmc.fits")()  # doctest: +ELLIPSIS
-    CRDS - INFO -  Would rename '.../data/16n1832tm_tmc.fits' --> '.../data/...m_tmc.fits'
+    CRDS - INFO -  Would rename 'data/16n1832tm_tmc.fits' --> 'data/...m_tmc.fits'
     >>> test_config.cleanup(old_state)
     """
 
@@ -91,7 +91,7 @@ def dt_cdbs_uniqname():
 
     >>> old_state = test_config.setup()
     >>> name = UniqnameScript("crds.misc.uniqname --standard --files data/s7g1700gl_dead.fits")()  # doctest: +ELLIPSIS
-    CRDS - INFO -  Rewriting '.../data/s7g1700gl_dead.fits' --> '.../data/..._dead.fits'
+    CRDS - INFO -  Rewriting 'data/s7g1700gl_dead.fits' --> 'data/..._dead.fits'
     >>> name1 = uniqname.uniqname(name)
     CRDS - INFO -  Rewriting '..._dead.fits' --> '..._dead.fits'
     >>> os.remove(name1)


### PR DESCRIPTION
Previously CRDS command line tools typically interpreted file names with no path to mean "the path is in the CRDS cache".   This reverts CRDS to normal UNIX semantics where a pathless file is intepreted to be in the current working directory.