### PR TITLE
CCD-1161 Implement timeout on CRDS Server network requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ Roman
 
 - added: distortion rmap + tpn [#867]
 
+JWST
+----
+
+- Implement timeout on CRDS Server network requests [#869]
+
 
 11.11.0 (unreleased)
 ====================

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -232,7 +232,7 @@ def get_total_bytes(info_map):
 
 def get_sqlite_db(observatory):
     """Download the CRDS database as a SQLite database."""
-    assert not config.get_cache_readonly(), "Readonly cache, updating the SQLite database cannot be done."""
+    assert not config.get_cache_readonly(), "Readonly cache, updating the SQLite database cannot be done."
     encoded_compressed_data = S.get_sqlite_db(observatory)
     data = zlib.decompress(base64.b64decode(encoded_compressed_data))
     path = config.get_sqlite3_db_path(observatory)

--- a/crds/client/proxy.py
+++ b/crds/client/proxy.py
@@ -144,10 +144,11 @@ class ServiceCallBinding:
 
     def _call_service(self, parameters, url):
         """Call the JSONRPC defined by `parameters` and raise a ServiceError on any exception."""
+        timeout = config.get_client_timeout_seconds()
         if not isinstance(parameters, bytes):
             parameters = parameters.encode("utf-8")
         try:
-            channel = request.urlopen(url, parameters)
+            channel = request.urlopen(url, parameters, timeout=timeout)
             return channel.read().decode("utf-8")
         except Exception as exc:
             raise exceptions.ServiceError("CRDS jsonrpc failure " + repr(self.__service_name) + " " + str(exc)) from exc

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -781,6 +781,12 @@ def get_client_retry_delay_seconds():
     """Return the integer number of seconds CRDS should wait between retrying failed network transactions."""
     return CLIENT_RETRY_DELAY_SECONDS.get()
 
+CLIENT_TIMEOUT = IntConfigItem(
+    "CRDS_CLIENT_TIMEOUT_SECONDS", 60, "Seconds to wait for a CRDS network request to complete.")
+
+def get_client_timeout_seconds():
+    return CLIENT_TIMEOUT.get()
+
 def enable_retries(retry_count=20, delay_seconds=10):
     """Set reasonable defaults for CRDS retries"""
     CLIENT_RETRY_COUNT.set(retry_count)
@@ -790,6 +796,8 @@ def disable_retries():
     """Set the defaults for only one try for each network transaction."""
     CLIENT_RETRY_COUNT.set(1)
     CLIENT_RETRY_DELAY_SECONDS.set(0)
+
+# -------------------------------------------------------------------------------------
 
 # -------------------------------------------------------------------------------------
 

--- a/documentation/crds_users_guide/source/environment.rst
+++ b/documentation/crds_users_guide/source/environment.rst
@@ -447,6 +447,9 @@ transaction with the CRDS server.  Defaults to 1 meaning 1 try with no retries.
 network transaction before trying again.  Defaults to 0 seconds,  meaning
 proceed immediately after fail.
 
+**CRDS_CLIENT_TIMEOUT_SECONDS** number of seconds CRDS will wait for a network
+transaction to complete.
+
 **CRDS_USE_LOCKING** boolean enabling/disabling CRDS cache locking,  currently
 only used for JWST and defaulting to enabled.   File locking is currently limited
 to JWST calibrations so HST sync and bestrefs tools must be run in single


### PR DESCRIPTION
For JSON RPC calls to the server, the default timeout for network operations is None, which means never time out. Though this has not been an issue before, recent events, as documented in CCD-1161, have shown otherwise.

A new environment, CRDS_CLIENT_TIMEOUT_SECONDS, is implemented, with a default value of 60.