### PR TITLE
fix/roman-getreferences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ JWST
 
 - add SUB400X256ALWB to the NIRCam subarray list [#915]
 
+Roman
+-----
+
+- bugfix: getreferences uses get_locator_module to call dataset_to_ref_header [#916]
+
+
 11.16.17 (2022-12-30)
 =====================
 

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -199,8 +199,8 @@ def _initial_recommendations(
         parameters = check_parameters(parameters)
         # temp workaround for roman archive db header format
         if observatory == "roman":
-            obs_pkg = utils.get_observatory_package(observatory)
-            parameters = obs_pkg.locate.dataset_to_ref_header(parameters)
+            obs_pkg = utils.get_locator_module(observatory)
+            parameters = obs_pkg.dataset_to_ref_header(parameters)
             log.verbose(name + "() revised parameters:\n", log.PP(parameters), verbosity=65)
 
         check_reftypes(reftypes)

--- a/crds/roman/__init__.py
+++ b/crds/roman/__init__.py
@@ -2,6 +2,10 @@ import os.path
 
 from crds.core import reftypes
 
+__all__ = [
+    "locate",
+]
+
 HERE  = os.path.abspath(os.path.dirname(__file__) or ".")
 
 TYPES = reftypes.from_package_file("roman", __file__)

--- a/crds/roman/__init__.py
+++ b/crds/roman/__init__.py
@@ -2,10 +2,6 @@ import os.path
 
 from crds.core import reftypes
 
-__all__ = [
-    "locate",
-]
-
 HERE  = os.path.abspath(os.path.dirname(__file__) or ".")
 
 TYPES = reftypes.from_package_file("roman", __file__)


### PR DESCRIPTION
Resolves "Attribute Error" when the `getreferences` method tries to call the `dataset_to_ref_header` function from crds.roman.locate module.