### PR TITLE
Refactored duplicate file / certify sha1sum checking

### DIFF
--- a/crds/certify/check_sha1sum.py
+++ b/crds/certify/check_sha1sum.py
@@ -4,6 +4,7 @@ the CRDS server.
 
 from crds import client
 from crds.core import utils, log
+from crds.core.exceptions import DuplicateSha1sumError
 
 def check_sha1sums(filepaths, observatory=None):
     """Given a list of filepaths which nominally will be submitted
@@ -18,10 +19,8 @@ def check_sha1sums(filepaths, observatory=None):
     """
     log.info("Checking local file sha1sums vs. CRDS server to identify files already in CRDS.")
     sha1sums = get_all_sha1sums(observatory)
-    errors = 0
     for filepath in filepaths:
-        errors += check_sha1sum(filepath, sha1sums, observatory)
-    return errors
+        check_sha1sum(filepath, sha1sums, observatory)
 
 def check_sha1sum(filepath, sha1sums=None, observatory=None):
     """Check to see if the sha1sum of `filepath` is identical to any
@@ -36,11 +35,9 @@ def check_sha1sum(filepath, sha1sums=None, observatory=None):
     log.verbose("Checking file", repr(filepath), "with sha1sum", repr(sha1sum),
                 "for duplication on CRDS server.")
     if sha1sum in sha1sums:
-        log.error("Submitted file", repr(filepath),
-                  "is identical to existing CRDS file",
-                  repr(sha1sums[sha1sum]))
-        return 1
-    return 0
+        raise DuplicateSha1sumError("Submitted file", repr(filepath),
+                                    "is identical to existing CRDS file",
+                                    repr(sha1sums[sha1sum]))
 
 def get_all_sha1sums(observatory=None):
     """Query the CRDS server for sha1sums for all existing files.

--- a/crds/core/exceptions.py
+++ b/crds/core/exceptions.py
@@ -230,6 +230,9 @@ class MissingArrayError(CrdsError):
 class MissingColumnError(CrdsError):
     """A specified (named?) column was not found in a reference file."""
 
+class DuplicateSha1sumError(CrdsError):
+    """This file is bit-for-bit identical with a file already in CRDS."""
+
 # -------------------------------------------------------------------------------------------
 
 class NameComparisonError(CrdsError):


### PR DESCRIPTION
This changes the behavior of the website to report sha1sum issues as "bad files" rather than as submission failures which technically should be limited to server malfunctions.