### PR TITLE
Add retries and optional checksum and file size verification to crds_s3_get

### DIFF
--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -29,6 +29,8 @@ import warnings
 from . import log, config, pysh, exceptions
 from .constants import ALL_OBSERVATORIES, INSTRUMENT_KEYWORDS
 
+# from ..client import proxy  # import deferred until required
+
 # from crds.client import api  # deferred import below to simplify basic dependencies
 
 # ===================================================================
@@ -682,7 +684,13 @@ def get_s3_uri_content(s3_uri, mode="text"):
 
     Returns  contents of `s3_uri`.
     """
+    from ..client import proxy
+
     log.verbose(f"Fetching content from URI: '{s3_uri}'")
+    return proxy.apply_with_retries(_get_s3_uri_content, s3_uri, mode)
+
+
+def _get_s3_uri_content(s3_uri, mode):
     bucket_name, key = s3_uri.replace("s3://", "").split("/", 1)
     import boto3
     s3 = boto3.resource("s3")
@@ -693,9 +701,16 @@ def get_s3_uri_content(s3_uri, mode="text"):
         return text
     return binary
 
+
 def get_url_content(url, mode="text"):
     """Return the contents of `url` as a string."""
+    from ..client import proxy
+
     log.verbose(f"Fetching content from URL: '{url}'")
+    return proxy.apply_with_retries(_get_url_content, url, mode)
+
+
+def _get_url_content(url, mode):
     import requests
     r = requests.get(url)
     r.raise_for_status()
@@ -703,10 +718,13 @@ def get_url_content(url, mode="text"):
         return r.text
     return r.content
 
+
 def get_uri_content(uri, mode="text"):
     """Reads and returns the contents of the given s3://, https://
     or filename uri.   Reads to memory, intended for small files.
     """
+    from ..client import proxy
+
     if uri.startswith("s3://"):
         return get_s3_uri_content(uri, mode)
     elif uri.startswith(("http://", "https://")):

--- a/documentation/crds_users_guide/source/environment.rst
+++ b/documentation/crds_users_guide/source/environment.rst
@@ -234,7 +234,7 @@ HST OPS bucket::
 
   export CRDS_CONFIG_URI=s3://hst-crds-cache-ops/config/hst/
   export CRDS_DOWNLOAD_MODE=plugin
-  export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} ${FILE_SIZE} ${FILE_SHA1SUM}'
+  export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
   export CRDS_PATH=/path/to/local/cache
   export CRDS_PICKLE_URI=s3://hst-crds-cache-ops/pickles/hst/
   export CRDS_REFERENCE_URI=s3://hst-crds-cache-ops/references/hst/
@@ -457,4 +457,3 @@ based locks.  multiprocessing is the default.  To support multiple
 terminal windows or pipeline processing,  file based locking must be used
 with filelock recommended and known problems having been observed with the
 lockfile package.
-

--- a/envs/s3.sh
+++ b/envs/s3.sh
@@ -16,4 +16,4 @@ export CRDS_USE_PICKLED_CONTEXTS=0
 export CRDS_PICKLE_URI=s3://account/crds_cache/pickles/jwst
 
 export CRDS_DOWNLOAD_MODE=plugin
-export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} ${FILE_SIZE} ${FILE_SHA1SUM}'
+export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -2,6 +2,12 @@
 """
 S3 download plugin for CRDS.
 
+Exit status:
+0 - success
+10 - failed file size verification
+11 - failed checksum verification
+other codes - aws-cli failure.  See https://docs.aws.amazon.com/cli/latest/topic/return-codes.html
+
 As of 2021-04-23, copies of this script are maintained in the crds
 and caldp repositories.  Please ensure that any bug fixes make it into
 both!
@@ -16,8 +22,8 @@ import sys
 from crds.core.utils import checksum
 
 
-MAX_SLEEP_SECONDS = 20
-BASE_SLEEP_SECONDS = 2
+BAD_SIZE_STATUS = 10
+BAD_CHECKSUM_STATUS = 11
 
 
 def parse_args():
