### PR TITLE
hotfix/api-character-validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.16.1 (unreleased)
+
+General
+-------
+
+- Hotfix for API character validation with more thorough testing added
+
+
 11.16.0 (2022-05-27)
 
 General

--- a/crds/submit/rc_submit.py
+++ b/crds/submit/rc_submit.py
@@ -57,13 +57,14 @@ NULL_FIELDTYPES = {
     'CharField'        : str,
     'TypedChoiceField' : str, }
 
-DESCRIPTION_RE = re.compile('[^0-9a-zA-Z\-_.,]+')
+DESCRIPTION_RE = re.compile('[^0-9a-zA-Z ,-._]+')
 
 def validate_description_text(text):
-    if DESCRIPTION_RE.search(text):
-        return True
+    err = DESCRIPTION_RE.search(text)
+    if err is not None:
+        return err.group()
     else:
-        return False
+        return None
 
 # Preserve order of YAML dicts (from https://stackoverflow.com/a/52621703):
 yaml.add_representer(dict, lambda self, data: yaml.representer.SafeRepresenter.represent_dict(self, data.items()))
@@ -333,9 +334,9 @@ class Submission(object):
         
         # Check for invalid characters in description text
         desc_text = self._fields['description']
-        desc_err = validate_description_text(desc_text)
-        if desc_err is True:
-            raise ValueError('Only alphanumeric, dashes, underscores, periods and commas allowed.')
+        invalid_char = validate_description_text(desc_text)
+        if invalid_char is not None:
+            raise ValueError(f'Invalid character detected: "{invalid_char}" - only alphanumeric, dashes, underscores, periods and commas are allowed.')
 
     @wraps(yaml.safe_dump)
     def yaml(self, *args, **kargs):

--- a/crds/tests/test_submit.py
+++ b/crds/tests/test_submit.py
@@ -265,12 +265,11 @@ class TestSubmission(object):
 
     def test_validate(self):
         self.s.add_file(list(self.tempfiles)[0])
-
         # Do something here to pass field validation checks:
         self.s['file_type']           = 'value'
         self.s['correctness_testing'] = 'value'
         self.s['deliverer']           = 'value'
-        self.s['description']         = 'value'
+        self.s['description']         = 'Dashes 0-9, underscores_1, commas, whitespace and periods 1234567890.'
         self.s['calpipe_version']     = 'value'
         self.s['modes_affected']      = 'value'
         self.s['instrument']          = 'stis'  # Only works for HST
@@ -279,13 +278,30 @@ class TestSubmission(object):
 
     @raises(ValueError)
     def test_invalid_description(self):
+        some_invalid_chars = ['!', '@', '$', '%', '^', '*', '(', ')', '+', '=', '~', '`', '"', '?', '/', '|', '{', '}', '[', ']', ':', ';', '<', '>']
         # Do something here to pass field validation checks:
         self.s['file_type']           = 'value'
         self.s['correctness_testing'] = 'value'
         self.s['deliverer']           = 'value'
-        self.s['description']         = 'Illegal character(s)!'
         self.s['calpipe_version']     = 'value'
         self.s['modes_affected']      = 'value'
         self.s['instrument']          = 'stis'  # Only works for HST
-
-        self.s.validate()
+        for bad in some_invalid_chars:
+            self.s['description'] = f'This desc is invalid because it contains a {bad} char.'
+            self.s.validate()
+    
+    @raises(ValueError)
+    def test_multiple_invalid_chars(self):
+        self.s['file_type']           = 'value'
+        self.s['correctness_testing'] = 'value'
+        self.s['deliverer']           = 'value'
+        self.s['calpipe_version']     = 'value'
+        self.s['modes_affected']      = 'value'
+        self.s['instrument']          = 'stis'  # Only works for HST
+        extrabad = "This (RFD) is invalid"
+        stillbad = "This RFD) is still invalid?"
+        justbad = "This RFD is $invalid."
+        bad_desc = [extrabad, stillbad, justbad]
+        for bad in bad_desc:
+            self.s['description'] = bad
+            self.s.validate()


### PR DESCRIPTION
The regular expression that checks for invalid characters in the programmatic submission API has been updated, with the escape character  '\' being replaced with whitespace. The previous regex was incorrectly causing some valid text descriptions in the Reason for Delivery field to raise an error. Additional tests with a wider variety of cases have also been added.