### PR TITLE
api/reason-for-delivery

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.16.3 (unreleased)
+
+General
+-------
+
+- Allow forward slash and equals signs in Reason for Delivery [#886]
+
+
 11.16.2 (2022-06-09)
 
 Roman

--- a/crds/submit/rc_submit.py
+++ b/crds/submit/rc_submit.py
@@ -57,7 +57,7 @@ NULL_FIELDTYPES = {
     'CharField'        : str,
     'TypedChoiceField' : str, }
 
-DESCRIPTION_RE = re.compile('[^0-9a-zA-Z ,-._]+')
+DESCRIPTION_RE = re.compile('[^A-Za-z0-9._\s/,=\-\+]')
 
 def validate_description_text(text):
     err = DESCRIPTION_RE.search(text)
@@ -336,7 +336,7 @@ class Submission(object):
         desc_text = self._fields['description']
         invalid_char = validate_description_text(desc_text)
         if invalid_char is not None:
-            raise ValueError(f'Invalid character detected: "{invalid_char}" - only alphanumeric, dashes, underscores, periods and commas are allowed.')
+            raise ValueError(f'Invalid character detected: "{invalid_char}" - only alphanumeric, dashes, underscores, periods, commas, forward slashes and equals signs are allowed.')
 
     @wraps(yaml.safe_dump)
     def yaml(self, *args, **kargs):

--- a/crds/tests/test_submit.py
+++ b/crds/tests/test_submit.py
@@ -269,7 +269,7 @@ class TestSubmission(object):
         self.s['file_type']           = 'value'
         self.s['correctness_testing'] = 'value'
         self.s['deliverer']           = 'value'
-        self.s['description']         = 'Dashes 0-9, underscores_1, commas, whitespace and periods 1234567890.'
+        self.s['description']         = 'Dash-es under_scores, commas, periods. 1234567890 += fwd/slash.'
         self.s['calpipe_version']     = 'value'
         self.s['modes_affected']      = 'value'
         self.s['instrument']          = 'stis'  # Only works for HST
@@ -278,7 +278,7 @@ class TestSubmission(object):
 
     @raises(ValueError)
     def test_invalid_description(self):
-        some_invalid_chars = ['!', '@', '$', '%', '^', '*', '(', ')', '+', '=', '~', '`', '"', '?', '/', '|', '{', '}', '[', ']', ':', ';', '<', '>']
+        some_invalid_chars = ['!', '@', '$', '%', '^', '*', '(', ')', '~', '`', '"', '?', '|', '{', '}', '[', ']', ':', ';', '<', '>']
         # Do something here to pass field validation checks:
         self.s['file_type']           = 'value'
         self.s['correctness_testing'] = 'value'
@@ -298,10 +298,11 @@ class TestSubmission(object):
         self.s['calpipe_version']     = 'value'
         self.s['modes_affected']      = 'value'
         self.s['instrument']          = 'stis'  # Only works for HST
-        extrabad = "This (RFD) is invalid"
-        stillbad = "This RFD) is still invalid?"
-        justbad = "This RFD is $invalid."
-        bad_desc = [extrabad, stillbad, justbad]
-        for bad in bad_desc:
+        invalid_strings = [
+          "This %RFD is invalid",
+          "This <RFD> is still invalid",
+          "This {RFD is $invalid."
+        ]
+        for bad in invalid_strings:
             self.s['description'] = bad
             self.s.validate()


### PR DESCRIPTION
CCD-1192 Updated regex to allow forward slashes, plus and equals signs in Reason for Delivery field for programmatic API submissions.