### PR TITLE
Add support for nircam extract1d

### DIFF
--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -3730,6 +3730,36 @@
             "tpn":"nircam_drizpars.tpn",
             "unique_rowkeys":null
         },
+        "extract1d":{
+            "derived_from":"Hand made 2021-04-07",
+            "extra_keys":null,
+            "file_ext":".json",
+            "filekind":"EXTRACT1D",
+            "filetype":"EXTRACT1D",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_extract1d_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_extract1d.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE",
+                    "META.INSTRUMENT.FILTER"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"6cec6a615f19b475e0b89db342238811a3419f76",
+            "suffix":"extract1d",
+            "text_descr":"1-D Spectral Extraction",
+            "tpn":"nircam_extract1d.tpn",
+            "unique_rowkeys":null
+        },
         "filteroffset":{
             "derived_from":"miri_filteroffset 2020-04-28 16:00:00",
             "extra_keys":null,

--- a/crds/jwst/specs/nircam_extract1d.rmap
+++ b/crds/jwst/specs/nircam_extract1d.rmap
@@ -1,0 +1,20 @@
+header = {
+    'derived_from' : 'Hand made 2021-04-07',
+    'file_ext' : '.json',
+    'filekind' : 'EXTRACT1D',
+    'filetype' : 'EXTRACT1D',
+    'instrument' : 'NIRCAM',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_nircam_extract1d.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE', 'META.INSTRUMENT.FILTER'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'reference_to_dataset' : {
+        'EXP_TYPE' : 'META.EXPOSURE.TYPE',
+    },
+    'sha1sum' : '6cec6a615f19b475e0b89db342238811a3419f76',
+    'suffix' : 'extract1d',
+    'text_descr' : '1-D Spectral Extraction',
+}
+
+selector = Match({
+})


### PR DESCRIPTION
Errors in the tests clued us into the fact that this rmap was delivered before the spec existed.  I filed a separate issue to investigate how that's possible.