### PR TITLE
Add some basic tests of Roman support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
     - pip install git+https://github.com/spacetelescope/jwst
+    - pip install git+https://github.com/spacetelescope/romancal
     - pip uninstall --yes crds
     - ./install
     - pip install .["submission","test","docs","synphot"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
         - CRDS_TEST_ROOT=/tmp
 
     matrix:
-        - PYTHON_VERSION=3.6
         - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -696,6 +696,13 @@ def certify_jwst_invalid_yaml():
     >>> test_config.cleanup(old_state)
     """
 
+def certify_test_roman_load_all_type_constraints():
+    """
+    >>> old_state = test_config.setup(url="https://roman-crds-serverless.stsci.edu", observatory="roman", cache=test_config.CRDS_TESTING_CACHE)
+    >>> generic_tpn.load_all_type_constraints("roman")
+    >>> test_config.cleanup(old_state)
+    """
+
 def certify_test_jwst_load_all_type_constraints():
     """
     >>> old_state = test_config.setup(url="https://jwst-crds-serverless.stsci.edu", observatory="jwst")

--- a/crds/tests/test_locking.py
+++ b/crds/tests/test_locking.py
@@ -23,6 +23,7 @@ from . import test_config
 def multiprocessing_instance(output_file_name):
     """Pretend to do something generic."""
     output_file = open(output_file_name, "a")
+
     with crds_cache_locking.get_cache_lock():
         for char in "testing":
             output_file.write(char)
@@ -34,7 +35,11 @@ def multiprocessing_instance(output_file_name):
 
 def try_multiprocessing():
     """Run some test functions using multiprocessing."""
-    pool = multiprocessing.Pool(5)
+    # Starting with Python 3.8, the default start method in macOS is
+    # "spawn", which causes the CRDS lock to be recreated for each
+    # process.
+    context = multiprocessing.get_context("fork")
+    pool = context.Pool(5)
     with tempfile.NamedTemporaryFile(mode="a") as output_file:
         pool.map(multiprocessing_instance, [output_file.name]*5)
         pool.close()

--- a/crds/tests/test_reftypes.py
+++ b/crds/tests/test_reftypes.py
@@ -227,8 +227,8 @@ def reftypes_roman_get_filekinds():
     """
     >>> old_state = test_config.setup()
     >>> types = reftypes.get_types_object("roman")
-    >>> types.get_filekinds("wfi")
-    ['all', 'flat']
+    >>> {'all', 'flat'}.issubset(types.get_filekinds("wfi"))
+    True
     >>> test_config.cleanup(old_state)
     """
 

--- a/crds/tests/test_reftypes.py
+++ b/crds/tests/test_reftypes.py
@@ -10,7 +10,7 @@ from nose.tools import assert_raises, assert_true
 
 from crds.core import utils, log, exceptions
 from crds.certify import reftypes
-from crds import hst, jwst
+from crds import hst, jwst, roman
 
 from crds.tests import test_config
 
@@ -65,6 +65,26 @@ def reftypes_jwst_save_json_specs():
     """
     >>> old_state = test_config.setup()
     >>> SPECS = os.path.join(os.path.abspath(jwst.HERE), "specs")
+    >>> specs = reftypes.load_raw_specs(SPECS)
+    >>> f = tempfile.NamedTemporaryFile(delete=False)
+    >>> f.close()
+    >>> reftypes.save_json_specs(specs, f.name) # doctest: +ELLIPSIS
+    CRDS - INFO -  Saved combined type specs to '...'
+    >>> test_config.cleanup(old_state)
+    """
+
+def reftypes_roman_load_raw_specs():
+    """
+    >>> old_state = test_config.setup()
+    >>> SPECS = os.path.join(os.path.abspath(roman.HERE), "specs")
+    >>> spec = reftypes.load_raw_specs(SPECS)
+    >>> test_config.cleanup(old_state)
+    """
+
+def reftypes_roman_save_json_specs():
+    """
+    >>> old_state = test_config.setup()
+    >>> SPECS = os.path.join(os.path.abspath(roman.HERE), "specs")
     >>> specs = reftypes.load_raw_specs(SPECS)
     >>> f = tempfile.NamedTemporaryFile(delete=False)
     >>> f.close()
@@ -164,6 +184,27 @@ def reftypes_jwst_reference_name_to_tpn_infos():    # doctest: +ELLIPSIS
     >>> test_config.cleanup(old_state)
     """
 
+def reftypes_roman_reference_name_to_tpn_infos():
+    """
+    >>> old_state = test_config.setup()
+    >>> types = reftypes.get_types_object("roman")
+    >>> infos = types.reference_name_to_tpninfos("roman_wfi_flat.asdf")
+    >>> print(log.PP(infos))
+    [('META.AUTHOR', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.DESCRIPTION', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.INSTRUMENT.DETECTOR', 'HEADER', 'CHARACTER', 'OPTIONAL', values=('WFI01', 'WFI02', 'WFI03', 'WFI04', 'WFI05', 'WFI06', 'WFI07', 'WFI08', 'WFI09', 'WFI10', 'WFI11', 'WFI12', 'WFI13', 'WFI14', 'WFI15', 'WFI16', 'WFI17', 'WFI18', 'ANY', 'N/A')),
+     ('META.INSTRUMENT.DETECTOR', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.INSTRUMENT.NAME', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.INSTRUMENT.NAME', 'HEADER', 'CHARACTER', 'REQUIRED', values=('WFI',)),
+     ('META.INSTRUMENT.OPTICAL_ELEMENT', 'HEADER', 'CHARACTER', 'OPTIONAL', values=('F062', 'F087', 'F106', 'F129', 'W146', 'F158', 'F184', 'GRISM', 'PRISM', 'CLEAR', 'DARK', 'ENGINEERING', 'N/A', 'ANY', 'UNKNOWN')),
+     ('META.INSTRUMENT.OPTICAL_ELEMENT', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.PEDIGREE', 'HEADER', 'CHARACTER', 'REQUIRED', values=('&JWSTPEDIGREE',)),
+     ('META.REFTYPE', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
+     ('META.TELESCOPE', 'HEADER', 'CHARACTER', 'REQUIRED', values=('ROMAN',)),
+     ('META.USEAFTER', 'HEADER', 'CHARACTER', 'REQUIRED', values=('&JWSTDATE',))]
+    >>> test_config.cleanup(old_state)
+    """
+
 def reftypes_hst_get_filekinds():
     """
     >>> old_state = test_config.setup()
@@ -179,6 +220,15 @@ def reftypes_jwst_get_filekinds():
     >>> types = reftypes.get_types_object("jwst")
     >>> types.get_filekinds("niriss")
     ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'pars-image2pipeline', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wcsregions', 'wfssbkg']
+    >>> test_config.cleanup(old_state)
+    """
+
+def reftypes_roman_get_filekinds():
+    """
+    >>> old_state = test_config.setup()
+    >>> types = reftypes.get_types_object("roman")
+    >>> types.get_filekinds("wfi")
+    ['all', 'flat']
     >>> test_config.cleanup(old_state)
     """
 

--- a/crds/tests/test_substitutions.py
+++ b/crds/tests/test_substitutions.py
@@ -163,6 +163,16 @@ def substitutions_validate_jwst():
     >>> test_config.cleanup(old_state)
     """
 
+def substitutions_validate_roman():
+    """
+    >>> old_state = test_config.setup(url="https://roman-crds-serverless.stsci.edu", cache=test_config.CRDS_TESTING_CACHE)
+    >>> old_verbose = log.set_verbose()
+    >>> substitutions.validate_substitutions("roman-operational")  # doctest: +ELLIPSIS
+    CRDS - DEBUG -  Using CACHED CRDS reference assignment rules last updated on '...'
+    CRDS - DEBUG -  Instrument 'wfi' has no substitutions.
+    >>> _ = log.set_verbose(old_verbose)
+    >>> test_config.cleanup(old_state)
+    """
 # ==================================================================================
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(name="crds",
       author="STScI CRDS s/w developers",
       url="https://hst-crds.stsci.edu",
       license="BSD",
+      python_requires=">=3.7",
       install_requires=["astropy", "numpy", "filelock"] + SUBMISSION_DEPS,
       extras_require={
           "jwst": ["jwst"],


### PR DESCRIPTION
We added some initial Roman rules files in https://github.com/spacetelescope/crds-cache-test/pull/5, so we should now be able to run some basic tests.  I looked through the existing JWST and HST-specific tests and added Roman versions where appropriate (except for the "certify a mapping" and "certify a reference" test cases that @PaulHuwe is working on).