### PR TITLE
Add CCDAMP to ACS SATUFILE parkey

### DIFF
--- a/crds/hst/specs/acs_satufile.rmap
+++ b/crds/hst/specs/acs_satufile.rmap
@@ -8,7 +8,7 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'acs_satufile.rmap',
     'observatory' : 'HST',
-    'parkey' : (('DETECTOR',), ('DATE-OBS', 'TIME-OBS')),
+    'parkey' : (('DETECTOR', 'CCDAMP'), ('DATE-OBS', 'TIME-OBS')),
     'reffile_format' : 'IMAGE',
     'reffile_required' : 'YES',
     'reffile_switch' : 'BIASCORR',

--- a/crds/hst/tpns/acs_sat.tpn
+++ b/crds/hst/tpns/acs_sat.tpn
@@ -5,10 +5,11 @@
 # datatype = (Integer|Real|Logical|Double|Character)
 # presence = (Optional|Required)
 #
-# NAME	KEYTYPE  DATATYPE	PRESENCE	VALUES
+# NAME   KEYTYPE   DATATYPE   PRESENCE   VALUES
 #----------------------------------------------------------
-INSTRUME	H	C	R   	ACS
-FILETYPE	H	C	R    	"FULL-WELL SATURATION LEVEL MAP"
-DETECTOR	H	C	R	WFC,HRC,SBC
-USEAFTER  	H	C	R	&SYBDATE
-PEDIGREE  	H	C	R	&PEDIGREE
+INSTRUME   H   C   R   ACS
+FILETYPE   H   C   R   "FULL-WELL SATURATION LEVEL MAP"
+DETECTOR   H   C   R   WFC,HRC,SBC
+CCDAMP     H   C   R   A,B,C,D,AC,AD,BC,BD,ABCD,N/A
+USEAFTER   H   C   R   &SYBDATE
+PEDIGREE   H   C   R   &PEDIGREE


### PR DESCRIPTION
It has come to light that the ACS SATUFILE will need to match on CCDAMP for one of the detectors.  We're allowing N/A because the file for the WFC detector will not.