### PR TITLE
Update STIS and ACS IMPHTTAB DATACOL validations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+11.4.2 (unreleased)
+===================
+
+- Update STIS and ACS IMPHTTAB validations to permit additional
+  values in the DATACOL column. [#844]
+
 11.4.1 (2021-09-15)
 ===================
 

--- a/crds/hst/tpns/acs_imp.tpn
+++ b/crds/hst/tpns/acs_imp.tpn
@@ -23,7 +23,7 @@ USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R
 OBSMODE             C        C         R
-DATACOL             C        C         R
+DATACOL             C        C         R    PHOTBW,PHOTBW1,PHOTFLAM,PHOTFLAM1,PHOTPLAM,PHOTPLAM1,PHTFLAM1,PHTFLAM11,PHTFLAM2,PHTFLAM21
 PHOTFLAM            C        D         R
 PHOTPLAM            C        D         O
 PHOTBW              C        D         O

--- a/crds/hst/tpns/stis_imp.tpn
+++ b/crds/hst/tpns/stis_imp.tpn
@@ -10,7 +10,7 @@
 #   NOTE: DETECTOR should ALWAYS be wild-carded to ANY
 
 # 08/18/14  78534  MSwam   changes for multi-extension columns
-#   NOTE: Originally the STIS Team listed the L3_PHOTFLAM1 and L5_PAR1VALUES as 
+#   NOTE: Originally the STIS Team listed the L3_PHOTFLAM1 and L5_PAR1VALUES as
 #         datatype = LONG INT, but since CDBS certify has no selection for
 #         that type, we are using D instead.
 #
@@ -25,7 +25,7 @@ USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R
 OBSMODE             C        C         R
-DATACOL             C        C         R    PHOTFLAM,PHOTPLAM,PHOTBW
+DATACOL             C        C         R    PHOTBW,PHOTBW1,PHOTFLAM,PHOTFLAM1,PHOTPLAM,PHOTPLAM1,PHTFLAM1,PHTFLAM11,PHTFLAM2,PHTFLAM21
 PHOTFLAM            C        D         R
 PHOTPLAM            C        D         O
 PHOTBW              C        D         O


### PR DESCRIPTION
The .tpn for STIS did not include all the permitted values, and ACS was missing them entirely.