### PR TITLE
fix/roman-useafter-format-revision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+11.16.5 (unreleased)
+====================
+
+Roman
+-----
+
+- Useafter string reformats with space instead of "T" between date and time [#888]
+
+
 11.16.4 (2022-06-22)
 ====================
 

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -443,8 +443,8 @@ def reference_keys_to_dataset_keys(rmapping, header):
     >>> config.ALLOW_BAD_USEAFTER.reset()
     >>> reference_keys_to_dataset_keys( \
     namedtuple('x', ['reference_to_dataset', 'filename'])({}, 'secret_code_file.txt'), \
-    {'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14T12:34:56'})
-    {'ROMAN.META.EXPOSURE.START_TIME': '1879-03-14T12:34:56', 'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED'}
+    {'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14 12:34:56'})
+    {'ROMAN.META.EXPOSURE.START_TIME': '1879-03-14 12:34:56', 'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED'}
 
     ==================================================
     Test setting DATE/TIME with no USEAFTER, but allowed "bad use after".
@@ -453,7 +453,7 @@ def reference_keys_to_dataset_keys(rmapping, header):
     >>> config.ALLOW_BAD_USEAFTER.set("1")
     False
     >>> reference_keys_to_dataset_keys(namedtuple('x', ['reference_to_dataset', 'filename'])({}, 'secret_code_file.txt'), {})
-    {'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED', 'ROMAN.META.EXPOSURE.START_TIME': '1900-01-01T00:00:00'}
+    {'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED', 'ROMAN.META.EXPOSURE.START_TIME': '1900-01-01 00:00:00'}
 
     ==================================================
     Test setting DATE/TIME from USEAFTER.
@@ -462,15 +462,15 @@ def reference_keys_to_dataset_keys(rmapping, header):
     >>> config.ALLOW_BAD_USEAFTER.set("1")
     False
     >>> reference_keys_to_dataset_keys(namedtuple('x', ['reference_to_dataset', 'filename'])({}, 'secret_code_file.txt'), \
-    {'ROMAN.META.USEAFTER' : '1770-12-01T01:23:45', 'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14T12:34:56'})
-    {'ROMAN.META.USEAFTER': '1770-12-01T01:23:45', 'ROMAN.META.EXPOSURE.START_TIME': '1770-12-01T01:23:45', 'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED'}
+    {'ROMAN.META.USEAFTER' : '1770-12-01 01:23:45', 'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14 12:34:56'})
+    {'ROMAN.META.USEAFTER': '1770-12-01 01:23:45', 'ROMAN.META.EXPOSURE.START_TIME': '1770-12-01 01:23:45', 'ROMAN.META.SUBARRAY.NAME': 'UNDEFINED', 'ROMAN.META.EXPOSURE.TYPE': 'UNDEFINED'}
 
     ==================================================
     Test bad formatted USEAFTER.
 
     >>> config.ALLOW_BAD_USEAFTER.reset()
     >>> reference_keys_to_dataset_keys(namedtuple('x', ['reference_to_dataset', 'filename'])({}, 'secret_code_file.txt'), \
-    {'ROMAN.META.USEAFTER' : 'bad user after', 'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14T12:34:56'})
+    {'ROMAN.META.USEAFTER' : 'bad user after', 'ROMAN.META.EXPOSURE.START_TIME' : '1879-03-14 12:34:56'})
     Traceback (most recent call last):
     ...
     crds.core.exceptions.InvalidUseAfterFormat: Bad USEAFTER time format = 'bad user after'
@@ -533,7 +533,7 @@ def reference_keys_to_dataset_keys(rmapping, header):
         filename = header.get("ROMAN.META.FILENAME", None) or rmapping.filename
 
         reformatted = timestamp.reformat_useafter(filename, header).split()
-        dt_string = f"{reformatted[0]}T{reformatted[1]}"
+        dt_string = f"{reformatted[0]} {reformatted[1]}"
         header["ROMAN.META.EXPOSURE.START_TIME"] = dt_string
 
     log.verbose("reference_to_dataset output header:\n", log.PP(header), verbosity=80)

--- a/crds/tests/test_roman.py
+++ b/crds/tests/test_roman.py
@@ -23,7 +23,7 @@ class TestRoman(unittest.TestCase):
     def tearDown(self):
         test_config.cleanup(self.old_state)
 
-    def test_getreferences_with_valid_header(self):
+    def test_getreferences_with_valid_header_ISOT_fmt(self):
         """ test_getreferences_with_valid_header: test satisfies Roman 303.1 and 628.1
         """
         result = heavy_client.getreferences(
@@ -32,6 +32,23 @@ class TestRoman(unittest.TestCase):
                 "ROMAN.META.INSTRUMENT.DETECTOR": "WFI01",
                 "ROMAN.META.EXPOSURE.TYPE": "WFI_IMAGE",
                 "ROMAN.META.EXPOSURE.START_TIME": "2020-02-01T00:00:00"
+            },
+            observatory="roman",
+            context="roman_0005.pmap",
+            reftypes=["dark"]
+        )
+
+        assert pathlib.Path(result["dark"]).name == "roman_wfi_dark_0001.asdf"
+    
+    def test_getreferences_with_valid_header_ISO_fmt(self):
+        """ test_getreferences_with_valid_header: test satisfies Roman 303.1 and 628.1
+        """
+        result = heavy_client.getreferences(
+            {
+                "ROMAN.META.INSTRUMENT.NAME": "WFI",
+                "ROMAN.META.INSTRUMENT.DETECTOR": "WFI01",
+                "ROMAN.META.EXPOSURE.TYPE": "WFI_IMAGE",
+                "ROMAN.META.EXPOSURE.START_TIME": "2020-02-01 00:00:00"
             },
             observatory="roman",
             context="roman_0005.pmap",


### PR DESCRIPTION
CCD-1195 Useafter string reformats with space instead of T between date and time