### PR TITLE
Simplified file submission copying and ingest directory setup

### DIFF
--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -580,9 +580,11 @@ def create_path(path, mode=DEFAULT_DIR_PERMS):
         if not os.path.exists(subdir):
             log.verbose("Creating", repr(subdir), "with permissions %o" % mode)
             os.mkdir(subdir, mode)
+            os.chmod(subdir, mode)
 
 def ensure_dir_exists(fullpath, mode=DEFAULT_DIR_PERMS):
-    """Creates dirs from `fullpath` if they don't already exist.
+    """Creates dirs from `fullpath` if they don't already exist.  fullpath
+    is assumed to include a filename which will not be created.
     """
     create_path(os.path.dirname(fullpath), mode)
 


### PR DESCRIPTION
Assumes the CRDS server ingest directory is directly visible to end users
on a local file system mount,  e.g. /grp/crds/ingest/jwst/ops/homer;  this
eliminates the need for using pldmsins1.stsci.edu as a gateway system, ssh setup, etc.

Added explicit chmod to crds.core.utils.create_path().