### PR TITLE
bugfix/any-equal-weight-special-case-error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-11.17.02 (unreleased)
+11.17.1 (unreleased)
 =====================
 
 General
@@ -6,8 +6,12 @@ General
 
 - Removed python 3.8 check from ci.yml [#934]
 - Removed references to ICD-47 in users guide [#936]
-- Switch jwst DATAMODEL to jwst.datamodels.JwstDataModel [#938]
+- translate 'ANY' as equal to '*' when selecting match rules in rmap changes. Prevents equal weight special case errors from occurring unnecessarily [#939]
 
+JWST
+----
+
+- Switch jwst DATAMODEL to jwst.datamodels.JwstDataModel [#938]
 
 11.17.0 (2023-04-21)
 ===================

--- a/crds/core/selectors.py
+++ b/crds/core/selectors.py
@@ -2073,6 +2073,8 @@ Restore original debug behavior:
                             valid_values_map[name])
                 self._validate_value(name, value, valid_values_map[name], runtime=False)
         for other in self.keys():
+            # convert 'ANY' to '*'
+            key = tuple([utils.condition_value(k) for k in key])
             if key != other and match_superset(other, key) and \
                 not different_match_weight(key, other):
                 # include match case filename and useafter data in log message


### PR DESCRIPTION
translate 'ANY' as equal to '*' when selecting match rules in rmap changes. Prevents equal weight special case errors from occurring unnecessarily. Resolves CCD-1283 and CCD-1239