### PR TITLE
Remove unnecessary call to get_submission_info

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -69,9 +69,7 @@ __all__ = [
     
     "push_remote_context",
     "get_remote_context",
-    
-    "get_submission_info",
-    
+        
     "jpoll_pull_messages",
     "jpoll_abort",
     
@@ -403,12 +401,6 @@ def get_remote_context(observatory, pipeline_name):
             (observatory, pipeline_name)) from exc
 
 # ==============================================================================
-
-def get_submission_info(observatory, username):
-    """Return configuration parameters needed for command line file submission
-    relative to the current server, observatory, and username.
-    """
-    return utils.Struct(S.get_submission_info(observatory, username))
 
 def jpoll_pull_messages(key, since_id=None):
     """Return a list of jpoll json message objects from the channel associated

--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -39,7 +39,6 @@ this command line interface must be members of the CRDS operators group
         self.username = None
         self.connection = None
         self.submission = None
-        self.submission_info = None
         self.pmap_mode = None
         self.pmap_name = None
         self.instruments_filekinds = None
@@ -87,7 +86,6 @@ this command line interface must be members of the CRDS operators group
         self.username = self.args.username or config.get_username()
         password = config.get_password()
         self.base_url = config.get_server_url(self.observatory)
-        self.submission_info = api.get_submission_info(self.observatory, self.username)
         self.instruments_filekinds = utils.get_instruments_filekinds(self.observatory, self.files) if self.args.files else {}
         self.instrument = list(self.instruments_filekinds.keys())[0] if len(self.instruments_filekinds) == 1 else "none"
         self.connection = web.CrdsDjangoConnection(


### PR DESCRIPTION
https://jira.stsci.edu/browse/CCD-388

Per Todd, all we need to do here is remove the call to get_submission_info -- since files are being uploaded over HTTPS now, there's no reason why anyone would need a filesystem path.