### PR TITLE
Add V3 of ACS header hook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.10.0 (unreleased)
+====================
+
+HST
+---
+
+- Add V3 of ACS precondition header hook. [#863]
+
 11.9.0 (2022-02-23)
 ===================
 
@@ -10,7 +18,6 @@ HST
 ---
 
 - Add LITREF check to tpns for synphot component files. [#862]
-
 
 11.8.0 (2022-02-15)
 ===================

--- a/crds/hst/acs.py
+++ b/crds/hst/acs.py
@@ -1,7 +1,8 @@
 """Master ACS hooks module,  importer of versioned hooks."""
 
 from .acs_v1 import precondition_header_acs_biasfile_v1  # , acs_biasfile_filter
-from .acs_v2 import precondition_header_acs_biasfile_v2, fallback_header_acs_biasfile_v2, acs_biasfile_filter, acs_darkfile_filter
+from .acs_v2 import precondition_header_acs_biasfile_v2, fallback_header_acs_biasfile_v2 # , acs_biasfile_filter, acs_darkfile_filter
+from .acs_v3 import precondition_header_acs_biasfile_v3, fallback_header_acs_biasfile_v3, acs_biasfile_filter, acs_darkfile_filter
 
 #
 # This section contains relevant code from cdbsquery.py and explanation,  such as it is.

--- a/crds/hst/acs_common.py
+++ b/crds/hst/acs_common.py
@@ -11,10 +11,14 @@ from crds.core import rmap, log, utils, timestamp
 
 ACS_HALF_CHIP_COLS = 2048         #used in custom bias selection algorithm
 
-SM4 = timestamp.reformat_date("2009-05-14 00:00:00.000000")
 # date beyond which an exposure was
 # taken in the SM4 configuration
 # (day 2009.134 = May 14 2009,
 #  after HST was captured by
 #  the shuttle during SM4, and
 #  pre-SM4 exposures had ceased)
+SM4 = timestamp.reformat_date("2009-05-14 00:00:00.000000")
+
+# Date after which subarray references were added to the
+# BIASFILE rmap so header preconditioning is no longer needed.
+PRE_SM4_SUBARRAY = timestamp.reformat_date("2002-08-01 00:00:00.000000")

--- a/crds/hst/acs_v3.py
+++ b/crds/hst/acs_v3.py
@@ -1,0 +1,164 @@
+"""
+Updated February 2022 to prevent preconditioning where
+new subarray references have been added to the rmap.
+
+Additionally, the BIASFILE parkey was updated to match
+on RAW_LTVn instead of LTVn.
+"""
+import copy
+
+from .acs_common import *
+
+
+def precondition_required(header, exptime):
+    """
+    Return True if this header requires preconditioning.
+    """
+    if header["DETECTOR"] != "WFC":
+        return True
+
+    if exptime < PRE_SM4_SUBARRAY:
+        return True
+
+    if "APERTURE" not in header or header["APERTURE"] == "UNDEFINED":
+        return True
+
+    if float(header["CCDGAIN"]) in (4.0, 8.0):
+        return True
+
+    if header["CCDAMP"] in ("AD", "BC"):
+        return True
+
+    return False
+
+
+def precondition_header_acs_biasfile_v3(rmap, header_in):
+    """Mutate the incoming dataset header based upon hard coded rules
+    and the header's contents.   This is an alternative to generating
+    an equivalent and bulkier rmap.
+    """
+    header = dict(header_in)
+    log.verbose("acs_biasfile_precondition_header:", log.format_parameter_list(header))
+
+    exptime = timestamp.reformat_date(header["DATE-OBS"] + " " + header["TIME-OBS"])
+
+    if not precondition_required(header, exptime):
+        return header
+
+    if (exptime < SM4):
+        #if "APERTURE" not in header or header["APERTURE"] == "UNDEFINED":
+        log.verbose("Mapping pre-SM4 APERTURE to N/A")
+        header["APERTURE"] = "N/A"
+    try:
+        naxis1 = int(float(header["NAXIS1"]))
+    except ValueError:
+        log.verbose("acs_biasfile_selection: bad NAXIS1.")
+        # sys.exc_clear()
+    else:
+        header["NAXIS1"] = utils.condition_value(str(naxis1))
+        # if pre-SM4 and NAXIS1 > HALF_CHIP
+        exptime = timestamp.reformat_date(header["DATE-OBS"] + " " + header["TIME-OBS"])
+        if (exptime < SM4):
+            if naxis1 > ACS_HALF_CHIP_COLS:
+                if header["CCDAMP"] in ["A","D"]:
+                    log.verbose("acs_bias_file_selection: exposure is pre-SM4, converting amp A or D " +
+                                "to AD for NAXIS1 = " + header["NAXIS1"])
+                    header["CCDAMP"] = "AD"
+                elif header["CCDAMP"] in ["B","C"]:
+                    log.verbose("acs_bias_file_selection: exposure is pre-SM4, converting amp B or C " +
+                                "to BC for NAXIS1 = " + header["NAXIS1"])
+                    header["CCDAMP"] = "BC"
+    if header['DETECTOR'] == "WFC" and \
+        header['XCORNER'] == "0.0" and header['YCORNER'] == "0.0":
+        log.verbose("acs_biasfile_selection: precondition_header halving NAXIS2")
+        try:
+            naxis2 = int(float(header["NAXIS2"])) / 2
+        except ValueError:
+            log.verbose("acs_biasfile_selection: bad NAXIS2.")
+            # sys.exc_clear()
+        else:
+            header["NAXIS2"] = utils.condition_value(str(naxis2))
+    dump_mutations(header_in, header)
+    return header
+
+
+def dump_mutations(header1, header2):
+    log.verbose("In header1 not header2:", set(dict(header1).items()) - set(dict(header2).items()))
+    log.verbose("In header2 not header1:", set(dict(header2).items()) - set(dict(header1).items()))
+
+
+
+BIASFILE_PARKEYS = ('DETECTOR', 'CCDAMP', 'CCDGAIN', 'APERTURE', 'NAXIS1', 'NAXIS2', 'RAW_LTV1', 'RAW_LTV2', 'XCORNER', 'YCORNER', 'CCDCHIP')
+
+
+def fallback_header_acs_biasfile_v3(rmap, header_in):
+    """Mutates dataset header for 2nd try when primary match fails."""
+    header = precondition_header_acs_biasfile_v3(rmap, header_in)
+    log.verbose("No matching BIAS file found for",
+               "NAXIS1=" + repr(header['NAXIS1']),
+               "NAXIS2=" + repr(header['NAXIS2']),
+               "RAW_LTV1=" + repr(header['RAW_LTV1']),
+               "RAW_LTV2=" + repr(header['RAW_LTV2']))
+    log.verbose("Trying full-frame default search")
+    if header['DETECTOR'] == "WFC":
+        header["NAXIS1"] = "4144.0"
+        header["NAXIS2"] = "2068.0"
+        header["RAW_LTV1"] = "24.0"
+        header["RAW_LTV2"] = "0.0"
+    else:
+        header["NAXIS1"] = "1062.0"
+        header["NAXIS2"] = "1044.0"
+        header["RAW_LTV1"] = "19.0"
+        if header['CCDAMP'] in ["C","D"]:
+            header["RAW_LTV2"] = "0.0"
+        else: # assuming HRC with CCDAMP = A or B
+            header["RAW_LTV2"] = "20.0"
+    return header
+
+def acs_biasfile_filter(kmap_orig):
+    """
+    Post-SM4 APERTURE's of '' were all replaced and cannot match,  hence dropped at CRDS rmap generation time.
+    """
+    kmap = copy.deepcopy(kmap_orig)
+    header_additions = {
+        "hooks" : {
+            "precondition_header" : "precondition_header_acs_biasfile_v3",
+            "fallback_header" : "fallback_header_acs_biasfile_v3",
+            },
+        }
+    for match in kmap_orig:
+        header = dict(list(zip(BIASFILE_PARKEYS, match)))
+        if header["APERTURE"] == "":
+            for filemap in kmap_orig[match]:
+                if filemap.date > SM4:
+                    log.warning("Removing empty post-SM4 APERTURE for", repr(filemap))
+                else:  # conceptually,  N/A.   To prevent conincidental stronger matches: *.
+                    log.warning("Setting empty pre-SM4 APERTURE to 'N/A' for", repr(filemap))
+                    new_match = match[0:3] + ("N/A",) + match[4:]
+                    if new_match not in kmap:
+                        kmap[new_match] = []
+                    if filemap not in kmap[new_match]:
+                        kmap[new_match].append(filemap)
+                        kmap[new_match].sort()
+                kmap[match].remove(filemap)
+            if not kmap[match]:
+                log.warning("Removing empty match", repr(match))
+                del kmap[match]
+    return kmap, header_additions
+
+
+def acs_darkfile_filter(kmap_orig):
+    """
+    Post-SM4 APERTURE's of '' were all replaced and cannot match,  hence dropped at CRDS rmap generation time.
+    """
+    kmap = copy.deepcopy(kmap_orig)
+    header_additions = {}
+    for match in kmap_orig:
+        header = dict(list(zip(BIASFILE_PARKEYS, match)))
+        try:
+            if float(header["CCDGAIN"]) == -999.0:
+                log.warning("CCDGAIN=-999.0 Deleting match", match, "with", kmap[match])
+                del kmap[match]
+        except Exception:
+            pass
+    return kmap, header_additions


### PR DESCRIPTION
This adds a new set of hooks for ACS BIASFILE with the following changes:

- Skip preconditioning for observation dates on 2009-05-14 or after, unless the dataset has known bogus values in its header
- Match references using RAW_LTVn keywords instead of LTVn (LTVn is modified by the cal code which affects reprocessing results)

I ran bestrefs on all ACS headers using the new hooks and @mmcdonald123 confirmed that the results are as expected.
