### PR TITLE
Restored the WFC3 BPIXTAB table check

### DIFF
--- a/crds/hst/specs/combined_specs.json
+++ b/crds/hst/specs/combined_specs.json
@@ -2412,7 +2412,11 @@
             "suffix":"bpx",
             "text_descr":"Data Quality (Bad Pixel) Initialization Table",
             "tpn":"wfc3_bpx.tpn",
-            "unique_rowkeys":null
+            "unique_rowkeys":[
+                "CCDCHIP",
+                "PIX1",
+                "PIX2"
+            ]
         },
         "ccdtab":{
             "extra_keys":[],

--- a/crds/hst/specs/wfc3_bpixtab.spec
+++ b/crds/hst/specs/wfc3_bpixtab.spec
@@ -12,4 +12,5 @@
     'suffix': 'bpx',
     'text_descr': 'Data Quality (Bad Pixel) Initialization Table',
     'tpn': 'wfc3_bpx.tpn',
+    'unique_rowkeys': ('CCDCHIP', 'PIX1', 'PIX2'),
 }


### PR DESCRIPTION
On review,  Matt M. thought our recent issues with BPIXTAB massive pixel changes may be a one-off and requested that I restore the BPIXTAB table check.