### PR TITLE
Fix model type validations in nirspec_area.tpn and miri_dark.tpn

### DIFF
--- a/crds/jwst/tpns/miri_dark.tpn
+++ b/crds/jwst/tpns/miri_dark.tpn
@@ -5,7 +5,7 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkModel
+META.MODEL_TYPE  H  S  R  DarkMIRIModel
 
 SCI   A   X   O   (ndim(SCI_ARRAY,4))
 ERR   A   X   O   (ndim(ERR_ARRAY,4))

--- a/crds/jwst/tpns/nirspec_area.tpn
+++ b/crds/jwst/tpns/nirspec_area.tpn
@@ -4,7 +4,7 @@ replace NIR_FILTER (is_imaging_mode(EXP_TYPE))
 
 include includes/nirspec_sci_array_norefpix.tpn
 
-META.MODEL_TYPE  H  S  R  NirspecSlitAreaModel,NirspecMosAreaModel,NirspecIfuAreaModel
+META.MODEL_TYPE  H  S  R  PixelAreaModel,NirspecSlitAreaModel,NirspecMosAreaModel,NirspecIfuAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector


### PR DESCRIPTION
This PR fixes two mistakes in the new META.MODEL_TYPE validations that became evident as we started validating existing files.