### PR TITLE
Remove observatory-specific plugin for hijack_warnings

### DIFF
--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -629,28 +629,6 @@ def fits_to_parkeys(header):
     """Map a FITS header onto rmap parkeys appropriate for this observatory."""
     return dict(header)
 
-# ============================================================================
-
-def hijack_warnings(func, *args, **keys):
-    """Re-map dependency warnings to CRDS warnings so they're counted and logged
-    to web output.
-    """
-    with warnings.catch_warnings():
-        # save and replace warnings.showwarning
-        old_showwarning, warnings.showwarning = \
-            warnings.showwarning, abstract.hijacked_showwarning
-
-        # Always handle astropy warnings
-        from astropy.utils.exceptions import AstropyUserWarning
-        warnings.simplefilter("always", AstropyUserWarning)
-
-        try:
-            result = func(*args, **keys)
-        finally:
-            warnings.showwarning = old_showwarning
-
-    return result
-
 # =======================================================================
 
 def test():

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -635,40 +635,6 @@ def disable_fits_annotations():
 
 # ============================================================================
 
-def hijack_warnings(func, *args, **keys):
-    """Re-map dependency warnings to CRDS warnings so they're counted and logged
-    to web output.   astropy and datamodels are remapped.
-    """
-    with warnings.catch_warnings():
-        # save and replace warnings.showwarning
-        old_showwarning, warnings.showwarning = \
-            warnings.showwarning, abstract.hijacked_showwarning
-
-        # Always handle astropy warnings
-        from astropy.utils.exceptions import AstropyUserWarning
-        warnings.simplefilter("always", AstropyUserWarning)
-
-        # ValidationWarning was moved to stdatamodels after jwst
-        # 0.17.1.  The backup import from jwst can be removed
-        # once older versions are no longer being used.
-        try:
-            from stdatamodels.validate import ValidationWarning
-        except ImportError:
-            from jwst.datamodels.validate import ValidationWarning
-
-        warnings.filterwarnings("always", r".*", ValidationWarning, f".*jwst.*")
-        if not config.ALLOW_SCHEMA_VIOLATIONS:
-            warnings.filterwarnings("error", r".*is not one of.*", ValidationWarning, f".*jwst.*")
-
-        try:
-            result = func(*args, **keys)
-        finally:
-            warnings.showwarning = old_showwarning
-
-    return result
-
-# ============================================================================
-
 def test():
     """Run the module doctests."""
     import doctest

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -781,39 +781,6 @@ def get_cross_strapped_pairs(header):
 
 # ============================================================================
 
-def hijack_warnings(func, *args, **keys):
-    """Re-map dependency warnings to CRDS warnings so they're counted and logged
-    to web output.   astropy and datamodels are remapped.
-
-    Can't do much testing since the doctest ignores stderr.
-
-    >>> hijack_warnings(lambda *args, **keys: print('hooligan'), None, None)
-    hooligan
-
-    """
-    with warnings.catch_warnings():
-        # save and replace warnings.showwarning
-        old_showwarning, warnings.showwarning = \
-            warnings.showwarning, abstract.hijacked_showwarning
-
-        # Always handle astropy warnings
-        from astropy.utils.exceptions import AstropyUserWarning
-        warnings.simplefilter("always", AstropyUserWarning)
-
-        from stdatamodels.validate import ValidationWarning
-        warnings.filterwarnings("always", r".*", ValidationWarning, f".*roman.*")
-        if not config.ALLOW_SCHEMA_VIOLATIONS:
-            warnings.filterwarnings("error", r".*is not one of.*", ValidationWarning, f".*roman.*")
-
-        try:
-            result = func(*args, **keys)
-        finally:
-            warnings.showwarning = old_showwarning
-
-    return result
-
-# ============================================================================
-
 def test():
     """Run the module doctests."""
     import doctest


### PR DESCRIPTION
In crds 10.2.0 we changed the`@hijack_warnings` decorator to call an observatory-specific plugin so that we could support both Roman and JWST.  Unfortunately the `utils.file_to_observatory` method (indirectly) calls a method wrapped with that decorator, which means you need the observatory to determine the observatory, which results in the software defaulting to "jwst", which breaks `crds bestrefs` calls on HST data in certain environment variable configurations.

This PR changes `@hijack_warnings` back to its original form.  This is possible because Roman and JWST now share code in stdatamodels so there is no longer a need to catch different warnings depending on the observatory.

The two failing tests are due to an unrelated change in a Roman schema.