### PR TITLE
tests/roman-metrics-logger-decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.17.3 (unreleased)
+====================
+
+ROMAN
+-----
+
+- Added metrics-logger decorators with DMS tags to appropriate Roman tests [#942]
+
 11.17.2 (2023-06-29)
 ====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@
 ROMAN
 -----
 
-- Added metrics-logger decorators with DMS tags to appropriate Roman tests [#942]
+- Added metrics-logger decorators with DMS tags to appropriate Roman tests [#943]
 
 11.17.2 (2023-06-29)
 ====================

--- a/crds/tests/test_roman.py
+++ b/crds/tests/test_roman.py
@@ -8,7 +8,7 @@ from crds.core.exceptions import CrdsLookupError
 
 from crds.tests import test_config
 from nose.tools import raises
-
+from metrics_logger.decorators import metrics_logger
 
 class TestRoman(unittest.TestCase):
     """ TestRoman is a collection of crds unit tests for ROMAN.
@@ -23,6 +23,7 @@ class TestRoman(unittest.TestCase):
     def tearDown(self):
         test_config.cleanup(self.old_state)
 
+    @metrics_logger("DMS16", "DMS25")
     def test_getreferences_with_valid_header_ISOT_fmt(self):
         """ test_getreferences_with_valid_header: test satisfies Roman 303.1 and 628.1
         """
@@ -39,7 +40,8 @@ class TestRoman(unittest.TestCase):
         )
 
         assert pathlib.Path(result["dark"]).name == "roman_wfi_dark_0001.asdf"
-    
+
+    @metrics_logger("DMS16", "DMS25", "DMS26")
     def test_getreferences_with_valid_header_ISO_fmt(self):
         """ test_getreferences_with_valid_header: test satisfies Roman 303.1 and 628.1
         """
@@ -86,7 +88,7 @@ class TestRoman(unittest.TestCase):
 
         assert pathlib.Path(result["distortion"]).name == "roman_wfi_distortion_0001.asdf"
 
-
+    @metrics_logger("DMS16")
     @raises(CrdsLookupError)
     def test_getreferences_with_invalid_header(self):
         """ test_getreferences_with_invalid_header: test satisfies Roman 303.1
@@ -103,6 +105,7 @@ class TestRoman(unittest.TestCase):
             reftypes=["dark"]
         )
 
+    @metrics_logger("DMS114", "DMS25", "DMS26")
     def test_list_references(self):
         """ test_list_references: test satisfies Roman 303.2 and 628.2
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ test = [
   "flake8",
   "bandit",
   "coverage",
+  "metrics-logger",
 ]
 docs = [
   "sphinx",


### PR DESCRIPTION
- Resolves CCD-1324 : added metrics_logger decorators with DMS tags to relevant Roman tests
- TODO: add metrics_logger to test deps (waiting for availability on PyPi)