### PR TITLE
gh/release-token-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Create GitHub release (triggers publish-to-pypi workflow)
         uses: zendesk/action-create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         with:
           tag_name: ${{ github.event.inputs.version }}
           release_name: ${{ github.event.inputs.version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 11.16.5 (unreleased)
 ====================
 
+General
+-------
+
+- Updated GH action release token [#889]
+
 Roman
 -----
 


### PR DESCRIPTION
Pointing to a new release token for github actions to use (old one with original name still exists in case a rollback is needed).