### PR TITLE
Fix exception behavior when S3_RETURN_URI is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 .project
 *.pyc
 *~
+*.egg-info/
 
 documentation/crds_users_guide/build
 documentation/crds_users_guide/*.tar.gz

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -848,15 +848,18 @@ def cache_references(pipeline_context, bestrefs, ignore_cache=False):
 
     Returns:   { reference_keyword :  reference_local_filepath ... }
     """
-    wanted = get_cache_filelist_and_report_errors(bestrefs)
+    wanted = _get_cache_filelist_and_report_errors(bestrefs)
 
-    localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False).get_local_files(wanted)[0]
+    if config.S3_RETURN_URI:
+        localrefs = {name: api.get_flex_uri(name) for name in wanted}
+    else:
+        localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False).get_local_files(wanted)[0]
 
     refs = _squash_unicode_in_bestrefs(bestrefs, localrefs)
 
     return refs
 
-def get_cache_filelist_and_report_errors(bestrefs):
+def _get_cache_filelist_and_report_errors(bestrefs):
     """Compute the list of files to download based on the `bestrefs` dictionary,
     skimming off and reporting errors, and raising an exception on the last error seen.
 

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -848,7 +848,7 @@ def cache_references(pipeline_context, bestrefs, ignore_cache=False):
 
     Returns:   { reference_keyword :  reference_local_filepath ... }
     """
-    wanted = _get_cache_filelist_and_report_errors(bestrefs)
+    wanted = get_cache_filelist_and_report_errors(bestrefs)
 
     localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False).get_local_files(wanted)[0]
 
@@ -856,7 +856,7 @@ def cache_references(pipeline_context, bestrefs, ignore_cache=False):
 
     return refs
 
-def _get_cache_filelist_and_report_errors(bestrefs):
+def get_cache_filelist_and_report_errors(bestrefs):
     """Compute the list of files to download based on the `bestrefs` dictionary,
     skimming off and reporting errors, and raising an exception on the last error seen.
 

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -851,7 +851,7 @@ def cache_references(pipeline_context, bestrefs, ignore_cache=False):
     wanted = _get_cache_filelist_and_report_errors(bestrefs)
 
     if config.S3_RETURN_URI:
-        localrefs = {name: api.get_flex_uri(name) for name in wanted}
+        localrefs = {name: get_flex_uri(name) for name in wanted}
     else:
         localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False).get_local_files(wanted)[0]
 

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -122,16 +122,10 @@ def getreferences(parameters, reftypes=None, context=None, ignore_cache=False,
     final_context, bestrefs = _initial_recommendations("getreferences",
         parameters, reftypes, context, ignore_cache, observatory, fast)
 
-    if config.S3_RETURN_URI:
-        bestrefs = api.get_cache_filelist_and_report_errors(bestrefs)
-        best_refs_paths = {}
-        for reftype, filename in bestrefs.items():
-            best_refs_paths[reftype] = api.get_flex_uri(filename)
-    else:
-        # Attempt to cache the recommended references,  which unlike dump_mappings
-        # should work without network access if files are already cached.
-        best_refs_paths = api.cache_references(
-            final_context, bestrefs, ignore_cache=ignore_cache)
+    # Attempt to cache the recommended references,  which unlike dump_mappings
+    # should work without network access if files are already cached.
+    best_refs_paths = api.cache_references(
+        final_context, bestrefs, ignore_cache=ignore_cache)
 
     return best_refs_paths
 

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -123,6 +123,7 @@ def getreferences(parameters, reftypes=None, context=None, ignore_cache=False,
         parameters, reftypes, context, ignore_cache, observatory, fast)
 
     if config.S3_RETURN_URI:
+        bestrefs = api.get_cache_filelist_and_report_errors(bestrefs)
         best_refs_paths = {}
         for reftype, filename in bestrefs.items():
             best_refs_paths[reftype] = api.get_flex_uri(filename)


### PR DESCRIPTION
This addresses an issue where getreferences does not raise an exception for missing reference file types when S3_RETURN_URI is enabled.