### PR TITLE
docs/sync-flags-and-filemap-property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ General
 -------
 - Don't issue warning in ``crds sync`` for files with status "delivered" [#903]
 
-- Documentation minor updates: command_line_tools, programmatic_interface [#904]
+- Documentation minor updates: command_line_tools, programmatic_interface [#905]
 
 11.16.15 (2022-10-20)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,11 @@
-Unreleased
-==========
+11.16.16 (Unreleased)
+=====================
 
 General
 -------
 - Don't issue warning in ``crds sync`` for files with status "delivered" [#903]
+
+- Documentation minor updates: command_line_tools, programmatic_interface [#904]
 
 11.16.15 (2022-10-20)
 =====================

--- a/documentation/crds_users_guide/source/command_line_tools.rst
+++ b/documentation/crds_users_guide/source/command_line_tools.rst
@@ -318,6 +318,36 @@ versions of CRDS rules.   While the download directory of files can be
 explicitly specified,  sync is primarily used to download files to a CRDS
 cache which organizes and can locate files in a standard way.
 
+.. tip::
+
+  `crds.sync` detects the observatory based on whichever environment variables have
+  been set, or a flag for the desired observatory included in the command (`--hst`, 
+  `--jwst`, `--roman`). If no flag is included and the environment variables were 
+  not set, `crds.sync` will default to JWST.
+
+  To sync with HST without any environment variables set, you would need to include 
+  the `--hst` flag:
+
+  .. code-block:: bash
+    
+      crds.sync --hst --files 2cd1621ei_dkc.fits --output-dir
+
+  Or set the correct server url environment variable first:
+
+  .. code-block:: bash
+
+      export CRDS_SERVER_URL=https://hst-crds.stsci.edu
+      crds sync --files 2cd1621ei_dkc.fits --output-dir
+
+  The below command produces an error because no environment variables were set 
+  and the --hst flag is not included in the command, so crds.sync defaults 
+  to JWST even though the user is trying to sync an HST file:
+
+  .. code-block:: bash
+    
+      crds sync --files 2cd1621ei_dkc.fits --output-dir
+
+
 * Dry-Running Cache Changes
    
    Since CRDS cache operations can involve significant network downloads, as a

--- a/documentation/crds_users_guide/source/programmatic_interface.rst
+++ b/documentation/crds_users_guide/source/programmatic_interface.rst
@@ -439,3 +439,20 @@ your system's default browser::
 Note that the page's *confirm*, *cancel*, and *force* buttons will not be available
 unless authenticated.  If they seem to be missing, try logging in with the *Login*
 button at the upper right-hand corner of the page.
+
+* Submission `file_map` Attribute
+
+   As of `v11.16.12`, the submission object includes a `file_map` property which returns a dictionary of uploaded reference filenames, "old" mappings (keys) paired with automatically renamed references, newly generated mappings (values).
+
+   .. code-block:: python
+
+       s.file_map
+
+       {'miri_dark_test.fits': 'jwst_miri_dark_0075.fits',
+       'jwst_miri_dark_0033.rmap': 'jwst_miri_dark_0034.rmap',
+       'jwst_0511.pmap': 'jwst_0512.pmap',
+       'jwst_miri_0513.imap': 'jwst_miri_0514.imap'}
+  
+   Note that before a new context has been set, the new mapping names are hypothetical.
+   If the submission has not yet been confirmed, the same is true of the new reference filenames. 
+


### PR DESCRIPTION
User guide documentation updates:
- CCD-996 crds.sync requires observatory-specific flag when environment variables are not set
- CCD-1215 code example and description of submission API file_map property