### PR TITLE
Simplified use of sync --purge-rejected and --purge-blacklisted

### DIFF
--- a/crds/sync.py
+++ b/crds/sync.py
@@ -291,7 +291,8 @@ class SyncScript(cmdline.ContextsScript):
 
         # verification is relative to sync'ed files,  and can include file replacement if
         # defects are found.
-        if self.args.check_files or self.args.check_sha1sum or self.args.repair_files:
+        if (self.args.check_files or self.args.check_sha1sum or self.args.repair_files or
+            self.args.purge_blacklisted or self.args.purge_rejected):
             self.verify_files(verify_file_list)
 
         # context pickles should only be (re)generated after mappings are fully sync'ed and verified


### PR DESCRIPTION
Added args.purge_blacklisted and args.purge_rejected (bad mappings or references respectively) as driver for sync.verify_files since verification is required for purging.   This is related to removing bad files from /grp/crds/cache so they don't get used accidentally.