### PR TITLE
Enable bestrefs I/O under Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,15 @@ JWST
 
 -  update niriss pars-jumpstep parkeys [#890]
 
+11.16.6 (TBD)
+=============
+
+General
+-------
+
+- Revised core.utils to allow I/O to work under Windows [#891]
+
+
 11.16.5 (2022-06-27)
 ====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,6 @@ JWST
 
 -  update niriss pars-jumpstep parkeys [#890]
 
-11.16.6 (TBD)
-=============
-
 General
 -------
 

--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -17,6 +17,7 @@ import ast
 import gc
 import json
 import warnings
+import platform
 
 # ===================================================================
 
@@ -619,10 +620,10 @@ def is_writable(filepath, no_exist=True):
         return no_exist and len(os.path.dirname(filepath)) and is_writable(os.path.dirname(filepath))
     stats = os.stat(filepath)
     user_writeable = bool(stats.st_mode & stat.S_IWUSR)
-    user_id = os.geteuid() if 'windows' not in os.environ['OS'].lower() else stats.st_uid
+    user_id = os.geteuid() if 'windows' not in platform.system().lower() else stats.st_uid
     effective_user_matches =  bool(stats.st_uid == user_id)
     group_writeable = bool(stats.st_mode & stat.S_IWGRP)
-    group_id = os.getgroups() if 'windows' not in os.environ['OS'].lower() else [stats.st_gid]
+    group_id = os.getgroups() if 'windows' not in platform.system().lower() else [stats.st_gid]
     group_matches = bool(stats.st_gid in group_id)
     other_writeable = bool(stats.st_mode & stat.S_IWOTH)
     return bool((user_writeable and effective_user_matches) or

--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -619,9 +619,11 @@ def is_writable(filepath, no_exist=True):
         return no_exist and len(os.path.dirname(filepath)) and is_writable(os.path.dirname(filepath))
     stats = os.stat(filepath)
     user_writeable = bool(stats.st_mode & stat.S_IWUSR)
-    effective_user_matches =  bool(stats.st_uid == os.geteuid())
+    user_id = os.geteuid() if 'windows' not in os.environ['OS'].lower() else stats.st_uid
+    effective_user_matches =  bool(stats.st_uid == user_id)
     group_writeable = bool(stats.st_mode & stat.S_IWGRP)
-    group_matches = bool(stats.st_gid in os.getgroups())
+    group_id = os.getgroups() if 'windows' not in os.environ['OS'].lower() else [stats.st_gid]
+    group_matches = bool(stats.st_gid in group_id)
     other_writeable = bool(stats.st_mode & stat.S_IWOTH)
     return bool((user_writeable and effective_user_matches) or
                 (group_writeable and group_matches) or


### PR DESCRIPTION
These simple changes allows the CRDS operations for **'crds.bestrefs.assign_bestrefs()'**, and any other CRDS function that uses these functions, to operate under Windows while keeping the exact same functionality under all other OS's.

The changes were tested under a version of CRDS which was installed simply using **'pip install -e .'** from a local clone of the CRDS code into an existing Python 3.8 conda environment under Windows 10.  In fact, the revised code was tested by updating a WFPC2 observation using the command: 

**crds.bestrefs.assign_bestrefs(['u5b8060pr_c0m.fits'], sync_references=True)**

The updated file was then able to be processed using STWCS later confirming that everything worked as expected for any CRDS installation. 