### PR TITLE
ccd-1142/reason-for-delivery-api-validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.15.1 (unreleased)
+====================
+
+General
+-------
+
+- Minor bugfix checks for invalid (special) chars in "reason for delivery" text submitted via programmatic api [#882]
+
 11.15.0 (2022-05-23)
 ====================
 

--- a/crds/tests/test_submit.py
+++ b/crds/tests/test_submit.py
@@ -276,3 +276,16 @@ class TestSubmission(object):
         self.s['instrument']          = 'stis'  # Only works for HST
 
         self.s.validate()
+
+    @raises(ValueError)
+    def test_invalid_description(self):
+        # Do something here to pass field validation checks:
+        self.s['file_type']           = 'value'
+        self.s['correctness_testing'] = 'value'
+        self.s['deliverer']           = 'value'
+        self.s['description']         = 'Illegal character(s)!'
+        self.s['calpipe_version']     = 'value'
+        self.s['modes_affected']      = 'value'
+        self.s['instrument']          = 'stis'  # Only works for HST
+
+        self.s.validate()


### PR DESCRIPTION
- Minor bugfix checks for invalid (special) chars in "reason for delivery" text submitted via programmatic api. Previous behavior caused the api to "freeze" or timeout with no explanation of what caused the error. The new behavior imitates the web api by returning an error with a descriptive help message if the user tries to submit description text containing anything besides alphanumeric, dashes, underscores, commas or periods.
- Added test for crds.rc_submit.Submission().validate() when 'description' field contains illegal characters