### PR TITLE
Cover for bug in DataModel.to_flat_dict

### DIFF
--- a/crds/jwst/gen_system_crdscfg.py
+++ b/crds/jwst/gen_system_crdscfg.py
@@ -22,8 +22,7 @@ import yaml
 # ----------------------------------------------------------------------------------------------
 
 from jwst import __version__ as jwst_version
-from jwst.stpipe import pipeline
-from jwst import pipeline as pipepkg
+from jwst.stpipe import Pipeline
 
 # ----------------------------------------------------------------------------------------------
 
@@ -92,7 +91,7 @@ class CrdsCfgGenerator:
             log.info("Processing", repr(pipeline_cfg))
             cfgdir = "configs" # os.path.dirname(pipepkg.__file__) or ""
             cfgpath = os.path.join(cfgdir, pipeline_cfg)
-            p = pipeline.Pipeline.from_config_file(cfgpath)
+            p = Pipeline.from_config_file(cfgpath)
             steps_to_reftypes = {}
             for name, stepcfg in p.steps.items():
                 if stepcfg.get("skip", True):

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -10,6 +10,8 @@ import os.path
 import re
 import warnings
 
+from asdf.tags.core import NDArrayType
+
 # =======================================================================
 
 from crds.core import rmap, config, utils, timestamp, log, exceptions

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -81,6 +81,12 @@ def get_data_model_flat_dict(filepath):
     try:
         with datamodels.open(filepath) as d_model:
             flat_dict = d_model.to_flat_dict(include_arrays=False)
+            # stdatamodels 0.1.0 has a bug that causes arrays to still
+            # be returned:
+            flat_dict = {
+                k: v for k, v in flat_dict.items()
+                if not isinstance(v, NDArrayType)
+            }
     except Exception as exc:
         raise exceptions.ValidationError("JWST Data Models:", str(exc).replace("u'","'")) from exc
     return flat_dict

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -20,6 +20,8 @@ import re
 import warnings
 from collections import namedtuple
 
+from asdf.tags.core import NDArrayType
+
 # =======================================================================
 
 from crds.core import rmap, config, utils, timestamp, log, exceptions
@@ -138,16 +140,7 @@ def get_extra_tpninfos(refpath):
 def project_check(refpath):
     """
     >>> get_data_model_flat_dict('tests/data/roman_wfi16_f158_flat_small.asdf')
-    {'asdf_library.author': 'Space Telescope Science Institute', 'asdf_library.homepage': 'http://github.com/spacetelescope/asdf', 'asdf_library.name': 'asdf', 'asdf_library.version': '2.7.1', 'history.entries.0.description': 'Creation of dummy flat file for CRDS testing during DMS build 0.0.', 'history.entries.0.time': '2020-11-04T20:01:23', 'history.entries.1.description': 'Update of dummy flat file to test history entries.', 'history.entries.1.time': '2020-11-04T20:02:13', 'history.extensions.0.extension_class': 'astropy.io.misc.asdf.extension.AstropyAsdfExtension', 'history.extensions.0.software.name': 'astropy', 'history.extensions.0.software.version': '4.1', 'history.extensions.1.extension_class': 'asdf.extension.BuiltinExtension', 'history.extensions.1.software.name': 'asdf', 'history.extensions.1.software.version': '2.7.1', 'data': array([[0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.]], dtype=float32), 'dq': array([[0, 0, 0, 0],
-           [0, 0, 0, 0],
-           [0, 0, 0, 0],
-           [0, 0, 0, 0]], dtype=uint16), 'err': array([[0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.]], dtype=float32), 'meta.author': 'Space Telescope Science Institute', 'meta.date': '2020-12-02T22:56:06.721', 'meta.description': 'Flat reference file.', 'meta.filename': 'roman_wfi16_f158_flat_small.asdf', 'meta.instrument.detector': 'WFI16', 'meta.instrument.name': 'WFI', 'meta.instrument.optical_element': 'F158', 'meta.model_type': 'FlatModel', 'meta.pedigree': 'DUMMY', 'meta.reftype': 'FLAT', 'meta.telescope': 'ROMAN', 'meta.useafter': '2020-01-01T00:00:00.000'}
+    {'asdf_library.author': 'Space Telescope Science Institute', 'asdf_library.homepage': 'http://github.com/spacetelescope/asdf', 'asdf_library.name': 'asdf', 'asdf_library.version': '2.7.1', 'history.entries.0.description': 'Creation of dummy flat file for CRDS testing during DMS build 0.0.', 'history.entries.0.time': '2020-11-04T20:01:23', 'history.entries.1.description': 'Update of dummy flat file to test history entries.', 'history.entries.1.time': '2020-11-04T20:02:13', 'history.extensions.0.extension_class': 'astropy.io.misc.asdf.extension.AstropyAsdfExtension', 'history.extensions.0.software.name': 'astropy', 'history.extensions.0.software.version': '4.1', 'history.extensions.1.extension_class': 'asdf.extension.BuiltinExtension', 'history.extensions.1.software.name': 'asdf', 'history.extensions.1.software.version': '2.7.1', 'meta.author': 'Space Telescope Science Institute', 'meta.date': '2020-12-02T22:56:06.721', 'meta.description': 'Flat reference file.', 'meta.filename': 'roman_wfi16_f158_flat_small.asdf', 'meta.instrument.detector': 'WFI16', 'meta.instrument.name': 'WFI', 'meta.instrument.optical_element': 'F158', 'meta.model_type': 'FlatModel', 'meta.pedigree': 'DUMMY', 'meta.reftype': 'FLAT', 'meta.telescope': 'ROMAN', 'meta.useafter': '2020-01-01T00:00:00.000'}
 
     """
     return get_data_model_flat_dict(refpath)
