### PR TITLE
Add 5 and 6 to the permissible COS LIFE_ADJ values

### DIFF
--- a/crds/hst/tpns/cos_1dx.tpn
+++ b/crds/hst/tpns/cos_1dx.tpn
@@ -19,11 +19,11 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "1-D EXTRACTION PARAMETERS TABLE"
 DETECTOR            H        C         R    FUV,NUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
-DESCRIP             H        C         R    
+DESCRIP             H        C         R
 PEDIGREE            H        C         R    &PEDIGREE
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4
+LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_1dx_ld.tpn
+++ b/crds/hst/tpns/cos_1dx_ld.tpn
@@ -15,7 +15,7 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    1DX
@@ -35,7 +35,7 @@ CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,13
           2952,2979,2996,3018,3035,3057,3074,3094,\
           2635,2950,3000,3360
 APERTURE            C        C         R    PSA,BOA,WCA,FCA
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4
+LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_2zx.tpn
+++ b/crds/hst/tpns/cos_2zx.tpn
@@ -14,10 +14,10 @@
 # NAME          KEYTYPE  DATATYPE  PRESENCE VALUES
 #----------------------------------------------------------
 INSTRUME            H        C         R    COS
-FILETYPE            H        C         R    "TWO-ZONE SPECTRAL EXTRACTION PARAMETERS TABLE"   
+FILETYPE            H        C         R    "TWO-ZONE SPECTRAL EXTRACTION PARAMETERS TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_2zx_ld.tpn
+++ b/crds/hst/tpns/cos_2zx_ld.tpn
@@ -27,7 +27,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 APERTURE            C        C         R    PSA,BOA
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_disp.tpn
+++ b/crds/hst/tpns/cos_disp.tpn
@@ -14,12 +14,12 @@
 INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "DISPERSION RELATION REFERENCE TABLE"
 DETECTOR            H        C         R    FUV,NUV
-LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,N/A
+LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,5,6,N/A
 OBSTYPE             H        C         R    SPECTROSCOPIC
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
-DESCRIP             H        C         R    
+DESCRIP             H        C         R
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_disp_ld.tpn
+++ b/crds/hst/tpns/cos_disp_ld.tpn
@@ -13,12 +13,12 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    DISP
 DETECTOR            C        C         R    FUV,NUV
-LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,N/A
+LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,5,6,N/A
 OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE        C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC

--- a/crds/hst/tpns/cos_flat.tpn
+++ b/crds/hst/tpns/cos_flat.tpn
@@ -14,11 +14,11 @@
 INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "FLAT FIELD REFERENCE IMAGE"
 DETECTOR            H        C         R    FUV,NUV
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
-DESCRIP             H        C         R    
+DESCRIP             H        C         R
 OPT_ELEM            H        C         O    G130M,G160M,G140L,\
                                             G185M,G225M,G285M,G230L, \
                                             MIRRORA,MIRRORB,ANY
-LIFE_ADJ            H        I         R    -1,0,1,2,3,4,-11
+LIFE_ADJ            H        I         R    -1,0,1,2,3,4,5,6,-11

--- a/crds/hst/tpns/cos_flat_ld.tpn
+++ b/crds/hst/tpns/cos_flat_ld.tpn
@@ -13,7 +13,7 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    FLAT
@@ -21,7 +21,7 @@ DETECTOR            C        C         R    FUV,NUV
 OPT_ELEM            C        C         O    G130M,G160M,G140L,\
                                             G185M,G225M,G285M,G230L,\
                                             MIRRORA,MIRRORB
-LIFE_ADJ            C        I         R    -1,0,1,2,3,4,-11
+LIFE_ADJ            C        I         R    -1,0,1,2,3,4,5,6,-11
 PEDIGREE            C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_lamp.tpn
+++ b/crds/hst/tpns/cos_lamp.tpn
@@ -15,11 +15,11 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "TEMPLATE CAL LAMP SPECTRA TABLE"
 DETECTOR            H        C         R    FUV,NUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
-DESCRIP             H        C         R    
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4
+DESCRIP             H        C         R
+LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_lamp_ld.tpn
+++ b/crds/hst/tpns/cos_lamp_ld.tpn
@@ -13,11 +13,11 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    LAMP
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4
+LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
 DETECTOR            C        C         R    FUV,NUV
 OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE        C        C         R    INFLIGHT,GROUND,MODEL,DUMMY

--- a/crds/hst/tpns/cos_phot.tpn
+++ b/crds/hst/tpns/cos_phot.tpn
@@ -17,11 +17,11 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "PHOTOMETRIC SENSITIVITY REFERENCE TABLE"
 DETECTOR            H        C         R    FUV,NUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
-DESCRIP             H        C         R    
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+DESCRIP             H        C         R
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_phot_ld.tpn
+++ b/crds/hst/tpns/cos_phot_ld.tpn
@@ -15,7 +15,7 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    PHOT
@@ -35,7 +35,7 @@ CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,13
           2952,2979,2996,3018,3035,3057,3074,3094,\
           2635,2950,3000,3360
 APERTURE            C        C         R    PSA,BOA,WCA
-LIFE_ADJ            C        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            C        I         R    -1,0,1,-11,2,3,4,5,6
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_profile.tpn
+++ b/crds/hst/tpns/cos_profile.tpn
@@ -1,7 +1,7 @@
 # Reference file name: PROFTAB
 # Keyword switch: ALGNCORR
 # Reference file extension: _profile
-# 
+#
 # .tpn file
 #
 # Template file used by certify to check reference files
@@ -17,7 +17,7 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "2D SPECTRUM PROFILE TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_profile_ld.tpn
+++ b/crds/hst/tpns/cos_profile_ld.tpn
@@ -26,7 +26,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 APERTURE            C        C         R    PSA,BOA,ANY
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_trace.tpn
+++ b/crds/hst/tpns/cos_trace.tpn
@@ -16,7 +16,7 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "1D SPECTRAL TRACE TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_trace_ld.tpn
+++ b/crds/hst/tpns/cos_trace_ld.tpn
@@ -25,7 +25,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 APERTURE            C        C         R    PSA,BOA
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_wcp.tpn
+++ b/crds/hst/tpns/cos_wcp.tpn
@@ -11,11 +11,11 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "WAVECAL PARAMETERS REFERENCE TABLE"
 DETECTOR            H        C         R    FUV,NUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-VCALCOS             H        C         R    
+VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
-DESCRIP             H        C         R    
+DESCRIP             H        C         R
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 N_SIGMA             C        R         O

--- a/crds/hst/tpns/cos_wcp_ld.tpn
+++ b/crds/hst/tpns/cos_wcp_ld.tpn
@@ -9,7 +9,7 @@
 #--------------------------------------------------------------------------
 USEAFTER_DATE       H        C         R    &SYBDATE
 OPUS_FLAG           H        C         R    Y,N
-COMPARISON_FILE     H        C         R    
+COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT          H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    WCP
@@ -18,7 +18,7 @@ OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE            C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4
+LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
 N_SIGMA             C        R         O
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE


### PR DESCRIPTION
COS will be delivering reference files with LIFE_ADJ=5 this year, and LIFE_ADJ=6 in 2022.  I don't see the harm in accepting both early.