### PR TITLE
Add LITREF to synphot component tpns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,32 @@
+11.9.0 (unreleased)
+===================
+
+HST
+---
+
+- Add LITREF check to tpns for synphot component files. [#862]
+
 11.8.0 (2022-02-15)
 ===================
+
+Roman
+-----
 
 - New PixelArea RefType + PyTests. [#861]
 
 11.7.0 (2022-02-09)
 ===================
 
+Roman
+-----
+
 - New Photom RefType + PyTests. [#860]
 
 11.6.1 (2022-02-07)
 ===================
+
+JWST
+----
 
 - Add pub to the possible submission groups. [#859]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,32 +1,20 @@
 11.9.0 (unreleased)
 ===================
 
-HST
----
-
-- Add LITREF check to tpns for synphot component files. [#862]
+- Add LITREF check to tpns for synphot component files (HST). [#862]
 
 11.8.0 (2022-02-15)
 ===================
-
-Roman
------
 
 - New PixelArea RefType + PyTests. [#861]
 
 11.7.0 (2022-02-09)
 ===================
 
-Roman
------
-
 - New Photom RefType + PyTests. [#860]
 
 11.6.1 (2022-02-07)
 ===================
-
-JWST
-----
 
 - Add pub to the possible submission groups. [#859]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,48 +1,81 @@
 11.9.0 (unreleased)
 ===================
 
-- Add LITREF check to tpns for synphot component files (HST). [#862]
+HST
+---
+
+- Add LITREF check to tpns for synphot component files. [#862]
 
 11.8.0 (2022-02-15)
 ===================
+
+Roman
+-----
 
 - New PixelArea RefType + PyTests. [#861]
 
 11.7.0 (2022-02-09)
 ===================
 
+Roman
+-----
+
 - New Photom RefType + PyTests. [#860]
 
 11.6.1 (2022-02-07)
 ===================
+
+JWST
+----
 
 - Add pub to the possible submission groups. [#859]
 
 11.6.0 (2022-01-13)
 ===================
 
+JWST
+----
+
 - Update submission urls to include jwst-crds-pub [#856]
 
 - Fix syntax in all_tpn affecting readpatt verification [#857]
 
--  Update minimum python to 3.8 [#858]
+Infrastructure
+--------------
 
-   Also make this the 11.6.0 release
+-  Update minimum python to 3.8 [#858]
 
 11.5.2 (2021-12-10)
 ===================
 
-Trim translations to be specific to roman [#854]
+Roman
+-----
+
+- Trim translations to be specific to roman [#854]
 
 11.5.1 (Unreleased)
 ===================
 
-- Update documentation for the Submission API [#853]
+JWST
+----
 
 - Update miri pathloss spec [#855]
 
+Infrastructure
+--------------
+
+- Update documentation for the Submission API [#853]
+
 11.5.0 (2021-10-28)
 ===================
+
+JWST
+----
+
+- Add new reftype fringefreq [#846]
+
+Roman
+-----
 
 - Added new reftype saturation            [#847]
 
@@ -50,15 +83,19 @@ Trim translations to be specific to roman [#854]
 
 - Changed readnoise reftype definition    [#851]
 
-- Add new reftype fringefreq [#846]
-
 11.4.3 (2021-09-30)
 ===================
+
+JWST
+----
 
 - Change JWST validation errors into warnings. [#845]
 
 11.4.2 (2021-09-20)
 ===================
+
+HST
+---
 
 - Update STIS and ACS IMPHTTAB validations to permit additional
   values in the DATACOL column. [#844]
@@ -66,8 +103,14 @@ Trim translations to be specific to roman [#854]
 11.4.1 (2021-09-15)
 ===================
 
+JWST
+----
+
 - Update JWST certifier to show all datamodels validation failures
   instead of stopping at the first. [#842]
+
+Infrastructure
+--------------
 
 - Switch to setuptools_scm for package version management and
   deprecate ``crds.__rationale__`` variable. [#843]

--- a/crds/hst/tpns/synphot_syn.tpn
+++ b/crds/hst/tpns/synphot_syn.tpn
@@ -22,6 +22,8 @@ DESCRIP             H        C         R
 PEDIGREE            H        C         W    &PEDIGREE
 DATE                H        C         R
 
+LITREF              H        C         W
+
 WAVELENGTH      C        R             R
 THROUGHPUT      C        R             W
 

--- a/crds/hst/tpns/synphot_syn_ld.tpn
+++ b/crds/hst/tpns/synphot_syn_ld.tpn
@@ -22,6 +22,8 @@ DESCRIP             H        C         R
 PEDIGREE            H        C         W    &PEDIGREE
 DATE                H        C         R
 
+LITREF              H        C         W
+
 WAVELENGTH      C        R             R
 THROUGHPUT      C        R             W
 

--- a/crds/hst/tpns/synphot_th.tpn
+++ b/crds/hst/tpns/synphot_th.tpn
@@ -22,6 +22,8 @@ DESCRIP             H        C         R
 DATE                H        C         R
 PEDIGREE            H        C         W    &PEDIGREE
 
+LITREF              H        C         W
+
 WAVELENGTH          C        R         R
 EMISSIVITY          C        R         W
 

--- a/crds/hst/tpns/synphot_th_ld.tpn
+++ b/crds/hst/tpns/synphot_th_ld.tpn
@@ -22,6 +22,8 @@ DESCRIP             H        C         R
 DATE                H        C         R
 PEDIGREE            H        C         W    &PEDIGREE
 
+LITREF              H        C         W
+
 WAVELENGTH          C        R         R
 EMISSIVITY          C        R         W
 

--- a/crds/tests/test_bestrefs.py
+++ b/crds/tests/test_bestrefs.py
@@ -432,7 +432,7 @@ class TestBestrefs(test_config.CRDSTestCase):
         return now.isoformat().split("T")[0]
 
     def test_bestrefs_affected_datasets(self):
-        self.run_script(f"crds.bestrefs --affected-datasets --old-context hst_0943.pmap --new-context hst_0947.pmap "
+        self.run_script(f"crds.bestrefs --affected-datasets --old-context hst_0978.pmap --new-context hst_0980.pmap "
                         f"--datasets-since {self.get_10_days_ago()}",
                         expected_errs=0)
 

--- a/crds/tests/test_synphot_hst.py
+++ b/crds/tests/test_synphot_hst.py
@@ -291,6 +291,7 @@ def dt_synphot_certify_refs():
     CRDS - INFO -  Certifying 'data/wfc3_ir_f098m_002_th.fits' (1/1) as 'FITS' relative to context 'hst_0691.pmap'
     CRDS - INFO -  FITS file 'wfc3_ir_f098m_002_th.fits' conforms to FITS standards.
     CRDS - ERROR -  New filename version (002) must exceed previous version (002)
+    CRDS - WARNING -  Missing suggested keyword 'LITREF'
     CRDS - INFO -  Mode columns defined by spec for new reference 'wfc3_ir_f098m_002_th.fits[1]' are: ['WAVELENGTH']
     CRDS - INFO -  All column names for this table new reference 'wfc3_ir_f098m_002_th.fits[1]' are: ['WAVELENGTH', 'EMISSIVITY']
     CRDS - INFO -  Checking for duplicate modes using intersection ['WAVELENGTH']
@@ -341,6 +342,7 @@ def dt_synphot_certify_refs():
     CRDS - INFO -  Certifying 'data/wfc3_uvis_f469nf2_003_syn.fits' (1/1) as 'FITS' relative to context 'hst_0691.pmap'
     CRDS - INFO -  FITS file 'wfc3_uvis_f469nf2_003_syn.fits' conforms to FITS standards.
     CRDS - ERROR -  New filename version (003) must exceed previous version (003)
+    CRDS - WARNING -  Missing suggested keyword 'LITREF'
     CRDS - INFO -  Mode columns defined by spec for new reference 'wfc3_uvis_f469nf2_003_syn.fits[1]' are: ['WAVELENGTH']
     CRDS - INFO -  All column names for this table new reference 'wfc3_uvis_f469nf2_003_syn.fits[1]' are: ['WAVELENGTH', 'THROUGHPUT']
     CRDS - INFO -  Checking for duplicate modes using intersection ['WAVELENGTH']

--- a/crds/tests/test_synphot_hst.py
+++ b/crds/tests/test_synphot_hst.py
@@ -331,7 +331,7 @@ def dt_synphot_certify_refs():
     CRDS - INFO -  >> **** Verification found 0 warning(s) and 0 error(s). ****
     CRDS - INFO -  ########################################
     CRDS - INFO -  1 errors
-    CRDS - INFO -  1 warnings
+    CRDS - INFO -  2 warnings
     CRDS - INFO -  40 infos
     1
 
@@ -382,7 +382,7 @@ def dt_synphot_certify_refs():
     CRDS - INFO -  >> **** Verification found 0 warning(s) and 0 error(s). ****
     CRDS - INFO -  ########################################
     CRDS - INFO -  1 errors
-    CRDS - INFO -  1 warnings
+    CRDS - INFO -  2 warnings
     CRDS - INFO -  40 infos
     1
 


### PR DESCRIPTION
LITREF should be an optional string-type keyword but we'll display a warning when it is missing.