### PR TITLE
Mapped "dyld: Library not loaded:" to a warning so certify users get

### DIFF
--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -587,6 +587,7 @@ RECATEGORIZED_MESSAGE = {
     'Unregistered XTENSION value' : log.info,
     'checksum is not' : log.error,
     'Invalid CHECKSUM' : log.error,
+    'dyld: Library not loaded:' : log.warning,  # bad fitsverify not running,  not a known problem with reference.
 }
 
 def interpret_fitsverify_output(status, output):


### PR DESCRIPTION
more warning when fitsverify isn't running right.