### PR TITLE
Fix for runtests return value

### DIFF
--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -615,7 +615,7 @@ class FileCacher:
         plugin_cmd = plugin_cmd.replace("${SOURCE_URL}", url)
         plugin_cmd = plugin_cmd.replace("${OUTPUT_PATH}", localpath)
         log.verbose("Running download plugin:", repr(plugin_cmd))
-        status = os.system(plugin_cmd)
+        status = os.WEXITSTATUS(os.system(plugin_cmd))
         if status != 0:
             if status == 2:
                 raise KeyboardInterrupt("Interrupted plugin.")

--- a/runtests
+++ b/runtests
@@ -34,4 +34,4 @@ elif "--profile" in sys.argv:
 else:
     status = os.system("nosetests")
 os.system("python -m crds.list --status --log-time")
-sys.exit(status)
+sys.exit(os.WEXITSTATUS(status))


### PR DESCRIPTION
This is an interesting story!  It turns out that `os.system` doesn't just return the exit status of the executing command:

```
exit status indication: a 16-bit number, whose low byte is the signal number that killed the process, and whose high byte is the exit status (if the signal number is zero); the high bit of the low byte is set if a core file was produced.
```

Since nosetests exited with status 1, and the process wasn't killed, we had high byte 0x01 and low byte 0x00, which is the integer 256.  It turns out that exit status is only allowed in the range 0-255, so when you call sys.exit(status), it performs mod 256 on the input before passing it along.  256 mod 256 = 0 so in the end we were reporting success.

I checked both the server and client code for cases where we're using the return value from os.system, and only found one other example.  This PR fixes both of them.