### PR TITLE
roman/optical-element-translation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.16.2 (unreleased)
+
+Roman
+-----
+
+- added ref-rmap header translation for p_optical_element, updated tests [#885]
+
+
 11.16.1 (2022-06-06)
 
 General

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -481,6 +481,7 @@ def reference_keys_to_dataset_keys(rmapping, header):
     translations = {
         "ROMAN.META.EXPOSURE.P_EXPTYPE" : "ROMAN.META.EXPOSURE.TYPE",
         "ROMAN.META.INSTRUMENT.P_DETECTOR"  : "ROMAN.META.INSTRUMENT.DETECTOR",
+        "ROMAN.META.INSTRUMENT.P_OPTICAL_ELEMENT": "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT",
     }
 
     # Rmap header reference_to_dataset field tranlations,  can override basic!

--- a/crds/tests/test_roman.py
+++ b/crds/tests/test_roman.py
@@ -55,6 +55,20 @@ class TestRoman(unittest.TestCase):
 
         assert pathlib.Path(result["flat"]).name == "roman_wfi_flat_0004.asdf"
 
+        result = heavy_client.getreferences(
+            {
+                "ROMAN.META.INSTRUMENT.NAME": "WFI",
+                "ROMAN.META.INSTRUMENT.DETECTOR": "WFI01",
+                "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT": "F213",
+                "ROMAN.META.EXPOSURE.START_TIME": "2020-02-01T00:00:00"
+            },
+            observatory="roman",
+            context="roman_0005.pmap",
+            reftypes=["distortion"]
+        )
+
+        assert pathlib.Path(result["distortion"]).name == "roman_wfi_distortion_0001.asdf"
+
 
     @raises(CrdsLookupError)
     def test_getreferences_with_invalid_header(self):

--- a/crds/tests/test_roman.py
+++ b/crds/tests/test_roman.py
@@ -93,7 +93,8 @@ class TestRoman(unittest.TestCase):
 
         expected_result = {
             "roman_wfi_flat_0004.asdf",
-            "roman_wfi_dark_0001.asdf",
+            "roman_wfi_distortion_0001.asdf",
+            "roman_wfi_dark_0001.asdf"
         }
 
         list_command = [


### PR DESCRIPTION
- added ref-rmap header translation for p_optical_element
- added getreferences test using new distortion reference type