### PR TITLE
Added visit_Constant to mapping_verifier

### DIFF
--- a/crds/core/mapping_verifier.py
+++ b/crds/core/mapping_verifier.py
@@ -89,6 +89,7 @@ LEGAL_NODES = {
     'visit_Not',
     'visit_NameConstant',
     'visit_USub',
+    'visit_Constant',
 }
 
 CUSTOMIZED_NODES = {


### PR DESCRIPTION
Needed for Python-3.8 support,  adds new whitelisted AST node.