### PR TITLE
Turned off API certify check for rmap updates 

### DIFF
--- a/crds/core/git_version.py
+++ b/crds/core/git_version.py
@@ -1,9 +1,9 @@
 
 
-__version__ = '7abb4e0f'
+__version__ = '8491d53b'
 
 __full_version_info__ = '''
-branch: update-git-hash
-sha1: 7abb4e0f
+branch: turn-off-check-rmap-updates
+sha1: 8491d53b
 '''
     

--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -297,7 +297,7 @@ this command line interface must be members of the CRDS operators group
         certify.certify_files(
             self.files, context=self.pmap_name, dump_provenance=True, 
             compare_old_reference=True, observatory=self.observatory,
-            run_fitsverify=True, check_rmap=True, check_sha1sums=True)
+            run_fitsverify=True, check_rmap=False, check_sha1sums=True)
         if log.errors():
             raise CrdsError("Certify errors found.  Aborting submission.")
         


### PR DESCRIPTION
due to issues with availability of unreleased or unsynced rmaps.