### PR TITLE
Add awscli as an aws extra dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(name="crds",
           "dev" : ["ipython","jupyterlab"],
           "test" : TEST_DEPS,
           "docs" : ["sphinx","sphinx_rtd_theme","docutils"],
-          "aws" : ["boto3"]
+          "aws" : ["awscli", "boto3"]
       },
       tests_require=TEST_DEPS,
       zip_safe=False,


### PR DESCRIPTION
I didn't realize awscli was a pip package, this will save users of the S3 plugin from having to install it separately.