### PR TITLE
Remove DETECTOR from nircam_apcorr spec definition

### DIFF
--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1556,7 +1556,7 @@
                 "Match",
                 "UseAfter"
             ],
-            "derived_from":"Hand made 2019-10-22",
+            "derived_from":"Hand made 2020-05-06",
             "extra_keys":null,
             "file_ext":".fits",
             "filekind":"APCORR",
@@ -1568,7 +1568,6 @@
             "observatory":"JWST",
             "parkey":[
                 [
-                    "META.INSTRUMENT.DETECTOR",
                     "META.EXPOSURE.TYPE"
                 ],
                 [
@@ -1576,7 +1575,7 @@
                     "META.OBSERVATION.TIME"
                 ]
             ],
-            "sha1sum":"fa68b4bbe9e83e7d824b90e2120856692fd84554",
+            "sha1sum":"7e922270697b909ae131a3e482176ee5e443a9d0",
             "suffix":"apcorr",
             "text_descr":"Aperture Correction",
             "tpn":"nircam_apcorr.tpn",

--- a/crds/jwst/specs/nircam_apcorr.rmap
+++ b/crds/jwst/specs/nircam_apcorr.rmap
@@ -1,6 +1,6 @@
 header = {
     'classes' : ('Match', 'UseAfter'),
-    'derived_from' : 'Hand made 2019-10-22',
+    'derived_from' : 'Hand made 2020-05-06',
     'file_ext' : '.fits',
     'filekind' : 'APCORR',
     'filetype' : 'APCORR',
@@ -8,8 +8,8 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'jwst_nircam_apcorr.rmap',
     'observatory' : 'JWST',
-    'parkey' : (('META.INSTRUMENT.DETECTOR', 'META.EXPOSURE.TYPE'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : 'fa68b4bbe9e83e7d824b90e2120856692fd84554',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '7e922270697b909ae131a3e482176ee5e443a9d0',
     'suffix' : 'apcorr',
     'text_descr' : 'Aperture Correction',
     'unique_rowkeys' : ('FILTER', 'PUPIL', 'EEFRACTION'),


### PR DESCRIPTION
From further discussion of the NIRCam APCORR files, [JP-315](https://jira.stsci.edu/browse/CRDS-315), basing the reference files on DETECTOR was determined to be incorrect. Formally removing the selection criterion from the code spec.