### PR TITLE
Remove rogue whitespace from FGS subarray name

### DIFF
--- a/crds/jwst/tpns/fgs_all.tpn
+++ b/crds/jwst/tpns/fgs_all.tpn
@@ -24,7 +24,7 @@ META.EXPOSURE.TYPE          H   C   O   FGS_DARK,FGS_FOCUS,FGS_IMAGE,FGS_INTFLAT
 # remove from .tpn when no longer present in active context.
 META.SUBARRAY.NAME         H    C   O    8X8,32X32,128X128,2048X64,\
                                          \
-                                         SUBIDSTRIPCENTER,SUBIDSTRIPLL​,\
+                                         SUBIDSTRIPCENTER,SUBIDSTRIPLL,\
                                          SUBTUNE32CENTERG1,SUBTUNE32CENTERG2,SUBTUNE32LLG1,SUBTUNE32LLG2,\
                                          \
                                          SUB128CENTER,SUB128DIAGONAL,SUB128LLCORNER,\


### PR DESCRIPTION
GitHub doesn't show it well on the diff, but there is a trailing zero-width space on the end of `SUBIDSTRIPLL​`.