### PR TITLE
switch default jwst model to non-deprecated JwstDataModel

### DIFF
--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -55,7 +55,7 @@ def get_datamodels():
     if MODEL is None:
         with log.error_on_exception(
                 "Failed constructing basic JWST DataModel"):
-            MODEL = datamodels.DataModel()
+            MODEL = datamodels.JwstDataModel()
     return datamodels
 
 # =============================================================================

--- a/crds/jwst/schema.py
+++ b/crds/jwst/schema.py
@@ -106,7 +106,7 @@ def _load_schema(schema_name=None):
     """Return the core data model schema."""
     from . import locate
     datamodels = locate.get_datamodels()
-    model = datamodels.DataModel(schema=schema_name)
+    model = datamodels.JwstDataModel(schema=schema_name)
     return model.schema
 
 def _schema_to_flat(schema):


### PR DESCRIPTION
jwst.datamodels.Datamodel is deprecated and will soon be removed


While working to clean up the DataModel links between jwst and stdatamodels I opened a PR to remove deprecated models from stdatamodels (which jwst imports and exposes at `jwst.datamodels`). The model `jwst.datamodels.DataModel` is deprecated and was slated for removal in stdatamodels 1.5. CRDS appears to use this as some sort of default model (the details are beyond my understanding, a crds expert can hopefully chime in and teach me how the "sausage is made").

As `jwst.datamodels.JwstDataModel` is the replacement for `jwst.datamodels.DataModel`, this PR switches the usage to the non-deprecated model.

I attempted to run tests locally but following a `pip install -e .` within the checked out crds repository jwst tests were failing with a seemingly unrelated:
```
...
INTERNALERROR>     url = URL[:-len(URL_SUFFIX)]
INTERNALERROR> NameError: name 'URL' is not defined
```
I suspect that I did not correctly install crds locally and am hoping the CI for this PR will test the changes.