### PR TITLE
Add asdf to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name="crds",
       url="https://hst-crds.stsci.edu",
       license="BSD",
       python_requires=">=3.7",
-      install_requires=["astropy", "numpy", "filelock"] + SUBMISSION_DEPS,
+      install_requires=["astropy", "numpy", "filelock", "asdf"] + SUBMISSION_DEPS,
       extras_require={
           "jwst": ["jwst"],
           "roman" : ["romancal"],


### PR DESCRIPTION
At least some basic crds functions fail without asdf (`crds list --resolve-contexts --contexts` on a JWST cache, for example), so it seems that we should list it as a requirement instead of relying on the jwst or romancal packages to bring it in.