### PR TITLE
actions/limit-ci-to-master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,8 @@ name: Changelog
 on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize, reopened]
-
+    branches:
+    - master
 jobs:
   changelog:
     name: Confirm changelog entry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - '*'
   pull_request:
+    branches:
+    - master
 
 jobs:
   pytest:


### PR DESCRIPTION
- only run actions/tests on pushes and PRs to master