### PR TITLE
roman/dataset-to-ref-params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Roman
 
 - bugfix: getreferences uses get_locator_module to call dataset_to_ref_header [#916]
 
-- bestrefs calls `dataset_to_ref_header`` outside of the "fast" condition. Header translation for Roman will occur regardless of the "fast" arg (which can sometimes be determined by the logging verbosity level).
+- bestrefs calls `dataset_to_ref_header`` outside of the "fast" condition. Header translation for Roman will occur regardless of the "fast" arg (which can sometimes be determined by the logging verbosity level). [#917]
 
 
 11.16.17 (2022-12-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Roman
 
 - bugfix: getreferences uses get_locator_module to call dataset_to_ref_header [#916]
 
+- bestrefs calls `dataset_to_ref_header`` outside of the "fast" condition. Header translation for Roman will occur regardless of the "fast" arg (which can sometimes be determined by the logging verbosity level).
+
 
 11.16.17 (2022-12-30)
 =====================

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -197,14 +197,14 @@ def _initial_recommendations(
 
         check_observatory(observatory)
         parameters = check_parameters(parameters)
-        # temp workaround for roman archive db header format
-        if observatory == "roman":
-            obs_pkg = utils.get_locator_module(observatory)
-            parameters = obs_pkg.dataset_to_ref_header(parameters)
-            log.verbose(name + "() revised parameters:\n", log.PP(parameters), verbosity=65)
-
         check_reftypes(reftypes)
         check_context(context)
+    
+    # fix for roman archive db header format
+    if observatory == "roman":
+        obs_pkg = utils.get_locator_module(observatory)
+        parameters = obs_pkg.dataset_to_ref_header(parameters)
+        log.verbose(name + "() revised parameters:\n", log.PP(parameters), verbosity=65)
 
     mode, final_context = get_processing_mode(observatory, context)
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_pars = {
     "scripts" : glob.glob("scripts/*"),
     }
 
-TEST_DEPS = ["lockfile", "mock", "nose", "pytest", "pylint", "flake8", "bandit",]
+TEST_DEPS = ["lockfile", "mock", "nose", "pytest", "pylint", "flake8", "bandit", "coverage",]
 
 SUBMISSION_DEPS = ["requests", "lxml", "parsley"]
 


### PR DESCRIPTION
- Minor fix to call `dataset_to_ref_header` outside of the "fast" condition in bestrefs for Roman. Previously this function was only being called if verbosity level was set higher than 60 (which translates into fast=False). The header matching for Roman will occur regardless of the "fast" arg.