### PR TITLE
CCD-1214 roman-pipeline-autoconfirmation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+11.16.15 (unreleased)
+=====================
+
+Roman
+-----
+- Automatic confirmation for roman pipeline reference file submissions [#904]
+
 11.16.14 (2022-09-22)
 =====================
 

--- a/crds/submit/rc_submit.py
+++ b/crds/submit/rc_submit.py
@@ -9,14 +9,12 @@ import collections
 import webbrowser
 
 from crds.core import log, config
-from crds.client import api
 from .submit import ReferenceSubmissionScript
 import urllib
 from functools import wraps
 from textwrap import wrap
 import re
 
-from crds.core.exceptions import ServiceError
 
 class NoFilesSelected(Exception):
     pass
@@ -69,93 +67,6 @@ def validate_description_text(text):
     else:
         return None
 
-def context_iterator(default_ctx=None, observatory=None):
-    old_ctx = api.get_default_context() if default_ctx is None else default_ctx
-    obs = api.get_default_observatory() if observatory is None else observatory
-    new_ctx_num = int(old_ctx.split('.')[0].split('_')[-1]) + 1
-    ndigits = 4 if new_ctx_num < 1000 else 0
-    zeros = (ndigits - len(str(new_ctx_num))) * '0'
-    new_ctx = obs + '_' + zeros + str(new_ctx_num) + '.pmap'
-    return new_ctx
-
-def find_new_rmaps(old_maps, new_maps):
-    """Identify any new rmap types i.e. no previous version exists in the older context. 
-    Used by renamed_mappings() to isolate any rmaps that were not renamed but should still
-    be added to the mapping dictionary.
-
-    Parameters
-    ----------
-    old_maps : list
-        all mappings associated with the 'old' (default) context
-    new_maps : list
-        all mappings associated with the 'new' (edit) context
-
-    Returns
-    -------
-    list
-        rmap filenames that are of a new type with no previous version existing.
-        If none are found, returns an empty list.
-    """
-    old = [c.split('_')[2] for c in old_maps if c.split('.')[-1] == 'rmap']
-    new = [c.split('_')[2] for c in new_maps if c.split('.')[-1] == 'rmap']
-    rtypes = [n for n in new if n not in old]
-    rnew = []
-    for r in rtypes:
-        rnew.extend([f for f in new_maps if r in f])
-    return rnew
-
-def renamed_mappings(old_ctx=None, new_ctx=None, observatory=None):
-    """Creates a dictionary of original:renamed mapping file pairs
-    following successful completion/confirmation of a submission.
-    Any new rmap types added that didn't exist in the old context
-    are returned as a list under the key 'new' inside the dictionary.
-
-    Kwargs can be used to override the observatory and contexts being
-    compared, regardless of your current CRDS configuration. For example,
-    if your environment is set to Roman Dev, you could still get the renamed 
-    mappings for an HST or JWST submission:
-    
-        map_dict = renamed_mappings(old_ctx='jwst_0034.pmap', observatory='jwst')
-    
-    would return a dictionary of mappings that were renamed between 'jwst_0034.pmap'
-    and the current 'jwst-edit' context (since the new_ctx was not set explicitly,
-    it defaults to the edit context of a given observatory.
-
-    Parameters
-    ----------
-    old_ctx : str, optional
-        name of the originating default context, by default None
-    new_ctx : str, optional
-        name of the new editing context, by default None
-    observatory : str, optional
-        name of the observatory, by default None
-
-    Returns
-    -------
-    dict
-        original:renamed mapping file pairs (pmap,imap and rmaps)
-    """
-    old_ctx = api.get_default_context() if old_ctx is None else old_ctx
-    observatory = api.get_default_observatory() if observatory is None else observatory
-    new_ctx = observatory + '-edit' if new_ctx is None else new_ctx
-    try:
-        old, new = api.get_mapping_names(old_ctx), api.get_mapping_names(new_ctx)
-        # if edit context isn't updated yet
-        if new == old:
-            new = api.get_mapping_names(context_iterator())
-    except ServiceError as err:
-        log.warning("Oops...you may need to confirm the submission first\n", err)
-        return
-    rnew = find_new_rmaps(old, new)
-    for i, n in enumerate(new):
-        new.pop(i) if n in rnew else None
-    map_dict = {}
-    for k, v in dict(zip(old, new)).items():
-        if k != v:
-            map_dict[k] = v
-    if rnew:
-        map_dict['new'] = rnew
-    return map_dict
 
 # Preserve order of YAML dicts (from https://stackoverflow.com/a/52621703):
 yaml.add_representer(dict, lambda self, data: yaml.representer.SafeRepresenter.represent_dict(self, data.items()))
@@ -230,10 +141,8 @@ class Submission(object):
         self._string = string
         self._context = context
         self._ready_url = None
-        self._connection = None
         self._results_id = None
         self._auto_confirm = False
-        self._confirmation = None
 
         config.base_url = BASE_URLS[self.string][self.observatory]
         if not os.environ.get('CRDS_SERVER_URL'):
@@ -405,10 +314,6 @@ class Submission(object):
     @property
     def ready_url(self):
         return self._ready_url
-
-    @property
-    def connection(self):
-        return self._connection
     
     @property
     def results_id(self):
@@ -420,10 +325,6 @@ class Submission(object):
     @property
     def auto_confirm(self):
         return self._auto_confirm
-
-    @property
-    def confirmation(self):
-        return self._confirmation
 
     # ------------------------------------------------------------------------------------
     # Custom methods:
@@ -467,17 +368,6 @@ class Submission(object):
     def yaml(self, *args, **kargs):
         '''YAML representation of this submission object.'''
         return yaml.safe_dump(dict(self), *args, **kargs)
-    
-    def update_file_map(self):
-        '''Add renamed pmap and imap filenames to file_map post-submission'''
-        if self._file_map is None:
-            self._file_map = {}
-        try:
-            mapping_dict = renamed_mappings()
-            if mapping_dict:
-                self._file_map.update(mapping_dict)
-        except Exception as e:
-            log.verbose(e, verbosity=75)
 
     def submit(self):
         '''Validate submission form, upload to CRDS staging, handle server-side
@@ -514,14 +404,8 @@ class Submission(object):
         if script._file_map in [{}, None]:
             script.get_file_map()
         self._file_map = script._file_map
-
-        self._connection = script.connection
         self._ready_url = script._ready_url
         self._results_id = script._results_id
-        self._confirmation = script._confirmation
-
-        if self._confirmation and self._confirmation.status_code == 200:
-            self.update_file_map()
 
         return SubmissionResult(
             error_count=script._error_count,

--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -298,7 +298,7 @@ this command line interface must be members of the CRDS operators group
 
     def login(self):
         """Log in to the CRDS server using server user credentials."""
-        log.info("Logging in aquiring lock.")
+        log.info("Logging in acquiring lock.")
         self.connection.fail_if_existing_lock()
         self.connection.login()
 

--- a/crds/submit/web.py
+++ b/crds/submit/web.py
@@ -127,7 +127,7 @@ class CrdsDjangoConnection:
         results_id = relative_url.split('/')[-1]
         resp = self.get(relative_url)
         csrf = resp.cookies['csrftoken']
-        url = self.abs_url('/submit_confirm/')
+        url = self.abs_url('/submit_confirm_pipeline/')
         response = self.session.post(url, {
             'results_id': results_id,
             'csrfmiddlewaretoken': csrf,

--- a/crds/submit/web.py
+++ b/crds/submit/web.py
@@ -90,7 +90,6 @@ class CrdsDjangoConnection:
     def post(self, relative_url, *post_dicts, **post_vars):
         """HTTP(S) POST `relative_url` and return the requests response object."""
         args = self.post_start(relative_url, *post_dicts, **post_vars)
-        
         return self.post_complete(args)
 
     @background.background
@@ -122,6 +121,22 @@ class CrdsDjangoConnection:
         if csrf_values:
             post_vars['csrfmiddlewaretoken'] = csrf_values[0]
         return self.post_start(relative_url, *post_dicts, **post_vars)
+    
+    def repost_confirm_or_cancel(self, ready_url, action="confirm"):
+        relative_url = '/' + '/'.join(ready_url.split('/')[-2:])
+        results_id = relative_url.split('/')[-1]
+        resp = self.get(relative_url)
+        csrf = resp.cookies['csrftoken']
+        url = self.abs_url('/submit_confirm/')
+        response = self.session.post(url, {
+            'results_id': results_id,
+            'csrfmiddlewaretoken': csrf,
+            'button': action,
+            })
+        self.dump_response("Response: ", response)
+        self.check_error(response)
+        return response
+
 
     """
     {'time_remaining': '3:57:58', 'user': 'jmiller_unpriv', 'created_on': '2017-02-23 16:12:55', 'type': 'instrument', 'is_expired': False, 'status': 'ok', 'name': 'miri'}

--- a/crds/submit/web.py
+++ b/crds/submit/web.py
@@ -90,6 +90,7 @@ class CrdsDjangoConnection:
     def post(self, relative_url, *post_dicts, **post_vars):
         """HTTP(S) POST `relative_url` and return the requests response object."""
         args = self.post_start(relative_url, *post_dicts, **post_vars)
+        
         return self.post_complete(args)
 
     @background.background


### PR DESCRIPTION
Roman pipeline authorized user can pass the --autoconfirm argument to automatically confirm reference file submissions as long as there are no errors. If there are errors, the submission is automatically canceled.

Minor updates to the file_map attribute for submission api script (no longer need to run "update_file_map()" - the script will try to get the renamed mappings and references even if the submission has not yet been confirmed (i.e. pmaps and imaps not actually generated yet).