### PR TITLE
For CCD-560 improve sync purging

### DIFF
--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -333,7 +333,7 @@ class Script:
     @property
     @utils.cached
     def bad_files(self):
-        """Return the current list of ALL known bad mappings and references, not context-specific."""
+        """Return the current set of ALL known bad mappings and references, not context-specific."""
         return self.server_info.bad_files_set
 
     @property

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -386,7 +386,9 @@ class SyncScript(cmdline.ContextsScript):
         else:
             active_references = self.get_context_references()
         # Handle GEIS paired data files
-        active_references = sorted(set(active_references + self.get_conjugates(active_references)))
+        active_references = set(active_references + self.get_conjugates(active_references))
+        if self.args.purge_rejected or self.args.purge_blacklisted:
+            active_references -= self.bad_files
         return active_references
     
     def update_context(self):
@@ -615,14 +617,14 @@ class SyncScript(cmdline.ContextsScript):
         if info["rejected"] != "false":
             log.verbose_warning("File", repr(base), "has been explicitly rejected.", verbosity=60)
             if self.args.purge_rejected:
-                self.remove_files([path], "files")
+                self.remove_files([path], "file")
             return
 
         if info["blacklisted"] != "false":
             log.verbose_warning("File", repr(base), "has been blacklisted or is dependent on a blacklisted file.",
                                 verbosity=60)
             if self.args.purge_blacklisted:
-                self.remove_files([path], "files")
+                self.remove_files([path], "file")
             return
         return
     


### PR DESCRIPTION
modified crds sync to avoid downloading bad files when --purge-rejected or --purge-blacklisted are set.   This prevents a download-purge loop.   Fixed some log message typos,  docstring.