### PR TITLE
Fixed bug in get_username() and get_password()

### DIFF
--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -782,7 +782,10 @@ def get_username(override=None):
             "CRDS_USERNAME", None, ini_section="authentication",
             comment="User's username on CRDS server, defaulting to current login.")
         # ultimately: override or env_var or ini_file or fallback function
-        USERNAME.set(override or USERNAME.get() or getpass.getuser())
+        username = override or USERNAME.get()
+        if username in ["None", "none", None]:
+            username = getpass.getuser()
+        USERNAME.set(username)
     return USERNAME.get()
 
 PASSWORD = None
@@ -799,7 +802,10 @@ def get_password(override=None):
             "CRDS_PASSWORD", None, ini_section="authentication",
             comment="User's password on CRDS server, defaulting to interactive echo-less entry.")
         # ultimately: override or env_var or ini_file or fallback function
-        PASSWORD.set(override or PASSWORD.get() or getpass.getpass())
+        password = override or PASSWORD.get()
+        if password in ["None", "none", None]:
+            password = getpass.getpass()
+        PASSWORD.set(password)
     return PASSWORD.get()
 
 # ===========================================================================


### PR DESCRIPTION
CRDS file submission has (theoretically) two ways of handling CRDS username + password:  (1) they can be recorded in the .crds.ini file (2) if not,  CRDS should prompt.   The prompt functionality was broken because None (False) was recorded as "None" (True) by the CRDS config code,  where "None" appeared to be the username or password value to the code.

This change restores the prompt which I think will be,  in some form,  critical once we switch to SSO:   The .crds.ini authentication configuration will need to be changed or phased out once usernames and passwords switch to AD/SSO.
