### PR TITLE
Create initial rmap and TPNs for new synphot reference file

### DIFF
--- a/crds/hst/specs/combined_specs.json
+++ b/crds/hst/specs/combined_specs.json
@@ -2152,6 +2152,35 @@
         }
     },
     "synphot":{
+        "obsmodes":{
+            "classes":[
+                "Match"
+            ],
+            "derived_from":"Initial hand made version 2020-03-25.",
+            "extra_keys":[],
+            "file_ext":".fits",
+            "filekind":"OBSMODES",
+            "filetype":"CROBSMODELIST",
+            "instrument":"SYNPHOT",
+            "ld_tpn":"synphot_obs_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"synphot_obsmodes.rmap",
+            "observatory":"HST",
+            "parkey":[
+                []
+            ],
+            "reffile_format":"TABLE",
+            "reffile_required":"YES",
+            "reffile_switch":"NONE",
+            "rmap_omit":"True",
+            "sha1sum":"2ccb22fa1a9794eabf46e02ed05e0a6eee16fe78",
+            "suffix":"obs",
+            "text_descr":"Observing Modes Table",
+            "tpn":"synphot_obs.tpn",
+            "unique_rowkeys":[
+                "OBSMODE"
+            ]
+        },
         "thermal":{
             "classes":[
                 "Match"

--- a/crds/hst/specs/synphot_obsmodes.rmap
+++ b/crds/hst/specs/synphot_obsmodes.rmap
@@ -1,0 +1,26 @@
+header = {
+    'classes' : ('Match',),
+    'derived_from' : 'Initial hand made version 2020-03-25.',
+    'extra_keys' : (),
+    'file_ext' : '.fits',
+    'filekind' : 'OBSMODES',
+    'filetype' : 'CROBSMODELIST',
+    'instrument' : 'SYNPHOT',
+    'ld_tpn' : 'synphot_obs_ld.tpn',
+    'mapping' : 'REFERENCE',
+    'name' : 'synphot_obsmodes.rmap',
+    'observatory' : 'HST',
+    'parkey' : ((),),
+    'reffile_format' : 'TABLE',
+    'reffile_required' : 'YES',
+    'reffile_switch' : 'NONE',
+    'rmap_omit' : 'True',
+    'sha1sum' : '2ccb22fa1a9794eabf46e02ed05e0a6eee16fe78',
+    'suffix' : 'obs',
+    'text_descr' : 'Observing Modes Table',
+    'tpn' : 'synphot_obs.tpn',
+    'unique_rowkeys' : ('OBSMODE',),
+}
+
+selector = Match({
+})

--- a/crds/hst/tpns/synphot_obs.tpn
+++ b/crds/hst/tpns/synphot_obs.tpn
@@ -1,0 +1,17 @@
+# Template file used by certify to check reference files
+# Some fields may be abbreviated to their first character:
+#
+# keytype = (Header|Group|Column)
+# datatype = (Integer|Real|Logical|Double|Character)
+# presence = (Optional|Required)
+#
+# NAME          KEYTYPE  DATATYPE  PRESENCE VALUES
+#--------------------------------------------------------------------------
+USEAFTER            H        C         R    &SYBDATE
+INSTRUME            H        C         R    SYNPHOT
+DBTABLE             H        C         R    CROBSMODELIST
+DESCRIP             H        C         R
+COMMENT             H        C         R
+HISTORY             H        C         R
+
+OBSMODE             C        C         R

--- a/crds/hst/tpns/synphot_obs_ld.tpn
+++ b/crds/hst/tpns/synphot_obs_ld.tpn
@@ -1,0 +1,17 @@
+# Template file used by certify to check reference files
+# Some fields may be abbreviated to their first character:
+#
+# keytype = (Header|Group|Column)
+# datatype = (Integer|Real|Logical|Double|Character)
+# presence = (Optional|Required)
+#
+# NAME          KEYTYPE  DATATYPE  PRESENCE VALUES
+#--------------------------------------------------------------------------
+USEAFTER            H        C         R    &SYBDATE
+INSTRUME            H        C         R    SYNPHOT
+DBTABLE             H        C         R    CROBSMODELIST
+DESCRIP             H        C         R
+COMMENT             H        C         R
+HISTORY             H        C         R
+
+OBSMODE             C        C         R


### PR DESCRIPTION
This new reference file contains a list of valid observation mode strings that will be used to perform integration tests on the other synphot files.  The reference will be initially populated with the obsmode strings in ReDCaT's test_pysynphot_tmc.py script.