### PR TITLE
Fix collections.abc deprecation

### DIFF
--- a/crds/core/custom_dict.py
+++ b/crds/core/custom_dict.py
@@ -7,7 +7,7 @@ TransformedDict --   generic MutableMapping with key and value transforms
 LazyFileDict   --  Demand loaded network of files (aka CRDS context)
 
 """
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 # =============================================================================
 


### PR DESCRIPTION
Fixes the following DeprecationWarning under Python 3.7 (deprecated under 3.8):
```
../crds/core/custom_dict.py:10: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```