@@ -162,16 +155,7 @@ def get_data_model_flat_dict(filepath):
     Returns   { file_keyword : keyword_value, ... }
 
     >>> get_data_model_flat_dict('tests/data/roman_wfi16_f158_flat_small.asdf')
-    {'asdf_library.author': 'Space Telescope Science Institute', 'asdf_library.homepage': 'http://github.com/spacetelescope/asdf', 'asdf_library.name': 'asdf', 'asdf_library.version': '2.7.1', 'history.entries.0.description': 'Creation of dummy flat file for CRDS testing during DMS build 0.0.', 'history.entries.0.time': '2020-11-04T20:01:23', 'history.entries.1.description': 'Update of dummy flat file to test history entries.', 'history.entries.1.time': '2020-11-04T20:02:13', 'history.extensions.0.extension_class': 'astropy.io.misc.asdf.extension.AstropyAsdfExtension', 'history.extensions.0.software.name': 'astropy', 'history.extensions.0.software.version': '4.1', 'history.extensions.1.extension_class': 'asdf.extension.BuiltinExtension', 'history.extensions.1.software.name': 'asdf', 'history.extensions.1.software.version': '2.7.1', 'data': array([[0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.]], dtype=float32), 'dq': array([[0, 0, 0, 0],
-           [0, 0, 0, 0],
-           [0, 0, 0, 0],
-           [0, 0, 0, 0]], dtype=uint16), 'err': array([[0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.],
-           [0., 0., 0., 0.]], dtype=float32), 'meta.author': 'Space Telescope Science Institute', 'meta.date': '2020-12-02T22:56:06.721', 'meta.description': 'Flat reference file.', 'meta.filename': 'roman_wfi16_f158_flat_small.asdf', 'meta.instrument.detector': 'WFI16', 'meta.instrument.name': 'WFI', 'meta.instrument.optical_element': 'F158', 'meta.model_type': 'FlatModel', 'meta.pedigree': 'DUMMY', 'meta.reftype': 'FLAT', 'meta.telescope': 'ROMAN', 'meta.useafter': '2020-01-01T00:00:00.000'}
+    {'asdf_library.author': 'Space Telescope Science Institute', 'asdf_library.homepage': 'http://github.com/spacetelescope/asdf', 'asdf_library.name': 'asdf', 'asdf_library.version': '2.7.1', 'history.entries.0.description': 'Creation of dummy flat file for CRDS testing during DMS build 0.0.', 'history.entries.0.time': '2020-11-04T20:01:23', 'history.entries.1.description': 'Update of dummy flat file to test history entries.', 'history.entries.1.time': '2020-11-04T20:02:13', 'history.extensions.0.extension_class': 'astropy.io.misc.asdf.extension.AstropyAsdfExtension', 'history.extensions.0.software.name': 'astropy', 'history.extensions.0.software.version': '4.1', 'history.extensions.1.extension_class': 'asdf.extension.BuiltinExtension', 'history.extensions.1.software.name': 'asdf', 'history.extensions.1.software.version': '2.7.1', 'meta.author': 'Space Telescope Science Institute', 'meta.date': '2020-12-02T22:56:06.721', 'meta.description': 'Flat reference file.', 'meta.filename': 'roman_wfi16_f158_flat_small.asdf', 'meta.instrument.detector': 'WFI16', 'meta.instrument.name': 'WFI', 'meta.instrument.optical_element': 'F158', 'meta.model_type': 'FlatModel', 'meta.pedigree': 'DUMMY', 'meta.reftype': 'FLAT', 'meta.telescope': 'ROMAN', 'meta.useafter': '2020-01-01T00:00:00.000'}
 
     """
     datamodels = get_datamodels()
@@ -180,6 +164,12 @@ def get_data_model_flat_dict(filepath):
         with datamodels.open(filepath) as d_model:
             d_model.validate()
             flat_dict = d_model.to_flat_dict(include_arrays=False)
+            # stdatamodels 0.1.0 has a bug that causes arrays to still
+            # be returned:
+            flat_dict = {
+                k: v for k, v in flat_dict.items()
+                if not isinstance(v, NDArrayType)
+            }
     except Exception as exc:
         raise exceptions.ValidationError("Roman Data Models:", str(exc).replace("u'","'")) from exc
     return flat_dict


### PR DESCRIPTION
`DataModel.to_flat_dict` returns NDArrayType instances even when include_arrays=False.  We'll need to fix that in stdatamodels, but this will stabilize our tests in the meantime.