### PR TITLE
Simplify crds sync --files

### DIFF
--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -576,7 +576,7 @@ def get_crds_ref_subdir_mode(observatory):
     """Return the mode value defining how reference files are located."""
     global CRDS_REF_SUBDIR_MODE
     if CRDS_REF_SUBDIR_MODE in ["None", None]:
-        mode_path = os.path.join(get_crds_cfgpath(observatory),  CRDS_SUBDIR_TAG_FILE)
+        mode_path = get_crds_ref_subdir_file(observatory)
         try:
             with open(mode_path) as pfile:
                 mode = pfile.read().strip()
@@ -601,10 +601,19 @@ def set_crds_ref_subdir_mode(mode, observatory):
     global CRDS_REF_SUBDIR_MODE
     check_crds_ref_subdir_mode(mode)
     CRDS_REF_SUBDIR_MODE = mode
-    mode_path = os.path.join(get_crds_cfgpath(observatory), CRDS_SUBDIR_TAG_FILE)
+    mode_path = get_crds_ref_subdir_file(observatory)
     if writable_cache_or_verbose("skipping subdir mode write."):
         from crds.core import heavy_client as hv   #  yeah,  kinda gross
         hv.cache_atomic_write(mode_path, mode, "Couldn't save sub-directory mode config")
+
+def get_crds_ref_subdir_file(observatory):
+    """Return path to CRDS config file defining cache organization.  Created 
+    automatically,  this is nominally for CRDS internal use only and cleanup.
+
+    Returns <path to cache organization config file>
+    """
+    return os.path.join(get_crds_cfgpath(observatory), CRDS_SUBDIR_TAG_FILE)
+    
 
 def check_crds_ref_subdir_mode(mode):
     """Check for valid reference location subdirectory `mode`."""

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -254,7 +254,7 @@ class SyncScript(cmdline.ContextsScript):
         self.add_argument("--save-pickles", action="store_true",
                           help="Save pre-compiled versions of the sync'ed contexts in the CRDS cache.  Keep pre-existing pickles.")
         self.add_argument("--output-dir", type=str, default=None,
-                          help="Directory to output sync'ed files, for simple syncs.")
+                          help="Directory to output sync'ed files, for simple syncs,  particularly --files.   Implies 'flat' cache.")
         self.add_argument("--clear-locks", action="store_true",
                           help="Remove CRDS cache file lock(s).")
         self.add_argument("--force-config-update", action="store_true",
@@ -303,6 +303,8 @@ class SyncScript(cmdline.ContextsScript):
         # If explicit files were specified,  do not update cache config.
         if self.args.files and self.args.output_dir:
             log.verbose_warning("Used explicit --files list and --output-dir,  skipping cache server_config update including default context and bad files.")
+            if config.writable_cache_or_verbose("skipping removal of ref_cache_subdir_mode file."):
+                os.remove(config.get_crds_ref_subdir_file(self.observatory))
         else:
             self.update_context()
 
@@ -326,6 +328,7 @@ class SyncScript(cmdline.ContextsScript):
             os.environ["CRDS_REFPATH_SINGLE"] = self.args.output_dir
             os.environ["CRDS_CFGPATH_SINGLE"] = self.args.output_dir
             os.environ["CRDS_PICKLEPATH_SINGLE"] = self.args.output_dir
+            self.args.organize = "flat"
 
         if self.readonly_cache:
             log.info("Syncing READONLY cache,  only checking functions are enabled.")


### PR DESCRIPTION
Modified "crds sync --files ... --output-dir ..." to eliminate junk files and unwanted instrument directory structure.