### PR TITLE
Corrected MIRI RESET array shape constraints

### DIFF
--- a/crds/jwst/tpns/miri_reset.tpn
+++ b/crds/jwst/tpns/miri_reset.tpn
@@ -3,10 +3,7 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-SCI     A       X      F   ((SCI_ARRAY.SHAPE==(1032,1024,5,30))
-ERR     A       X      F   ((ERR_ARRAY.SHAPE==(1032,1024,5,30))
-
 NGROUPS H       I      R
 NINTS   H       I      R
-SCI     A       X      R   ((SCI_ARRAY.SHAPE==(SUBSIZE1,SUBSIZE2,NGROUPS,NINTS))
-ERR     A       X      R   ((ERR_ARRAY.SHAPE==(SUBSIZE1,SUBSIZE2,NGROUPS,NINTS))
+SCI     A       X      R   (SCI_ARRAY.SHAPE==(NINTS,NGROUPS,SUBSIZE2,SUBSIZE1))
+ERR     A       X      R   (ERR_ARRAY.SHAPE==(NINTS,NGROUPS,SUBSIZE2,SUBSIZE1))


### PR DESCRIPTION
This is part of completing the type setup last worked on in 2014.