### PR TITLE
Change merge_overlaps default to true for all observatories

### DIFF
--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -263,7 +263,7 @@ class Selector:
         if "merge_overlaps" in self._rmap_header:
             self._merge_overlaps = str(self._rmap_header["merge_overlaps"]).upper() in ["TRUE", "1"]
         else:
-            self._merge_overlaps =  self._rmap_header.get("observatory", None) == "hst"
+            self._merge_overlaps = True
         if selections is not None:
             assert isinstance(selections, dict),  \
                 "selections should be a dictionary { key: choice, ... }."

--- a/crds/tests/test_reftypes.py
+++ b/crds/tests/test_reftypes.py
@@ -178,7 +178,7 @@ def reftypes_jwst_get_filekinds():
     >>> old_state = test_config.setup()
     >>> types = reftypes.get_types_object("jwst")
     >>> types.get_filekinds("niriss")
-    ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wcsregions', 'wfssbkg']
+    ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'pars-image2pipeline', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wcsregions', 'wfssbkg']
     >>> test_config.cleanup(old_state)
     """
 

--- a/documentation/crds_users_guide/source/file_submissions.rst
+++ b/documentation/crds_users_guide/source/file_submissions.rst
@@ -1041,23 +1041,15 @@ Match() solutions:
 Solution for Equal Weight Matches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To avoid losing the work entailed by a file submission completely,  equal
-weight match cases are reported as warnings to give lattitude in how to
-address the problem.   There are generally three solutions:
+To avoid losing the work entailed by a file submission completely, equal
+weight match cases are reported as warnings to give latitude in how to
+address the problem.   There are generally two solutions:
 
 1. Cancel the submission and regenerate the reference files with different
    parameter values which coincide with an existing category.
 
 2. Accept the submission but immediately edit the rmap to combine overlapping
    Match() categories.
-
-3. Last ditch: Accept the submission, but immediately set a "merge_overlaps" :
-   "TRUE" value in the rmap header.  Submit the new rmap using Submit Mappings.
-   merge_overlaps will cause disjoint categories to by dynamically shuffled
-   together for USEAFTER lookups.
-
-**NOTE:** For HST "merge_overlaps" defaults to "TRUE", but for JWST
-"merge_overlaps" defaults to "FALSE".
 
 Why CRDS Categorizes Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Our users prefer that merge_overlaps defaults to true for JWST as well.  I'll be running the JWST regression tests with this branch to confirm that nothing goes haywire with this change and will comment here with the results.

EDIT: Regression tests passed no problem.  This seems ready to go.