### PR TITLE
Simplify ingest copy,  drop ssh dependency

### DIFF
--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -580,7 +580,9 @@ def create_path(path, mode=DEFAULT_DIR_PERMS):
         if not os.path.exists(subdir):
             log.verbose("Creating", repr(subdir), "with permissions %o" % mode)
             os.mkdir(subdir, mode)
-            os.chmod(subdir, mode)
+            with log.verbose_warning_on_exception(
+                    "Failed chmod'ing new directory", repr(subdir), "to %o." % mode):
+                os.chmod(subdir, mode)
 
 def ensure_dir_exists(fullpath, mode=DEFAULT_DIR_PERMS):
     """Creates dirs from `fullpath` if they don't already exist.  fullpath

--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -199,7 +199,7 @@ this command line interface must be members of the CRDS operators group
         """
         try:
             output = pysh.out_err("cp ${name} ${path}", raise_on_error=True,
-                                  trace_commands=log.get_verbose() >= 65)
+                                  trace_commands=log.get_verbose())
             if output:
                 log.verbose(output)
             return output
@@ -213,10 +213,8 @@ this command line interface must be members of the CRDS operators group
         log.divider(name="wipe files", char="=")
         log.info("Wiping files at", repr(destination))
         host, path = destination.split(":")
-        if destination.startswith(socket.gethostname()):
-            output = pysh.out_err("rm -vf  ${path}/*")
-        else:
-            output = pysh.out_err("ssh ${host} rm -vf ${path}/*")
+        output = pysh.out_err("rm -vf  ${path}/*",
+                              trace_commands=log.get_verbose())
         if output:
             log.verbose(output)
 


### PR DESCRIPTION
Removed (hopefully) last vestiges of crds submit "ssh dependency" from the --wipe switch which removes existing files from the ingest directory.   Run on a non-gateway it would ssh to the gateway before trying to remove files.

Added an exception trap around new os.chmod function call added to force ingest directory permissions on the server while disregarding umask.