### PR TITLE
Add missing dependency to Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ os:
 sudo: false
 
 env:
-    # CONDA_JWST_DEPENDENCIES is used because CONDA_DEPENDENCIES is not truly global.
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='fitsverify'
+        - CONDA_DEPENDENCIES='cfitsio>3.440 fitsverify'
         - PIP_DEPENDENCIES='numpy coveralls'
         - CRDS_SERVER_URL='https://hst-crds.stsci.edu'
         - CRDS_TEST_ROOT=/tmp


### PR DESCRIPTION
Introduced to correct the following errors in the Travis build logs:

OS-X:
  CRDS - INFO -  >> dyld: Library not loaded: @rpath/libcfitsio.6.dylib
Linux:
  CRDS - INFO -  >> fitsverify: error while loading shared libraries: libcfitsio.so.6: cannot open shared object file: No such file or directory

Edit: The problem here seems to stem from the fact that last month conda also started publishing cfitsio on their own via a conda-feedstock recipe. This package provides `cfitsio 3.470` whereas Astroconda is currently only providing `3.440`. A rebuild of `fitsverify` should correct this and will be provided soon.