### PR TITLE
release/11.15.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 11.15.0 (unreleased)
 ====================
 
+General
+-------
+
+- Manually added release date for previous release [#881]
+
 HST
 ---
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ General
 
 - Manually added release date for previous release [#881]
 
+JWST
+----
+
+- Added new rmap for NIRISS filteroffset [#881]
+
 HST
 ---
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,13 @@
-11.14.0 (unreleased)
+11.15.0 (unreleased)
+====================
+
+HST
+---
+
+- Add substitutions for HST ACS to support biasfile selection [#880]
+
+
+11.14.0 (2022-05-05)
 ====================
 
 Roman
@@ -10,10 +19,6 @@ JWST
 
 - Add back pars-masterbackgroundnrsslitsstep in the jwst specs [#879]
 
-HST
----
-
-- Add substitutions for HST ACS to support biasfile selection [#880]
 
 11.13.1 (2022-04-26)
 ====================

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -4873,6 +4873,35 @@
             "tpn":"niriss_extract1d.tpn",
             "unique_rowkeys":null
         },
+        "filteroffset":{
+            "derived_from":"Handmade 2022-05-20 15:00:00",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"filteroffset",
+            "filetype":"FILTEROFFSET",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_filteroffset_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_filteroffset.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "reference_to_dataset":{
+                "EXP_TYPE":"META.EXPOSURE.TYPE"
+            },
+            "sha1sum":"7fde4d42ce1933445d397fd0df305d7a1dd02d53",
+            "suffix":"filteroffset",
+            "text_descr":"Filter Offset",
+            "tpn":"niriss_filteroffset.tpn",
+            "unique_rowkeys":null
+        },
         "flat":{
             "derived_from":"jwst_niriss_flat_0000.rmap",
             "extra_keys":null,

--- a/crds/jwst/specs/niriss_filteroffset.rmap
+++ b/crds/jwst/specs/niriss_filteroffset.rmap
@@ -1,0 +1,20 @@
+header = {
+    'derived_from' : 'Handmade 2022-05-20 15:00:00',
+    'file_ext' : '.asdf',
+    'filekind' : 'filteroffset',
+    'filetype' : 'FILTEROFFSET',
+    'instrument' : 'NIRISS',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_niriss_filteroffset.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'reference_to_dataset' : {
+        'EXP_TYPE' : 'META.EXPOSURE.TYPE',
+    },
+    'sha1sum' : '7fde4d42ce1933445d397fd0df305d7a1dd02d53',
+    'suffix' : 'filteroffset',
+    'text_descr' : 'Filter Offset',
+}
+
+selector = Match({
+})

--- a/crds/tests/test_reftypes.py
+++ b/crds/tests/test_reftypes.py
@@ -221,7 +221,7 @@ def reftypes_jwst_get_filekinds():
     >>> old_state = test_config.setup()
     >>> types = reftypes.get_types_object("jwst")
     >>> types.get_filekinds("niriss")
-    ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'pars-darkpipeline', 'pars-detector1pipeline', 'pars-image2pipeline', 'pars-outlierdetectionstep', 'pars-sourcecatalogstep', 'pars-spec2pipeline', 'pars-tweakregstep', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'speckernel', 'specprofile', 'spectrace', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wavemap', 'wcsregions', 'wfssbkg']
+    ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'pars-darkpipeline', 'pars-detector1pipeline', 'pars-image2pipeline', 'pars-outlierdetectionstep', 'pars-sourcecatalogstep', 'pars-spec2pipeline', 'pars-tweakregstep', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'speckernel', 'specprofile', 'spectrace', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wavemap', 'wcsregions', 'wfssbkg']
     >>> test_config.cleanup(old_state)
     """
 


### PR DESCRIPTION
Tag and release GA flow was not run in previous release, causing the 11.14.0 entry not to have a release date. The date was added manually, and the changelog entry for changes made since then were moved up to a new release version.