@@ -27,7 +33,6 @@ def parse_args():
     parser.add_argument("destination", help="Destination path on local filesystem")
     parser.add_argument("--file-size", help="Expected file size in bytes", type=int, default=None)
     parser.add_argument("--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
-    parser.add_argument("--max-retries", help="Maximum number of retries on download failure", type=int, default=3)
 
     return parser.parse_args()
 
@@ -35,41 +40,30 @@ def parse_args():
 def main():
     args = parse_args()
 
-    next_attempt = 1
-    while True:
-        returncode = 0
+    result = subprocess.run([
+        "aws", "s3", "cp", "--no-progress",
+        args.source,
+        args.destination,
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
 
-        result = subprocess.run([
-            "aws", "s3", "cp", "--no-progress",
-            args.source,
-            args.destination,
-        ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+    if result.returncode != 0:
+        output = "\\n".join(result.stdout.strip().splitlines())
+        print(f"crds_s3_get: Failed to download '{args.source}' with return code {result.returncode}: {output}", file=sys.stderr)
+        sys.exit(result.returncode)
 
-        if result.returncode == 0:
-            if args.file_size is not None:
-                downloaded_size = os.path.getsize(args.destination)
-                if downloaded_size != args.file_size:
-                    print(f"crds_s3_get: '{args.source}' failed file size check.  Expected: {args.file_size} Received: {downloaded_size}")
-                    returncode = 1
+    if args.file_size is not None:
+        downloaded_size = os.path.getsize(args.destination)
+        if downloaded_size != args.file_size:
+            print(f"crds_s3_get: '{args.source}' failed file size check.  Expected: {args.file_size} Received: {downloaded_size}")
+            os.unlink(args.destination)
+            sys.exit(BAD_SIZE_STATUS)
 
-            if args.file_sha1sum is not None:
-                downloaded_sha1sum = checksum(args.destination)
-                if downloaded_sha1sum != args.file_sha1sum:
-                    print(f"crds_s3_get: '{args.source}' failed checksum.  Expected: {args.file_sha1sum} Received: {downloaded_sha1sum}")
-                    returncode = 1
-        else:
-            output = "\\n".join(result.stdout.strip().splitlines())
-            print(f"crds_s3_get: Failed to download '{args.source}' with return code {result.returncode}: {output}", file=sys.stderr)
-            returncode = result.returncode
-
-        next_attempt += 1
-        if returncode == 0 or next_attempt > args.max_retries + 1:
-            sys.exit(returncode)
-        else:
-            # Exponential backoff with jitter, see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-            sleep_time = min(MAX_SLEEP_SECONDS, random.random() * (BASE_SLEEP_SECONDS ** (next_attempt - 1)))
-            print(f"crds_s3_get: Retrying after {sleep_time} seconds", file=sys.stderr)
-            time.sleep(sleep_time)
+    if args.file_sha1sum is not None:
+        downloaded_sha1sum = checksum(args.destination)
+        if downloaded_sha1sum != args.file_sha1sum:
+            print(f"crds_s3_get: '{args.source}' failed checksum.  Expected: {args.file_sha1sum} Received: {downloaded_sha1sum}")
+            os.unlink(args.destination)
+            sys.exit(BAD_CHECKSUM_STATUS)
 
 
 if __name__ == "__main__":

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -1,3 +1,76 @@
-#! /bin/sh
+#!/usr/bin/env python3
+"""
+S3 download plugin for CRDS.
 
-aws s3 cp --quiet --no-progress --only-show-errors  $1  $2
+As of 2021-04-23, copies of this script are maintained in the crds
+and caldp repositories.  Please ensure that any bug fixes make it into
+both!
+"""
+import argparse
+import os
+import random
+import subprocess
+import time
+import sys
+
+from crds.core.utils import checksum
+
+
+MAX_SLEEP_SECONDS = 20
+BASE_SLEEP_SECONDS = 2
+
+
+def parse_args():
+    parser = argparse.ArgumentParser("crds_s3_get", description="S3 download plugin for CRDS")
+
+    parser.add_argument("source", help="Source S3 URI")
+    parser.add_argument("destination", help="Destination path on local filesystem")
+    parser.add_argument("--file-size", help="Expected file size in bytes", type=int, default=None)
+    parser.add_argument("--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
+    parser.add_argument("--max-retries", help="Maximum number of retries on download failure", type=int, default=3)
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    next_attempt = 1
+    while True:
+        returncode = 0
+
+        result = subprocess.run([
+            "aws", "s3", "cp", "--no-progress",
+            args.source,
+            args.destination,
+        ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+
+        if result.returncode == 0:
+            if args.file_size is not None:
+                downloaded_size = os.path.getsize(args.destination)
+                if downloaded_size != args.file_size:
+                    print(f"crds_s3_get: '{args.source}' failed file size check.  Expected: {args.file_size} Received: {downloaded_size}")
+                    returncode = 1
+
+            if args.file_sha1sum is not None:
+                downloaded_sha1sum = checksum(args.destination)
+                if downloaded_sha1sum != args.file_sha1sum:
+                    print(f"crds_s3_get: '{args.source}' failed checksum.  Expected: {args.file_sha1sum} Received: {downloaded_sha1sum}")
+                    returncode = 1
+        else:
+            output = "\\n".join(result.stdout.strip().splitlines())
+            print(f"crds_s3_get: Failed to download '{args.source}' with return code {result.returncode}: {output}", file=sys.stderr)
+            returncode = result.returncode
+
+        next_attempt += 1
+        if returncode == 0 or next_attempt > args.max_retries + 1:
+            sys.exit(returncode)
+        else:
+            # Exponential backoff with jitter, see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+            sleep_time = min(MAX_SLEEP_SECONDS, random.random() * (BASE_SLEEP_SECONDS ** (next_attempt - 1)))
+            print(f"crds_s3_get: Retrying after {sleep_time} seconds", file=sys.stderr)
+            time.sleep(sleep_time)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Some useful updates to the crds_s3_get script:

- Add retries.  We've been seeing some transient errors from S3 and this will save pipeline operators from having to investigate and rescue jobs.
- Add optional checksum and file size verification