### PR TITLE
Add package metadata with source repo URL and others.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,5 +110,10 @@ setup(name="crds",
           'Programming Language :: Python :: 3',
           'Topic :: Scientific/Engineering :: Astronomy',
       ],
+      project_urls={
+          'Bug Reports': 'https://github.com/spacetelescope/crds/issues/',
+          'Source': 'https://github.com/spacetelescope/crds/',
+          'Help': 'https://hsthelp.stsci.edu/',
+      },
       **setup_pars
 )


### PR DESCRIPTION
To support testing automation efforts it's helpful to have the URL of the source repository in the package metadata.
Adding `project_urls` dictionary to `setup.py` similar to other `spacetelescope` projects.