### PR TITLE
Improve download_metadata

### DIFF
--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -61,8 +61,9 @@ from . import rmap, log, utils, config
 from .constants import ALL_OBSERVATORIES
 from .log import srepr
 from .exceptions import CrdsError, CrdsBadRulesError, CrdsBadReferenceError, CrdsConfigError, CrdsDownloadError
-from crds.client import api, proxy
-# import crds  forward
+from crds.client import api
+
+# import crds  # forward
 
 # ============================================================================
 
@@ -554,7 +555,6 @@ def update_config_info(observatory):
 def cache_server_info(info, observatory):
     """Write down the server `info` dictionary to help configure off-line use."""
     path = config.get_crds_cfgpath(observatory)
-    info.download_metadata = proxy.crds_encode(info.download_metadata)
     server_config_path = os.path.join(path, "server_config")
     cache_atomic_write(server_config_path, pprint.pformat(info), "SERVER INFO")
 
@@ -597,8 +597,6 @@ def load_server_info(observatory):
                          " for more information on configuring CRDS,  particularly CRDS_PATH and CRDS_SERVER_URL."):
         with open(server_config) as file_:
             info = ConfigInfo(ast.literal_eval(file_.read()))
-        if "download_metdata" in info:
-            info.download_metadata = proxy.crds_decode(info.download_metadata)
         info.status = "cache"
     return info
 


### PR DESCRIPTION
Moved decoding of download_metadata from get_server_info() into its own cached dedicated function based on server info.  Removed direct references to download_metadata from heavy_client.   This should both simplify and optimize by avoiding decoding of download_metadata when not being used.