### PR TITLE
Allow derived-from context to be specified when making a programmatic submission

### DIFF
--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -249,7 +249,7 @@ this command line interface must be members of the CRDS operators group
         """Return a dictionary mapping form variables to value strings for the basic command
         line submission parameters.
         """
-        return dict(
+        result = dict(
             pmap_mode = self.pmap_mode,
             pmap_name = self.pmap_name,
             instrument = self.instrument,
@@ -259,6 +259,11 @@ this command line interface must be members of the CRDS operators group
             auto_rename = not self.args.dont_auto_rename,
             compare_old_reference = not self.args.dont_compare_old_reference,
         )
+
+        if self.pmap_mode == "pmap_text":
+            result["pmap_text"] = self.pmap_name
+
+        return result
 
     def submission_complete(self, args):
         """Threaded completion function for any submission,  returns web response."""

--- a/crds/tests/test_submit.py
+++ b/crds/tests/test_submit.py
@@ -147,7 +147,7 @@ class TestSubmission(object):
         urlopen.return_value = open(cls.mockup_form)
 
         # Instantiate the Submission object used in these tests:
-        cls.s = Submission('hst', 'dev')
+        cls.s = Submission('hst', 'dev', context='hst_0723.pmap')
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This adds a `context` parameter to `Submission.__init__`, and fixes a wee bug in `crds.submit.submit`, which was not posting `pmap_text` to the server.