### PR TITLE
Add new ATODSAT column to ACS CCDTAB .tpn

### DIFF
--- a/crds/hst/tpns/acs_ccd.tpn
+++ b/crds/hst/tpns/acs_ccd.tpn
@@ -19,3 +19,4 @@ USEAFTER  	H	C	R	&SYBDATE
 PEDIGREE  	H	C	R	&PEDIGREE
 OVRHFLS         C       D       R       0:inf
 OVRHUFLS        C       D       R       0:inf
+ATODSAT         C       I       R       60000:70000


### PR DESCRIPTION
Per Meaghan/Tyler, the column is required and should contain positive integers between 60,000 and 70,000.  I tested the certifier on their new files and saw only warnings about the new row format.