### PR TITLE
Add additional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,10 +95,10 @@ setup(name="crds",
       extras_require={
           "jwst": ["jwst"],
           "submission": ["requests", "lxml", "parsley"],
-          "dev" : ["ipython","jupyterlab","ansible"],
+          "dev" : ["ipython","jupyterlab","ansible","helm"],
           "test" : TEST_DEPS,
           "docs" : ["sphinx","sphinx_rtd_theme","docutils"],
-          "aws" : ["boto3","awscli"]
+          "aws" : ["boto3","awscli"],
       },
       tests_require=TEST_DEPS,
       zip_safe=False,


### PR DESCRIPTION
Added awscli and helm (not really required) as CRDS aws and dev group dependencies respectively.  awscli is required by sync plugin scripts.