### PR TITLE
Refactor setup_test_cache to allow for simply updating local cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,12 @@ General
 -------
 
 - Removed python 3.8 check from ci.yml [#934]
+
 - Removed references to ICD-47 in users guide [#936]
+
 - translate 'ANY' as equal to '*' when selecting match rules in rmap changes. Prevents equal weight special case errors from occurring unnecessarily [#939]
+
+-  Refactor setup_test_cache to allow for simply updating local cache [#966]
 
 JWST
 ----

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -1,9 +1,9 @@
 #! /bin/bash -x
 usage="Usage: setup_test_cache CRDS_TEST_ROOT <c/u> where 'c' means clean and 'u' means update"
-update=${2:-"n"}
+update=${2:-"c"}
 export CRDS_TEST_ROOT=${1?$usage}
 
-if [ "$update" = "n" ]; then
+if [ "$update" = "c" ]; then
     (cd $CRDS_TEST_ROOT; rm -rf crds-cache-test;  git clone https://github.com/spacetelescope/crds-cache-test.git;)
     (cd $CRDS_TEST_ROOT; rm -rf crds-cache-default-test; mkdir crds-cache-default-test;)
 fi

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -1,9 +1,12 @@
-#! /bin/sh -x
+#! /bin/bash -x
+usage="Usage: setup_test_cache CRDS_TEST_ROOT <c/u> where 'c' means clean and 'u' means update"
+update=${2:-"n"}
+export CRDS_TEST_ROOT=${1?$usage}
 
-export CRDS_TEST_ROOT=$1
-
-(cd $CRDS_TEST_ROOT; rm -rf crds-cache-test;  git clone https://github.com/spacetelescope/crds-cache-test.git;)
-(cd $CRDS_TEST_ROOT; rm -rf crds-cache-default-test; mkdir crds-cache-default-test;)
+if [ "$update" = "n" ]; then
+    (cd $CRDS_TEST_ROOT; rm -rf crds-cache-test;  git clone https://github.com/spacetelescope/crds-cache-test.git;)
+    (cd $CRDS_TEST_ROOT; rm -rf crds-cache-default-test; mkdir crds-cache-default-test;)
+fi
 
 export CRDS_PATH=$CRDS_TEST_ROOT/crds-cache-default-test
 export CRDS_TESTING_CACHE=$CRDS_TEST_ROOT/crds-cache-test


### PR DESCRIPTION
The script `setup_test_cache` always clears out the local cache completely. The command line argument is added to the script to allow only updating the local cache. The usage now is as follows:
```
./setup_test_cache CRDS_TEST_ROOT <c/u>
```
where `<c/u>` is an optional argument. If `c`, the default behavior of completely clearing and rebuilding the local cache is done. This is also the default behavior if no argument is given. If anything other that `c` is given, such as `u`, the cache will only be updated with the current state of the HST/JWST operational servers.

When run without any arguments, a help text is given.