### PR TITLE
Don't logger.setLevel(DEBUG) by defaut

### DIFF
--- a/crds/core/log.py
+++ b/crds/core/log.py
@@ -115,7 +115,7 @@ import contextlib
 DEFAULT_VERBOSITY_LEVEL = 50
 
 class CrdsLogger:
-    def __init__(self, name="CRDS", enable_console=True, level=logging.DEBUG, enable_time=True):
+    def __init__(self, name="CRDS", enable_console=True, level=logging.INFO, enable_time=True):
         self.name = name
 
         self.handlers = []  # logging handlers, used e.g. to add console or file output streams
@@ -195,7 +195,12 @@ class CrdsLogger:
 
     def should_output(self, *args, **keys):
         verbosity = keys.get("verbosity", DEFAULT_VERBOSITY_LEVEL)
-        return not self.verbose_level < verbosity
+        do_output = not self.verbose_level < verbosity
+        if do_output:
+            self.logger.setLevel(logging.DEBUG)
+        else:
+            self.logger.setLevel(logging.INFO)
+        return do_output
 
     def verbose(self, *args, **keys):
         if self.should_output(*args, **keys):


### PR DESCRIPTION
I modified logging so the CRDS central logger only does setLevel(DEBUG)f the CRDS verbosity level indicates CRDS will actually issue DEBUG messages.   This is to preclude any possibility of turning on DEBUG for CRDS  dependencies.

The current default state of DEBUG is not to be confused with actually outputting DEBUG messages since they are also governed by the condition CRDS_VERBOSITY > 0.   This change merely defers setLevel(DEBUG) until the moment CRDS does issue DEBUG messages due to sufficient verbosity being set in CRDS.

I'm submitting this because collectively (CAL + CRDS + astropy + ...) logging has issues and there are complex chicken-and-egg relationships so there is always FUD that something in CRDS logging is wrong causing excess output we see.

