### PR TITLE
Additional certify check for synphot component tables

### DIFF
--- a/crds/hst/tpns/synphot_syn.tpn
+++ b/crds/hst/tpns/synphot_syn.tpn
@@ -22,3 +22,5 @@ DATE                H        C         R
 WAVELENGTH      C        R             R
 THROUGHPUT      C        R             W
 
+# Warn when the first and last throughput values are not both equal to 0:
+EXT1            D        X             R    (warn_only((EXT1_ARRAY.DATA.field("THROUGHPUT")[[0,-1]]==0.0).all()))

--- a/crds/hst/tpns/synphot_syn_ld.tpn
+++ b/crds/hst/tpns/synphot_syn_ld.tpn
@@ -21,3 +21,6 @@ DATE                H        C         R
 
 WAVELENGTH      C        R             R
 THROUGHPUT      C        R             W
+
+# Warn when the first and last throughput values are not both equal to 0:
+EXT1            D        X             R    (warn_only((EXT1_ARRAY.DATA.field("THROUGHPUT")[[0,-1]]==0.0).all()))


### PR DESCRIPTION
This PR adds an additional check that warns if the first and last THROUGHPUT values of a synphot component table are nonzero.  This is a check that ReDCaT currently performs manually as part of their delivery process.  Matt says it should be only a warning, since there are some special cases where nonzero values are permitted.

I tested this on a handful of existing files, and modified a file to have a nonzero value and witnessed the warning.