### PR TITLE
Change JWST validation errors into warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+11.4.3 (unreleased)
+===================
+
+- Change JWST validation errors into warnings. [#845]
+
 11.4.2 (2021-09-20)
 ===================
 

--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -685,7 +685,7 @@ class AsdfCertifier(ReferenceCertifier):
 
         with asdf.open(self.filename) as af:
             if not self._VERSION_RE.match(af["asdf_library"]["version"]):
-                self.log_and_track_error("File written with dev version of asdf library:", af["asdf_library"]["version"])
+                log.warning("File written with dev version of asdf library:", af["asdf_library"]["version"])
 
         self.check_schema()
 

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -81,28 +81,13 @@ def get_data_model_flat_dict(filepath):
     """Get the header from `filepath` using the jwst data model."""
     datamodels = get_datamodels()
     log.info("Checking JWST datamodels.")
+    # with log.error_on_exception("JWST Data Model (jwst.datamodels)"):
     try:
-        with warnings.catch_warnings(record=True) as captured_warnings:
-            with datamodels.open(filepath, cast_fits_arrays=False, validate_arrays=True) as d_model:
-                d_model.validate()
-
+        with datamodels.open(filepath) as d_model:
             flat_dict = d_model.to_flat_dict(include_arrays=False)
-
-        for captured_warning in captured_warnings:
-            if captured_warning.category == ValidationWarning:
-                log.error(f"Validation failure: {captured_warning.message}")
-            else:
-                log.warning(warnings.formatwarning(
-                    captured_warning.message,
-                    captured_warning.category,
-                    captured_warning.filename,
-                    captured_warning.lineno,
-                    captured_warning.line,
-                ))
-
-        return flat_dict
     except Exception as exc:
-        raise exceptions.ValidationError(str(exc)) from exc
+        raise exceptions.ValidationError("JWST Data Models:", str(exc).replace("u'","'")) from exc
+    return flat_dict
 
 # =======================================================================
 

--- a/crds/jwst/tpns/all_all.tpn
+++ b/crds/jwst/tpns/all_all.tpn
@@ -16,6 +16,8 @@ META.AUTHOR     H   C   R
 META.DESCRIPTION H   C  R
 META.HISTORY     H   C  R
 
+META.MODEL_TYPE  H   C  (warning(not(META_REFTYPE.startswith('pars-'))))
+
 # Make EXP_TYPE available in headers even if only UNDEFINED
 # Keyword cross-strapping doesn't work for UNDEFINED values...
 EXP_TYPE               H    C   O

--- a/crds/jwst/tpns/fgs_abvegaoffset.tpn
+++ b/crds/jwst/tpns/fgs_abvegaoffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  ABVegaOffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ABVegaOffsetModel

--- a/crds/jwst/tpns/fgs_apcorr.tpn
+++ b/crds/jwst/tpns/fgs_apcorr.tpn
@@ -8,7 +8,8 @@
 # NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
 #----------------------------------------------------------
 
-META.MODEL_TYPE  H  S  R  FgsImgApcorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FgsImgApcorrModel
 
 # FILTER                     C   C   R
 # PUPIL                      C   C   R

--- a/crds/jwst/tpns/fgs_area.tpn
+++ b/crds/jwst/tpns/fgs_area.tpn
@@ -2,7 +2,8 @@
 
 include includes/nir_sci_array_norefpix.tpn
 
-META.MODEL_TYPE  H  S  R  PixelAreaModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PixelAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector

--- a/crds/jwst/tpns/fgs_dark.tpn
+++ b/crds/jwst/tpns/fgs_dark.tpn
@@ -5,7 +5,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DarkModel
 
 # !!!! float32 ->  < 6G  ;  these further restrict .tpns above
 SCI       A           X         O             (SCI_ARRAY.DATA_TYPE=='float32')

--- a/crds/jwst/tpns/fgs_distortion.tpn
+++ b/crds/jwst/tpns/fgs_distortion.tpn
@@ -1,3 +1,4 @@
 # include includes/nir_subarray.tpn
 
-META.MODEL_TYPE  H  S  R  DistortionModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DistortionModel

--- a/crds/jwst/tpns/fgs_flat.tpn
+++ b/crds/jwst/tpns/fgs_flat.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  FlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FlatModel

--- a/crds/jwst/tpns/fgs_gain.tpn
+++ b/crds/jwst/tpns/fgs_gain.tpn
@@ -2,6 +2,7 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  GainModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  GainModel
 
 SCI    A    X    R   (ndim(SCI_ARRAY,2))

--- a/crds/jwst/tpns/fgs_ipc.tpn
+++ b/crds/jwst/tpns/fgs_ipc.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IPCModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IPCModel

--- a/crds/jwst/tpns/fgs_linearity.tpn
+++ b/crds/jwst/tpns/fgs_linearity.tpn
@@ -1,3 +1,4 @@
 include includes/nir_linearity.tpn
 
-META.MODEL_TYPE  H  S  R  LinearityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LinearityModel

--- a/crds/jwst/tpns/fgs_mask.tpn
+++ b/crds/jwst/tpns/fgs_mask.tpn
@@ -1,3 +1,4 @@
 include includes/nir_mask.tpn
 
-META.MODEL_TYPE  H  S  R  MaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MaskModel

--- a/crds/jwst/tpns/fgs_persat.tpn
+++ b/crds/jwst/tpns/fgs_persat.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PersistenceSatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PersistenceSatModel

--- a/crds/jwst/tpns/fgs_photom.tpn
+++ b/crds/jwst/tpns/fgs_photom.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  FgsImgPhotomModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FgsImgPhotomModel

--- a/crds/jwst/tpns/fgs_readnoise.tpn
+++ b/crds/jwst/tpns/fgs_readnoise.tpn
@@ -2,7 +2,8 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  ReadnoiseModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ReadnoiseModel
 
 BUNIT    H   C    W   DN,ADU
 

--- a/crds/jwst/tpns/fgs_saturation.tpn
+++ b/crds/jwst/tpns/fgs_saturation.tpn
@@ -8,7 +8,8 @@ include includes/nir_sci_array_both.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SaturationModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SaturationModel
 
 SCI   A   X    R  (ndim(SCI_ARRAY,2))
 DQ    A   X    O  (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/fgs_superbias.tpn
+++ b/crds/jwst/tpns/fgs_superbias.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SuperBiasModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SuperBiasModel

--- a/crds/jwst/tpns/fgs_trapdensity.tpn
+++ b/crds/jwst/tpns/fgs_trapdensity.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  TrapDensityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapDensityModel

--- a/crds/jwst/tpns/fgs_trappars.tpn
+++ b/crds/jwst/tpns/fgs_trappars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  TrapParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapParsModel

--- a/crds/jwst/tpns/miri_abvegaoffset.tpn
+++ b/crds/jwst/tpns/miri_abvegaoffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  ABVegaOffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ABVegaOffsetModel

--- a/crds/jwst/tpns/miri_apcorr.tpn
+++ b/crds/jwst/tpns/miri_apcorr.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  MirImgApcorrModel,MirLrsApcorrModel,MirMrsApcorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MirImgApcorrModel,MirLrsApcorrModel,MirMrsApcorrModel

--- a/crds/jwst/tpns/miri_area.tpn
+++ b/crds/jwst/tpns/miri_area.tpn
@@ -7,7 +7,8 @@ include includes/miri_subarray_both.tpn
 
 include includes/miri_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PixelAreaModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  O  PixelAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector

--- a/crds/jwst/tpns/miri_cubepar.tpn
+++ b/crds/jwst/tpns/miri_cubepar.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  MiriIFUCubeParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MiriIFUCubeParsModel
 
 # Make EXP_TYPE available in headers even if only UNDEFINED
 # Keyword cross-strapping doesn't work for UNDEFINED values...

--- a/crds/jwst/tpns/miri_dark.tpn
+++ b/crds/jwst/tpns/miri_dark.tpn
@@ -5,7 +5,8 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkMIRIModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DarkMIRIModel
 
 SCI   A   X   O   (ndim(SCI_ARRAY,4))
 ERR   A   X   O   (ndim(ERR_ARRAY,4))

--- a/crds/jwst/tpns/miri_distortion.tpn
+++ b/crds/jwst/tpns/miri_distortion.tpn
@@ -1,3 +1,4 @@
 # include includes/miri_subarray_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  DistortionModel,DistortionMRSModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DistortionModel,DistortionMRSModel

--- a/crds/jwst/tpns/miri_drizpars.tpn
+++ b/crds/jwst/tpns/miri_drizpars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  DrizParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DrizParsModel

--- a/crds/jwst/tpns/miri_extract1d.tpn
+++ b/crds/jwst/tpns/miri_extract1d.tpn
@@ -1,3 +1,4 @@
 # JSON references are also permitted, which do not
 # include a model type, so this must be optional.
-META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel,Extract1dIFUModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel,Extract1dIFUModel

--- a/crds/jwst/tpns/miri_filteroffset.tpn
+++ b/crds/jwst/tpns/miri_filteroffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  FilteroffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FilteroffsetModel

--- a/crds/jwst/tpns/miri_flat.tpn
+++ b/crds/jwst/tpns/miri_flat.tpn
@@ -5,4 +5,5 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  FlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FlatModel

--- a/crds/jwst/tpns/miri_fringe.tpn
+++ b/crds/jwst/tpns/miri_fringe.tpn
@@ -5,7 +5,8 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  FringeModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FringeModel
 
 SCI    A     X    O   (ndim(SCI_ARRAY,2))
 ERR    A     X    O   (ndim(ERR_ARRAY,2))

--- a/crds/jwst/tpns/miri_gain.tpn
+++ b/crds/jwst/tpns/miri_gain.tpn
@@ -2,7 +2,8 @@ include includes/miri_subarray_refpix.tpn
 
 include includes/miri_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  GainModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  GainModel
 
 SCI    A    X    R   (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/miri_ipc.tpn
+++ b/crds/jwst/tpns/miri_ipc.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IPCModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IPCModel

--- a/crds/jwst/tpns/miri_lastframe.tpn
+++ b/crds/jwst/tpns/miri_lastframe.tpn
@@ -3,4 +3,5 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  LastFrameModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LastFrameModel

--- a/crds/jwst/tpns/miri_linearity.tpn
+++ b/crds/jwst/tpns/miri_linearity.tpn
@@ -2,7 +2,8 @@ replace SCI COEFFS
 
 include includes/miri_subarray_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  LinearityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LinearityModel
 
 COEFFS       A           X         R            (has_type(COEFFS_ARRAY,'FLOAT'))
 COEFFS       A           X         R            (is_image(COEFFS_ARRAY))

--- a/crds/jwst/tpns/miri_mask.tpn
+++ b/crds/jwst/tpns/miri_mask.tpn
@@ -6,7 +6,8 @@ replace YDIM_MAX 1024
 replace DQ_TYPE 'INT'
 include includes/miri_sci_array_both.tpn
 
-META.MODEL_TYPE  H  S  R  MaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MaskModel
 
 DQ       A           X         O   (ndim(DQ_ARRAY,2))
 

--- a/crds/jwst/tpns/miri_photom.tpn
+++ b/crds/jwst/tpns/miri_photom.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  MirImgPhotomModel,MirLrsPhotomModel,MirMrsPhotomModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MirImgPhotomModel,MirLrsPhotomModel,MirMrsPhotomModel

--- a/crds/jwst/tpns/miri_psfmask.tpn
+++ b/crds/jwst/tpns/miri_psfmask.tpn
@@ -2,7 +2,8 @@ include includes/miri_subarray_refpix.tpn
 
 include includes/miri_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PsfMaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PsfMaskModel
 
 SCI       A           X         R            (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/miri_readnoise.tpn
+++ b/crds/jwst/tpns/miri_readnoise.tpn
@@ -2,7 +2,8 @@ include includes/miri_subarray_refpix.tpn
 
 include includes/miri_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  ReadnoiseModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ReadnoiseModel
 
 BUNIT    H   C    W   DN,ADU
 

--- a/crds/jwst/tpns/miri_regions.tpn
+++ b/crds/jwst/tpns/miri_regions.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  RegionsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  RegionsModel

--- a/crds/jwst/tpns/miri_reset.tpn
+++ b/crds/jwst/tpns/miri_reset.tpn
@@ -3,7 +3,8 @@ include includes/miri_err_array.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  ResetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ResetModel
 
 NGROUPS H       I      R
 NINTS   H       I      R

--- a/crds/jwst/tpns/miri_resol.tpn
+++ b/crds/jwst/tpns/miri_resol.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  MiriResolutionModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MiriResolutionModel

--- a/crds/jwst/tpns/miri_rscd.tpn
+++ b/crds/jwst/tpns/miri_rscd.tpn
@@ -1,5 +1,6 @@
 # MIRI RSCD
-META.MODEL_TYPE  H  S  R  RSCDModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  RSCDModel
 
 REFTYPE    H      C      R      RSCD
 

--- a/crds/jwst/tpns/miri_saturation.tpn
+++ b/crds/jwst/tpns/miri_saturation.tpn
@@ -7,7 +7,8 @@ include includes/miri_sci_array_both.tpn
 include includes/miri_dq_array.tpn
 include includes/miri_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SaturationModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SaturationModel
 
 SCI   A   X    R  (ndim(SCI_ARRAY,2))
 DQ    A   X    R  (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/miri_specwcs.tpn
+++ b/crds/jwst/tpns/miri_specwcs.tpn
@@ -1,3 +1,4 @@
 # include includes/miri_subarray_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  SpecwcsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SpecwcsModel

--- a/crds/jwst/tpns/miri_straymask.tpn
+++ b/crds/jwst/tpns/miri_straymask.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  StrayLightModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  StrayLightModel
 
 MASK       A           X         R             (MASK_ARRAY.SHAPE==(1024,1032))
 MASK       A           X         R             (has_type(MASK_ARRAY,'INT'))

--- a/crds/jwst/tpns/miri_tsophot.tpn
+++ b/crds/jwst/tpns/miri_tsophot.tpn
@@ -7,7 +7,8 @@
 #
 # NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
 #----------------------------------------------------------
-META.MODEL_TYPE  H  S  R  TsoPhotModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TsoPhotModel
 
 META.EXPOSURE.TYPE          H   C   R   MIR_IMAGE
 META.VISIT.TSOVISIT         H   C   R   TRUE,FALSE,ANY,N/A

--- a/crds/jwst/tpns/miri_wavelengthrange.tpn
+++ b/crds/jwst/tpns/miri_wavelengthrange.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  WavelengthrangeModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WavelengthrangeModel

--- a/crds/jwst/tpns/nircam_abvegaoffset.tpn
+++ b/crds/jwst/tpns/nircam_abvegaoffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  ABVegaOffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ABVegaOffsetModel

--- a/crds/jwst/tpns/nircam_apcorr.tpn
+++ b/crds/jwst/tpns/nircam_apcorr.tpn
@@ -2,7 +2,8 @@
 #----------------------------------------------------------
 include includes/apcorr.tpn
 
-META.MODEL_TYPE  H  S  R  NrcImgApcorrModel,NrcWfssApcorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NrcImgApcorrModel,NrcWfssApcorrModel
 
 FILTER                     C   C   R   CLEAR,F070W,F090W,F115W,F140M,F150W,F150W2,\
                                        F182M,F187N,F200W,F210M,F212N,WLP4,F277W,F356W,\

--- a/crds/jwst/tpns/nircam_area.tpn
+++ b/crds/jwst/tpns/nircam_area.tpn
@@ -2,7 +2,8 @@
 
 include includes/nir_sci_array_norefpix.tpn
 
-META.MODEL_TYPE  H  S  R  PixelAreaModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PixelAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector

--- a/crds/jwst/tpns/nircam_dark.tpn
+++ b/crds/jwst/tpns/nircam_dark.tpn
@@ -5,7 +5,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DarkModel
 
 SCI   A   X   R   (ndim(SCI_ARRAY,3))
 ERR   A   X   O   (ndim(ERR_ARRAY,3))

--- a/crds/jwst/tpns/nircam_distortion.tpn
+++ b/crds/jwst/tpns/nircam_distortion.tpn
@@ -1,3 +1,4 @@
 # include includes/nir_subarray.tpn
 
-META.MODEL_TYPE  H  S  R  DistortionModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DistortionModel

--- a/crds/jwst/tpns/nircam_drizpars.tpn
+++ b/crds/jwst/tpns/nircam_drizpars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  DrizParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DrizParsModel

--- a/crds/jwst/tpns/nircam_extract1d.tpn
+++ b/crds/jwst/tpns/nircam_extract1d.tpn
@@ -1,3 +1,4 @@
 # JSON references are also permitted, which do not
 # include a model type, so this must be optional.
-META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel

--- a/crds/jwst/tpns/nircam_filteroffset.tpn
+++ b/crds/jwst/tpns/nircam_filteroffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  FilteroffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FilteroffsetModel

--- a/crds/jwst/tpns/nircam_flat.tpn
+++ b/crds/jwst/tpns/nircam_flat.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  FlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FlatModel

--- a/crds/jwst/tpns/nircam_gain.tpn
+++ b/crds/jwst/tpns/nircam_gain.tpn
@@ -2,7 +2,8 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  GainModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  GainModel
 
 SCI    A    X    R   (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/nircam_ipc.tpn
+++ b/crds/jwst/tpns/nircam_ipc.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IPCModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IPCModel

--- a/crds/jwst/tpns/nircam_linearity.tpn
+++ b/crds/jwst/tpns/nircam_linearity.tpn
@@ -1,3 +1,4 @@
 include includes/nir_linearity.tpn
 
-META.MODEL_TYPE  H  S  R  LinearityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LinearityModel

--- a/crds/jwst/tpns/nircam_mask.tpn
+++ b/crds/jwst/tpns/nircam_mask.tpn
@@ -1,3 +1,4 @@
 include includes/nir_mask.tpn
 
-META.MODEL_TYPE  H  S  R  MaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MaskModel

--- a/crds/jwst/tpns/nircam_persat.tpn
+++ b/crds/jwst/tpns/nircam_persat.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PersistenceSatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PersistenceSatModel

--- a/crds/jwst/tpns/nircam_photom.tpn
+++ b/crds/jwst/tpns/nircam_photom.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  NrcImgPhotomModel,NrcWfssPhotomModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NrcImgPhotomModel,NrcWfssPhotomModel

--- a/crds/jwst/tpns/nircam_psfmask.tpn
+++ b/crds/jwst/tpns/nircam_psfmask.tpn
@@ -6,7 +6,8 @@ replace SCI_TYPE 'FLOAT'
 
 include includes/nir_sci_array_both.tpn
 
-META.MODEL_TYPE  H  S  R  PsfMaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PsfMaskModel
 
 SCI       A           X         R            (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/nircam_readnoise.tpn
+++ b/crds/jwst/tpns/nircam_readnoise.tpn
@@ -2,7 +2,8 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  ReadnoiseModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ReadnoiseModel
 
 BUNIT    H   C    W   DN,ADU
 

--- a/crds/jwst/tpns/nircam_saturation.tpn
+++ b/crds/jwst/tpns/nircam_saturation.tpn
@@ -8,7 +8,8 @@ include includes/nir_sci_array_both.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SaturationModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SaturationModel
 
 SCI   A   X    R  (ndim(SCI_ARRAY,2))
 DQ    A   X    O  (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/nircam_specwcs.tpn
+++ b/crds/jwst/tpns/nircam_specwcs.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  SpecwcsModel,NIRCAMGrismModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SpecwcsModel,NIRCAMGrismModel

--- a/crds/jwst/tpns/nircam_superbias.tpn
+++ b/crds/jwst/tpns/nircam_superbias.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SuperBiasModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SuperBiasModel

--- a/crds/jwst/tpns/nircam_trapdensity.tpn
+++ b/crds/jwst/tpns/nircam_trapdensity.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  TrapDensityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapDensityModel

--- a/crds/jwst/tpns/nircam_trappars.tpn
+++ b/crds/jwst/tpns/nircam_trappars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  TrapParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapParsModel

--- a/crds/jwst/tpns/nircam_tsophot.tpn
+++ b/crds/jwst/tpns/nircam_tsophot.tpn
@@ -8,7 +8,8 @@
 # NAME  KEYTYPE  DATATYPE   PRESENCE    VALUES
 #----------------------------------------------------------
 
-META.MODEL_TYPE  H  S  R  TsoPhotModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TsoPhotModel
 
 META.EXPOSURE.TYPE          H   C   R   NRC_TSIMAGE
 META.VISIT.TSOVISIT         H   C   R   TRUE,FALSE,ANY,N/A

--- a/crds/jwst/tpns/nircam_wavelengthrange.tpn
+++ b/crds/jwst/tpns/nircam_wavelengthrange.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  WavelengthrangeModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WavelengthrangeModel

--- a/crds/jwst/tpns/nircam_wfssbkg.tpn
+++ b/crds/jwst/tpns/nircam_wfssbkg.tpn
@@ -3,7 +3,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  WfssBkgModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WfssBkgModel
 
 META.EXPOSURE.TYPE    H      C     R     NRC_WFSS
 

--- a/crds/jwst/tpns/niriss_abvegaoffset.tpn
+++ b/crds/jwst/tpns/niriss_abvegaoffset.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  ABVegaOffsetModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ABVegaOffsetModel

--- a/crds/jwst/tpns/niriss_apcorr.tpn
+++ b/crds/jwst/tpns/niriss_apcorr.tpn
@@ -3,7 +3,8 @@
 #----------------------------------------------------------
 include includes/apcorr.tpn
 
-META.MODEL_TYPE  H  S  R  NisImgApcorrModel,NisWfssApcorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NisImgApcorrModel,NisWfssApcorrModel
 
 FILTER                     C   C   R   CLEAR,F090W,F115W,F140M,F150W,F200W,\
                                        F277W,F356W,F380M,F430M,F444W,F480M,\

--- a/crds/jwst/tpns/niriss_area.tpn
+++ b/crds/jwst/tpns/niriss_area.tpn
@@ -2,7 +2,8 @@
 
 include includes/nir_sci_array_norefpix.tpn
 
-META.MODEL_TYPE  H  S  R  PixelAreaModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PixelAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector

--- a/crds/jwst/tpns/niriss_dark.tpn
+++ b/crds/jwst/tpns/niriss_dark.tpn
@@ -5,7 +5,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DarkModel
 
 SCI   A   X   R   (ndim(SCI_ARRAY,3))
 ERR   A   X   O   (ndim(ERR_ARRAY,3))

--- a/crds/jwst/tpns/niriss_distortion.tpn
+++ b/crds/jwst/tpns/niriss_distortion.tpn
@@ -1,3 +1,4 @@
 # include includes/nir_subarray.tpn
 
-META.MODEL_TYPE  H  S  R  DistortionModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DistortionModel

--- a/crds/jwst/tpns/niriss_drizpars.tpn
+++ b/crds/jwst/tpns/niriss_drizpars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  DrizParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DrizParsModel

--- a/crds/jwst/tpns/niriss_extract1d.tpn
+++ b/crds/jwst/tpns/niriss_extract1d.tpn
@@ -1,3 +1,4 @@
 # JSON references are also permitted, which do not
 # include a model type, so this must be optional.
-META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel

--- a/crds/jwst/tpns/niriss_flat.tpn
+++ b/crds/jwst/tpns/niriss_flat.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  FlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FlatModel

--- a/crds/jwst/tpns/niriss_gain.tpn
+++ b/crds/jwst/tpns/niriss_gain.tpn
@@ -2,7 +2,8 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  GainModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  GainModel
 
 SCI    A    X    R   (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/niriss_ipc.tpn
+++ b/crds/jwst/tpns/niriss_ipc.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IPCModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IPCModel

--- a/crds/jwst/tpns/niriss_linearity.tpn
+++ b/crds/jwst/tpns/niriss_linearity.tpn
@@ -1,3 +1,4 @@
 include includes/nir_linearity.tpn
 
-META.MODEL_TYPE  H  S  R  LinearityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LinearityModel

--- a/crds/jwst/tpns/niriss_mask.tpn
+++ b/crds/jwst/tpns/niriss_mask.tpn
@@ -1,3 +1,4 @@
 include includes/nir_mask.tpn
 
-META.MODEL_TYPE  H  S  R  MaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MaskModel

--- a/crds/jwst/tpns/niriss_pathloss.tpn
+++ b/crds/jwst/tpns/niriss_pathloss.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  PathlossModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PathlossModel
 
 # Technically part of PS HDU
 APERTURE  H    C   R

--- a/crds/jwst/tpns/niriss_persat.tpn
+++ b/crds/jwst/tpns/niriss_persat.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PersistenceSatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PersistenceSatModel

--- a/crds/jwst/tpns/niriss_photom.tpn
+++ b/crds/jwst/tpns/niriss_photom.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  NisImgPhotomModel,NisWfssPhotomModel,NisSossPhotomModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NisImgPhotomModel,NisWfssPhotomModel,NisSossPhotomModel

--- a/crds/jwst/tpns/niriss_readnoise.tpn
+++ b/crds/jwst/tpns/niriss_readnoise.tpn
@@ -2,7 +2,8 @@ include includes/nir_subarray.tpn
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  ReadnoiseModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ReadnoiseModel
 
 BUNIT    H   C    W   DN,ADU
 

--- a/crds/jwst/tpns/niriss_saturation.tpn
+++ b/crds/jwst/tpns/niriss_saturation.tpn
@@ -8,7 +8,8 @@ include includes/nir_sci_array_both.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SaturationModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SaturationModel
 
 SCI   A   X    O  (ndim(SCI_ARRAY,2))
 DQ    A   X    O  (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/niriss_specwcs.tpn
+++ b/crds/jwst/tpns/niriss_specwcs.tpn
@@ -1,3 +1,4 @@
 include includes/nir_subarray.tpn
 
-META.MODEL_TYPE  H  S  R  SpecwcsModel,NIRISSGrismModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SpecwcsModel,NIRISSGrismModel

--- a/crds/jwst/tpns/niriss_superbias.tpn
+++ b/crds/jwst/tpns/niriss_superbias.tpn
@@ -5,4 +5,5 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SuperBiasModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SuperBiasModel

--- a/crds/jwst/tpns/niriss_throughput.tpn
+++ b/crds/jwst/tpns/niriss_throughput.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  ThroughputModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ThroughputModel

--- a/crds/jwst/tpns/niriss_trapdensity.tpn
+++ b/crds/jwst/tpns/niriss_trapdensity.tpn
@@ -1,4 +1,5 @@
 include includes/nir_subarray.tpn
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  TrapDensityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapDensityModel

--- a/crds/jwst/tpns/niriss_trappars.tpn
+++ b/crds/jwst/tpns/niriss_trappars.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  TrapParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapParsModel

--- a/crds/jwst/tpns/niriss_wavelengthrange.tpn
+++ b/crds/jwst/tpns/niriss_wavelengthrange.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  WavelengthrangeModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WavelengthrangeModel

--- a/crds/jwst/tpns/niriss_wfssbkg.tpn
+++ b/crds/jwst/tpns/niriss_wfssbkg.tpn
@@ -3,7 +3,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  WfssBkgModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WfssBkgModel
 
 META.EXPOSURE.TYPE    H      C     R     NIS_WFSS
 

--- a/crds/jwst/tpns/nirspec_apcorr.tpn
+++ b/crds/jwst/tpns/nirspec_apcorr.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  NrsMosApcorrModel,NrsIfuApcorrModel,NrsFsApcorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NrsMosApcorrModel,NrsIfuApcorrModel,NrsFsApcorrModel

--- a/crds/jwst/tpns/nirspec_area.tpn
+++ b/crds/jwst/tpns/nirspec_area.tpn
@@ -4,7 +4,8 @@ replace NIR_FILTER (is_imaging_mode(EXP_TYPE))
 
 include includes/nirspec_sci_array_norefpix.tpn
 
-META.MODEL_TYPE  H  S  R  PixelAreaModel,NirspecSlitAreaModel,NirspecMosAreaModel,NirspecIfuAreaModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PixelAreaModel,NirspecSlitAreaModel,NirspecMosAreaModel,NirspecIfuAreaModel
 
 # PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
 # PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector

--- a/crds/jwst/tpns/nirspec_barshadow.tpn
+++ b/crds/jwst/tpns/nirspec_barshadow.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  BarshadowModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  BarshadowModel
 
 EXP_TYPE   H      C      R     NRS_MSASPEC
 

--- a/crds/jwst/tpns/nirspec_camera.tpn
+++ b/crds/jwst/tpns/nirspec_camera.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  CameraModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  CameraModel

--- a/crds/jwst/tpns/nirspec_collimator.tpn
+++ b/crds/jwst/tpns/nirspec_collimator.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  CollimatorModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  CollimatorModel

--- a/crds/jwst/tpns/nirspec_cubepar.tpn
+++ b/crds/jwst/tpns/nirspec_cubepar.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  NirspecIFUCubeParsModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NirspecIFUCubeParsModel
 
 # Make EXP_TYPE available in headers even if only UNDEFINED
 # Keyword cross-strapping doesn't work for UNDEFINED values...

--- a/crds/jwst/tpns/nirspec_dark.tpn
+++ b/crds/jwst/tpns/nirspec_dark.tpn
@@ -9,7 +9,8 @@ include includes/nir_err_array.tpn
 include includes/nir_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  DarkModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DarkModel
 
 META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0
 

--- a/crds/jwst/tpns/nirspec_dflat.tpn
+++ b/crds/jwst/tpns/nirspec_dflat.tpn
@@ -7,7 +7,8 @@ include includes/nirspec_err_array.tpn
 include includes/nirspec_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  NirspecFlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NirspecFlatModel
 
 SCI          A           X         R             (ndim(SCI_ARRAY,3))
 # ERR          A           X         R             (ndim(ERR_ARRAY,3))

--- a/crds/jwst/tpns/nirspec_disperser.tpn
+++ b/crds/jwst/tpns/nirspec_disperser.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  DisperserModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DisperserModel

--- a/crds/jwst/tpns/nirspec_distortion.tpn
+++ b/crds/jwst/tpns/nirspec_distortion.tpn
@@ -1,3 +1,4 @@
 # include includes/nir_subarray.tpn
 
-META.MODEL_TYPE  H  S  R  DistortionModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  DistortionModel

--- a/crds/jwst/tpns/nirspec_extract1d.tpn
+++ b/crds/jwst/tpns/nirspec_extract1d.tpn
@@ -1,3 +1,4 @@
 # JSON references are also permitted, which do not
 # include a model type, so this must be optional.
-META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel,Extract1dIFUModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  O  Extract1dImageModel,MultiExtract1dImageModel,Extract1dIFUModel

--- a/crds/jwst/tpns/nirspec_fflat.tpn
+++ b/crds/jwst/tpns/nirspec_fflat.tpn
@@ -7,7 +7,8 @@ replace   NIR_FILTER   ((EXP_TYPE)in["NRS_MSASPEC"])
 # include includes/nir_dq_array.tpn
 # include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  NirspecFlatModel,NirspecQuadFlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NirspecFlatModel,NirspecQuadFlatModel
 
 #
 # Currently crds.certify doesn't have the capability of verifying something this complicated

--- a/crds/jwst/tpns/nirspec_flat.tpn
+++ b/crds/jwst/tpns/nirspec_flat.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  NirspecFlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NirspecFlatModel

--- a/crds/jwst/tpns/nirspec_fore.tpn
+++ b/crds/jwst/tpns/nirspec_fore.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  FOREModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FOREModel

--- a/crds/jwst/tpns/nirspec_fpa.tpn
+++ b/crds/jwst/tpns/nirspec_fpa.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  FPAModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  FPAModel

--- a/crds/jwst/tpns/nirspec_gain.tpn
+++ b/crds/jwst/tpns/nirspec_gain.tpn
@@ -6,7 +6,8 @@ replace YDIM_MAX 3200
 
 include includes/nirspec_sci_array_striped.tpn
 
-META.MODEL_TYPE  H  S  R  GainModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  GainModel
 
 SCI    A    X    R   (ndim(SCI_ARRAY,2))
 

--- a/crds/jwst/tpns/nirspec_ifufore.tpn
+++ b/crds/jwst/tpns/nirspec_ifufore.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IFUFOREModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IFUFOREModel

--- a/crds/jwst/tpns/nirspec_ifupost.tpn
+++ b/crds/jwst/tpns/nirspec_ifupost.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IFUPostModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IFUPostModel

--- a/crds/jwst/tpns/nirspec_ifuslicer.tpn
+++ b/crds/jwst/tpns/nirspec_ifuslicer.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IFUSlicerModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IFUSlicerModel

--- a/crds/jwst/tpns/nirspec_ipc.tpn
+++ b/crds/jwst/tpns/nirspec_ipc.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  IPCModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IPCModel

--- a/crds/jwst/tpns/nirspec_linearity.tpn
+++ b/crds/jwst/tpns/nirspec_linearity.tpn
@@ -13,7 +13,8 @@ include includes/nirspec_dq_array.tpn
 
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  LinearityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  LinearityModel
 
 COEFFS    A      X      R     (ndim(COEFFS_ARRAY,3))
 DQ        A      X      O     (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/nirspec_mask.tpn
+++ b/crds/jwst/tpns/nirspec_mask.tpn
@@ -10,6 +10,7 @@ include includes/nirspec_sci_array_striped.tpn
 
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  MaskModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MaskModel
 
 DQ       A           X        R       (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/nirspec_msa.tpn
+++ b/crds/jwst/tpns/nirspec_msa.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  MSAModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  MSAModel

--- a/crds/jwst/tpns/nirspec_ote.tpn
+++ b/crds/jwst/tpns/nirspec_ote.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  OTEModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  OTEModel

--- a/crds/jwst/tpns/nirspec_pathloss.tpn
+++ b/crds/jwst/tpns/nirspec_pathloss.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  PathlossModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PathlossModel
 
 # Technically part of PS HDU and required for all ver with different values
 # this latter aspect is not checked.

--- a/crds/jwst/tpns/nirspec_persat.tpn
+++ b/crds/jwst/tpns/nirspec_persat.tpn
@@ -4,4 +4,5 @@ replace NIR_FILTER (True)
 
 include includes/nir_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  PersistenceSatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PersistenceSatModel

--- a/crds/jwst/tpns/nirspec_photom.tpn
+++ b/crds/jwst/tpns/nirspec_photom.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  NrsFsPhotomModel,NrsMosPhotomModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NrsFsPhotomModel,NrsMosPhotomModel

--- a/crds/jwst/tpns/nirspec_readnoise.tpn
+++ b/crds/jwst/tpns/nirspec_readnoise.tpn
@@ -5,7 +5,8 @@ replace YDIM_MAX 3200
 
 include includes/nirspec_sci_array_striped.tpn
 
-META.MODEL_TYPE  H  S  R  ReadnoiseModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  ReadnoiseModel
 
 BUNIT    H   C    W   DN,ADU
 

--- a/crds/jwst/tpns/nirspec_refpix.tpn
+++ b/crds/jwst/tpns/nirspec_refpix.tpn
@@ -1,4 +1,5 @@
-META.MODEL_TYPE  H  S  R  IRS2Model
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  IRS2Model
 
 READPATT H   X     R    (('IRS2')in(READPATT))
 

--- a/crds/jwst/tpns/nirspec_saturation.tpn
+++ b/crds/jwst/tpns/nirspec_saturation.tpn
@@ -11,7 +11,8 @@ include includes/nirspec_sci_array_striped.tpn
 include includes/nirspec_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SaturationModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SaturationModel
 
 SCI   A   X    R  (ndim(SCI_ARRAY,2))
 DQ    A   X    O  (ndim(DQ_ARRAY,2))

--- a/crds/jwst/tpns/nirspec_sflat.tpn
+++ b/crds/jwst/tpns/nirspec_sflat.tpn
@@ -7,7 +7,8 @@ include includes/nirspec_err_array.tpn
 include includes/nirspec_dq_array.tpn
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  NirspecFlatModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  NirspecFlatModel
 
 WAVELENGTH   A           X         ((EXP_TYPE)in(['NRS_MSASPEC']))        (is_table(WAVELENGTH_ARRAY))
 WAVELENGTH   A           X         ((EXP_TYPE)in(['NRS_MSASPEC']))        (has_columns(WAVELENGTH_ARRAY,['WAVELENGTH']))

--- a/crds/jwst/tpns/nirspec_superbias.tpn
+++ b/crds/jwst/tpns/nirspec_superbias.tpn
@@ -10,6 +10,7 @@ include includes/nirspec_dq_array.tpn
 
 include includes/nir_dq_def_array.tpn
 
-META.MODEL_TYPE  H  S  R  SuperBiasModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  SuperBiasModel
 
 META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0

--- a/crds/jwst/tpns/nirspec_trapdensity.tpn
+++ b/crds/jwst/tpns/nirspec_trapdensity.tpn
@@ -4,4 +4,5 @@ replace NIR_FILTER True
 
 include includes/nirspec_sci_array_refpix.tpn
 
-META.MODEL_TYPE  H  S  R  TrapDensityModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  TrapDensityModel

--- a/crds/jwst/tpns/nirspec_wavecorr.tpn
+++ b/crds/jwst/tpns/nirspec_wavecorr.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  WaveCorrModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WaveCorrModel

--- a/crds/jwst/tpns/nirspec_wavelengthrange.tpn
+++ b/crds/jwst/tpns/nirspec_wavelengthrange.tpn
@@ -1,1 +1,2 @@
-META.MODEL_TYPE  H  S  R  WavelengthrangeModel
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  WavelengthrangeModel

--- a/crds/tests/test_certify.py
+++ b/crds/tests/test_certify.py
@@ -812,7 +812,7 @@ def certify_AsdfCertify_opaque_name():
     CRDS - INFO -  Certifying 'data/opaque_asd.tmp' as 'ASDF' relative to context 'jwst_0365.pmap'
     CRDS - INFO -  Setting 'META.INSTRUMENT.DETECTOR [DETECTOR]' = None to value of 'META.INSTRUMENT.P_DETECTOR [P_DETECT]' = 'NRS1|NRS2|'
     CRDS - INFO -  Checking JWST datamodels.
-    CRDS - ERROR -  data/opaque_asd.tmp Validation error : Unrecognized file type for: data/opaque_asd.tmp
+    CRDS - ERROR -  data/opaque_asd.tmp Validation error : JWST Data Models: Unrecognized file type for: data/opaque_asd.tmp
     >>> test_config.cleanup(old_state)
     >>> doctest.ELLIPSIS_MARKER = '...'
     """
@@ -849,7 +849,7 @@ def certify_jwst_bad_fits():
     CRDS - INFO -  Checking for duplicate modes using intersection ['FILTER', 'PUPIL']
     CRDS - WARNING -  No comparison reference for 'niriss_ref_photom_bad.fits' in context 'jwst_0541.pmap'. Skipping tables comparison.
     CRDS - INFO -  Checking JWST datamodels.
-    CRDS - ERROR -  Validation failure: While validating meta.instrument.detector the following error occurred: ...
+    CRDS - WARNING -  ValidationWarning : stdatamodels.validate : While validating meta.instrument.detector...
     >>> test_config.cleanup(old_state)
     """
 
@@ -995,7 +995,6 @@ def load_nirspec_staturation_tpn_lines():
     DQ_DEF       A           X         O             (has_column_type(DQ_DEF_ARRAY,'VALUE','INT'))
     DQ_DEF       A           X         O             (has_column_type(DQ_DEF_ARRAY,'NAME','STRING'))
     DQ_DEF       A           X         O             (has_column_type(DQ_DEF_ARRAY,'DESCRIPTION','STRING'))
-    META.MODEL_TYPE  H  S  R  SaturationModel
     SCI   A   X    R  (ndim(SCI_ARRAY,2))
     DQ    A   X    O  (ndim(DQ_ARRAY,2))
     META.EXPOSURE.GAIN_FACTOR     H   R   W  1.0:10.0
@@ -1058,7 +1057,6 @@ def load_nirspec_staturation_tpn():
      ('DQ_DEF', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression="(has_column_type(DQ_DEF_ARRAY,'VALUE','INT'))"),
      ('DQ_DEF', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression="(has_column_type(DQ_DEF_ARRAY,'NAME','STRING'))"),
      ('DQ_DEF', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression="(has_column_type(DQ_DEF_ARRAY,'DESCRIPTION','STRING'))"),
-     ('META.MODEL_TYPE', 'HEADER', 'CASE_SENSITIVE_CHARACTER', 'REQUIRED', values=('SaturationModel',)),
      ('SCI', 'ARRAY_FORMAT', 'EXPRESSION', 'REQUIRED', expression='(ndim(SCI_ARRAY,2))'),
      ('DQ', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression='(ndim(DQ_ARRAY,2))'),
      ('META.EXPOSURE.GAIN_FACTOR', 'HEADER', 'REAL', 'WARN', values=('1.0:10.0',))]
@@ -1099,7 +1097,6 @@ def load_miri_mask_tpn_lines():
     DQ       A           X         S             (DQ_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))
     DQ       A           X         S             (1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=1024)
     DQ       A           X         S             (1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=1032)
-    META.MODEL_TYPE  H  S  R  MaskModel
     DQ       A           X         O   (ndim(DQ_ARRAY,2))
     DQ_DEF       A           X         O             (is_table(DQ_DEF_ARRAY))
     DQ_DEF       A           X         O             (has_columns(DQ_DEF_ARRAY,['BIT','VALUE','NAME','DESCRIPTION']))
@@ -1142,7 +1139,6 @@ def load_miri_mask_tpn():
      ('DQ', 'ARRAY_FORMAT', 'EXPRESSION', 'IF_SUBARRAY', expression='(DQ_ARRAY.SHAPE[-2:]==(META_SUBARRAY_YSIZE,META_SUBARRAY_XSIZE))'),
      ('DQ', 'ARRAY_FORMAT', 'EXPRESSION', 'IF_SUBARRAY', expression='(1<=META_SUBARRAY_YSTART+DQ_ARRAY.SHAPE[-2]-1<=1024)'),
      ('DQ', 'ARRAY_FORMAT', 'EXPRESSION', 'IF_SUBARRAY', expression='(1<=META_SUBARRAY_XSTART+DQ_ARRAY.SHAPE[-1]-1<=1032)'),
-     ('META.MODEL_TYPE', 'HEADER', 'CASE_SENSITIVE_CHARACTER', 'REQUIRED', values=('MaskModel',)),
      ('DQ', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression='(ndim(DQ_ARRAY,2))'),
      ('DQ_DEF', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression='(is_table(DQ_DEF_ARRAY))'),
      ('DQ_DEF', 'ARRAY_FORMAT', 'EXPRESSION', 'OPTIONAL', expression="(has_columns(DQ_DEF_ARRAY,['BIT','VALUE','NAME','DESCRIPTION']))"),
@@ -1400,13 +1396,13 @@ def test_asdf_library_version_fail():
     CRDS - INFO -  ########################################
     CRDS - INFO -  Certifying 'data/jwst_fgs_distortion_bad_asdf_version.asdf' (1/1) as 'ASDF' relative to context 'jwst_0591.pmap'
     CRDS - INFO -  Setting 'META.EXPOSURE.TYPE [EXP_TYPE]' = None to value of 'META.EXPOSURE.P_EXPTYPE [P_EXPTYP]' = 'FGS_IMAGE|FGS_FOCUS|FGS_INTFLAT|FGS_SKYFLAT|'
-    CRDS - ERROR -  instrument='FGS' type='DISTORTION' data='data/jwst_fgs_distortion_bad_asdf_version.asdf' ::  File written with dev version of asdf library: 2.0.0.dev1213
+    CRDS - WARNING -  File written with dev version of asdf library: 2.0.0.dev1213
     CRDS - INFO -  Checking JWST datamodels.
     CRDS - INFO -  ########################################
-    CRDS - INFO -  1 errors
-    CRDS - INFO -  0 warnings
+    CRDS - INFO -  0 errors
+    CRDS - INFO -  1 warnings
     CRDS - INFO -  5 infos
-    1
+    0
     >>> test_config.cleanup(old_state)
     """
 

--- a/crds/tests/test_reftypes.py
+++ b/crds/tests/test_reftypes.py
@@ -147,7 +147,7 @@ def reftypes_jwst_reference_name_to_tpn_infos():    # doctest: +ELLIPSIS
      ('META.INSTRUMENT.GRATING', 'HEADER', 'CHARACTER', 'OPTIONAL', values=('G140M', 'G235M', 'G395M', 'G140H', 'G235H', 'G395H', 'PRISM', 'MIRROR', 'UNKNOWN', 'MULTIPLE', 'N/A', 'ANY')),
      ('META.INSTRUMENT.NAME', 'HEADER', 'CHARACTER', 'REQUIRED', values=('MIRI',)),
      ('META.INSTRUMENT.PUPIL', 'HEADER', 'CHARACTER', 'OPTIONAL', values=('CLEAR', 'CLEARP', 'F090W', 'F115W', 'F140M', 'F150W', 'F158M', 'F162M', 'F164N', 'F200W', 'F323N', 'F405N', 'F466N', 'F470N', 'FLAT', 'GDHS0', 'GDHS60', 'GR700XD', 'GRISMC', 'GRISMR', 'GRISMV2', 'GRISMV3', 'MASKBAR', 'MASKIPR', 'MASKRND', 'NRM', 'PINHOLES', 'WLM8', 'WLP8', 'ANY', 'N/A')),
-     ('META.MODEL_TYPE', 'HEADER', 'CASE_SENSITIVE_CHARACTER', 'REQUIRED', values=('FlatModel',)),
+     ('META.MODEL_TYPE', 'HEADER', 'CHARACTER', condition="(warning(not(META_REFTYPE.startswith('pars-'))))", values=()),
      ('META.PEDIGREE', 'HEADER', 'CHARACTER', 'REQUIRED', values=('&JWSTPEDIGREE',)),
      ('META.REFTYPE', 'HEADER', 'CHARACTER', 'REQUIRED', values=()),
      ('META.SUBARRAY.FASTAXIS', 'HEADER', 'INTEGER', 'OPTIONAL', values=('1', '-1', '2', '-2')),

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -3,14 +3,14 @@
 export CRDS_TEST_ROOT=$1
 
 (cd $CRDS_TEST_ROOT; rm -rf crds-cache-test;  git clone https://github.com/spacetelescope/crds-cache-test.git;)
-(cd $CRDS_TEST_ROOT; rm -rf crds-cache-default-test; curl https://hst-crds.stsci.edu/static/crds-cache-default-test.tar.bz2 -o crds-cache-default-test.tar.bz2; tar jxf crds-cache-default-test.tar.bz2; rm crds-cache-default-test.tar.bz2)
+(cd $CRDS_TEST_ROOT; rm -rf crds-cache-default-test; mkdir crds-cache-default-test;)
 
 export CRDS_PATH=$CRDS_TEST_ROOT/crds-cache-default-test
 export CRDS_TESTING_CACHE=$CRDS_TEST_ROOT/crds-cache-test
 
 export CRDS_SERVER_URL=https://hst-crds.stsci.edu
 python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
-python -m crds.sync --files l2d0959cj_pfl.fits n7p1032ao_apt.fits q5417413o_pct.fits xaf1429el_wcp.fits y2r1559to_apt.fits y2r16006o_pct.fits y951738kl_hv.fits yas2005el_hv.fits p7d1548qj_idc.fits 3241637sm_tmt.fits --stats --log-time
+python -m crds.sync --files l2d0959cj_pfl.fits n7p1032ao_apt.fits q5417413o_pct.fits xaf1429el_wcp.fits y2r1559to_apt.fits y2r16006o_pct.fits y951738kl_hv.fits yas2005el_hv.fits p7d1548qj_idc.fits 3241637sm_tmt.fits 41g16069m_tmg.fits 43h1909cm_tmc.fits --stats --log-time
 python -m crds.sync --contexts hst_cos.imap --fetch-references --log-time --stats
 
 export CRDS_SERVER_URL=https://jwst-crds.stsci.edu

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -10,7 +10,7 @@ export CRDS_TESTING_CACHE=$CRDS_TEST_ROOT/crds-cache-test
 
 export CRDS_SERVER_URL=https://hst-crds.stsci.edu
 python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
-python -m crds.sync --files l2d0959cj_pfl.fits n7p1032ao_apt.fits q5417413o_pct.fits xaf1429el_wcp.fits y2r1559to_apt.fits y2r16006o_pct.fits y951738kl_hv.fits yas2005el_hv.fits p7d1548qj_idc.fits 3241637sm_tmt.fits 41g16069m_tmg.fits 43h1909cm_tmc.fits --stats --log-time
+python -m crds.sync --files l2d0959cj_pfl.fits n7p1032ao_apt.fits q5417413o_pct.fits xaf1429el_wcp.fits y2r1559to_apt.fits y2r16006o_pct.fits y951738kl_hv.fits yas2005el_hv.fits p7d1548qj_idc.fits 3241637sm_tmt.fits 41g16069m_tmg.fits 43h1909cm_tmc.fits 43h1240om_tmc.fits --stats --log-time
 python -m crds.sync --contexts hst_cos.imap --fetch-references --log-time --stats
 
 export CRDS_SERVER_URL=https://jwst-crds.stsci.edu


### PR DESCRIPTION
This makes the following changes to the recently added JWST validations:

- DATAMODL validations for specific class names have been disabled.  The .tpn language doesn't easily support warnings for these kinds of checks, and we're going to revive this in a few months anyway, so it seems reasonable to just comment them out for now.  I restored the general warning that occurs when the DATAMODL keyword is missing.

- The asdf library dev version check has been changed from an error to a warning

- The get_data_model_flat_dict function has been reverted to its original state.  This means we're back to the status quo of not validating ASDF files and casting arrays to the schema dtype before FITS validation.  Datamodels validation failures will appear as warnings, as before.  Happily this also means we don't need to install a dev branch of jwst.