### PR TITLE
pytest/check-archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
           - ubuntu-latest
           # - macos-latest # TEMP 
         python-version:
-          # - 3.9
+          - 3.9
           - '3.10'
-          # - 3.11 
+          - 3.11
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
           - ubuntu-latest
           # - macos-latest # TEMP 
         python-version:
-          - 3.9
+          # - 3.9
           - '3.10'
-          - 3.11 
+          # - 3.11 
     steps:
       - uses: actions/checkout@v3
         with:

--- a/conftest.py
+++ b/conftest.py
@@ -142,6 +142,7 @@ def default_shared_state(crds_shared_group_cache):
 def hst_shared_cache_state(crds_shared_group_cache):
     cfg = ConfigState(cache=crds_shared_group_cache, url="https://hst-crds.stsci.edu", observatory="hst")
     cfg.config_setup()
+    return cfg
 
 
 @fixture(scope='function')

--- a/conftest.py
+++ b/conftest.py
@@ -139,6 +139,12 @@ def default_shared_state(crds_shared_group_cache):
 
 
 @fixture(scope='function')
+def hst_shared_cache_state(crds_shared_group_cache):
+    cfg = ConfigState(cache=crds_shared_group_cache, url="https://hst-crds.stsci.edu")
+    cfg.config_setup()
+
+
+@fixture(scope='function')
 def jwst_no_cache_state():
     #os.environ["CRDS_MAPPATH_SINGLE"] = test_data
     cfg = ConfigState(cache=None, url="https://jwst-crds.stsci.edu")

--- a/conftest.py
+++ b/conftest.py
@@ -140,7 +140,7 @@ def default_shared_state(crds_shared_group_cache):
 
 @fixture(scope='function')
 def hst_shared_cache_state(crds_shared_group_cache):
-    cfg = ConfigState(cache=crds_shared_group_cache, url="https://hst-crds.stsci.edu")
+    cfg = ConfigState(cache=crds_shared_group_cache, url="https://hst-crds.stsci.edu", observatory="hst")
     cfg.config_setup()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ markers = [
   "list",
   "locking",
   "matches",
+  "misc",
   "refactoring: tests in the crds.refactoring module",
   "reftypes",
   "rmap",

--- a/test/bestrefs/test_bestrefs.py
+++ b/test/bestrefs/test_bestrefs.py
@@ -74,9 +74,10 @@ def test_bestrefs_3_files(default_shared_state, caplog, hst_data):
             {hst_data}/j8bt06o6q_raw.fits {hst_data}/j8bt09jcq_raw.fits"""
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
+
 
 @pytest.mark.bestrefs
 def test_bestrefs_compare_source_files(default_shared_state, caplog, hst_data):
@@ -86,6 +87,7 @@ def test_bestrefs_compare_source_files(default_shared_state, caplog, hst_data):
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" No file header updates requested;  dry run.  Use --update-bestrefs to update FITS headers.
  ===> Processing {hst_data}/j8bt05njq_raw.fits
  instrument='ACS' type='ATODTAB' data='{hst_data}/j8bt05njq_raw.fits' ::  New best reference: 'kcb1734ij_a2d.fits' --> 'n/a' :: Would update.
@@ -113,7 +115,6 @@ def test_bestrefs_compare_source_files(default_shared_state, caplog, hst_data):
  19 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -124,7 +125,7 @@ def test_bestrefs_3_files_default_context_from_server(default_shared_state, capl
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
-
+    default_shared_state.cleanup()
     out_to_check = f""" No comparison context or source comparison requested.
  No file header updates requested;  dry run.  Use --update-bestrefs to update FITS headers.
  ===> Processing {hst_data}/j8bt05njq_raw.fits
@@ -135,7 +136,6 @@ def test_bestrefs_3_files_default_context_from_server(default_shared_state, capl
  5 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -146,6 +146,7 @@ def test_bestrefs_broken_dataset_file(default_shared_state, caplog, hst_data):
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" No comparison context or source comparison requested.
  No file header updates requested;  dry run.  Use --update-bestrefs to update FITS headers.
  ===> Processing {hst_data}/j8bt05njq_raw.fits
@@ -158,7 +159,6 @@ def test_bestrefs_broken_dataset_file(default_shared_state, caplog, hst_data):
  6 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -170,13 +170,12 @@ def test_bestrefs_broken_cache_and_server(broken_state, caplog, hst_data):
             BestrefsScript(argv)()
             assert pytest_wrapped_e.type == SystemExit
         out = caplog.text
-        
+    broken_state.cleanup()
     out_to_check = """ (FATAL) CRDS server connection and cache load FAILED.  Cannot continue.
  See https://hst-crds.stsci.edu/docs/cmdline_bestrefs/ or https://jwst-crds.stsci.edu/docs/cmdline_bestrefs/
  for more information on configuring CRDS,  particularly CRDS_PATH and CRDS_SERVER_URL. : [Errno 2] No such file or directory: '/nowhere/config/hst/server_config'"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    broken_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -185,6 +184,7 @@ def test_bestrefs_catalog_dataset(default_shared_state, caplog):
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = """ Dumping dataset parameters from CRDS server at 'https://hst-crds.stsci.edu' for ['LB6M01030']
  Dumped 1 of 1 datasets from CRDS server at 'https://hst-crds.stsci.edu'
  Computing bestrefs for datasets ['LB6M01030']
@@ -194,7 +194,7 @@ def test_bestrefs_catalog_dataset(default_shared_state, caplog):
  4 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
+
 
 
 @pytest.mark.bestrefs
@@ -204,6 +204,7 @@ def test_bestrefs_context_to_context(default_shared_state, caplog, hst_data):
     with caplog.at_level(logging.INFO, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" No file header updates requested;  dry run.  Use --update-bestrefs to update FITS headers.
  ===> Processing {hst_data}/j8bt05njq_raw.fits
  ===> Processing {hst_data}/j8bt06o6q_raw.fits
@@ -213,7 +214,6 @@ def test_bestrefs_context_to_context(default_shared_state, caplog, hst_data):
  4 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -223,6 +223,7 @@ def test_bestrefs_all_instruments_hst(default_shared_state, caplog, hst_data):
         test_brs = BestrefsScript(argv)
         test_brs.complex_init()
         out = caplog.messages
+    default_shared_state.cleanup()
     odd_pattern = re.compile(" Dumping dataset parameters for '[a-z0-9]{3,6}' from CRDS server at 'https://hst-crds.stsci.edu'")
     even_pattern = re.compile(" Downloaded  [0-9]{5,6} dataset ids for '[a-z0-9]{3,6}' since None")
     for i, line in enumerate(out):
@@ -232,7 +233,6 @@ def test_bestrefs_all_instruments_hst(default_shared_state, caplog, hst_data):
             assert re.match(even_pattern, line) is not None
         elif i < 13:
             assert re.match(odd_pattern, line) is not None
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -243,6 +243,7 @@ def test_bestrefs_datasets_since_auto_hst(default_shared_state, caplog):
         test_brs.complex_init()
         out = caplog.text
         messages = caplog.messages
+    default_shared_state.cleanup()
     out_to_check = """ Mapping differences from 'hst.pmap' --> 'test/data/hst/hst_0001.pmap' affect:
  {'acs': ['biasfile']}
  Possibly affected --datasets-since dates determined by 'hst.pmap' --> 'test/data/hst/hst_0001.pmap' are:
@@ -257,7 +258,6 @@ def test_bestrefs_datasets_since_auto_hst(default_shared_state, caplog):
         else:
             # using re b/c the numeric value is dynamic
             assert re.match(pattern, messages[-2]) is not None
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -267,11 +267,11 @@ def test_bestrefs_dataset_drop_ids(default_shared_state, caplog, hst_data):
         test_brs = BestrefsScript(argv)
         test_brs.complex_init()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" Loading file '{hst_data}/test_cos.json'
  Loaded 1 datasets from file '{hst_data}/test_cos.json' completely replacing existing headers."""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -281,19 +281,20 @@ def test_bestrefs_dataset_only_ids(default_shared_state, caplog, hst_data):
         test_brs = BestrefsScript(argv)
         test_brs.complex_init()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" Loading file '{hst_data}/test_cos.json'
  Loaded 1 datasets from file '{hst_data}/test_cos.json' completely replacing existing headers."""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
 def test_bestrefs_compare_source_canary(default_shared_state, caplog, hst_data):
     argv = f"""crds.bestrefs --new-context hst_0551.pmap --compare-source --load-pickles {hst_data}/canary.json --differences-are-errors --hst"""
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
-        test_brs = BestrefsScript(argv)()
+        BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" Loading file '{hst_data}/canary.json'
  Loaded 1 datasets from file '{hst_data}/canary.json' completely replacing existing headers.
  instrument='COS' type='BPIXTAB' data='LA7803FIQ' ::  Comparison difference: 'bar.fits' --> 'yae1249sl_bpix.fits' :: Would update.
@@ -303,7 +304,6 @@ def test_bestrefs_compare_source_canary(default_shared_state, caplog, hst_data):
  2 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -312,6 +312,7 @@ def test_bestrefs_donotreprocess_datasets(default_shared_state, caplog):
     with caplog.at_level(logging.INFO, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = """ Dumping dataset parameters from CRDS server at 'https://hst-crds.stsci.edu' for ['JA9553LVQ', 'JBBGRCGFQ']
  Dumped 2 of 2 datasets from CRDS server at 'https://hst-crds.stsci.edu'
  Computing bestrefs for datasets ['JA9553LVQ', 'JBBGRCGFQ']
@@ -320,7 +321,6 @@ def test_bestrefs_donotreprocess_datasets(default_shared_state, caplog):
  5 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -329,6 +329,7 @@ def test_bestrefs_donotreprocess_fix(default_shared_state, caplog, hst_data):
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" Command: ['crds.bestrefs', '--hst', '--old-context', 'hst_0628.pmap', '--new-context', 'hst_0633.pmap', '--print-affected', '--load-pickle', '{hst_data}/bestrefs_dnr_fix.json', '--verbosity=30']
  Using explicit new context 'hst_0633.pmap' for computing updated best references.
  Using explicit old context 'hst_0628.pmap'
@@ -365,7 +366,6 @@ def test_bestrefs_donotreprocess_fix(default_shared_state, caplog, hst_data):
  5 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs
@@ -374,6 +374,7 @@ def test_bestrefs_multiple_updates_with_error(default_shared_state, caplog, hst_
     with caplog.at_level(logging.DEBUG, logger="CRDS"):
         BestrefsScript(argv)()
         out = caplog.text
+    default_shared_state.cleanup()
     out_to_check = f""" Command: ['crds.bestrefs', '--hst', '--old-context', 'hst_0628.pmap', '--new-context', 'hst_0633.pmap', '--print-affected', '--load-pickle', '{hst_data}/bestrefs_new_error.json', '--verbosity=30']
  Using explicit new context 'hst_0633.pmap' for computing updated best references.
  Using explicit old context 'hst_0628.pmap'
@@ -412,7 +413,6 @@ def test_bestrefs_multiple_updates_with_error(default_shared_state, caplog, hst_
  3 infos"""
     for msg in out_to_check.splitlines():
         assert msg.strip() in out
-    default_shared_state.cleanup()
 
 
 @pytest.mark.bestrefs

--- a/test/certify/test_certify.py
+++ b/test/certify/test_certify.py
@@ -477,7 +477,6 @@ Certifying '{cache}/mappings/hst/hst_cos_wcptab.rmap' (18/19) as 'MAPPING' relat
 Certifying '{cache}/mappings/hst/hst_cos_xtractab.rmap' (19/19) as 'MAPPING' relative to context 'hst.pmap'
 ########################################
 0 errors
-0 warnings
 39 infos"""
     for msg in expected_out.splitlines():
         assert msg.strip() in out
@@ -622,7 +621,6 @@ Setting 'META.INSTRUMENT.DETECTOR [DETECTOR]' = 'MIRIMAGE' to value of 'P_DETECT
 Checking JWST datamodels.
 ########################################
 0 errors
-0 warnings
 7 infos"""
     for msg in expected_out.splitlines():
         assert msg.strip() in out
@@ -1542,7 +1540,6 @@ FITS file 'jwst_nirspec_ipc_with_asdf_extension.fits' conforms to FITS standards
 Checking JWST datamodels.
 ########################################
 1 errors
-0 warnings
 5 infos"""
     for msg in expected_out.splitlines():
         assert msg.strip() in out

--- a/test/core/test_reftypes.py
+++ b/test/core/test_reftypes.py
@@ -41,7 +41,6 @@ def test_reftypes_hst_save_json_specs(default_shared_state, test_temp_dir):
     default_shared_state.cleanup()
 
 
-@pytest.mark.jwst
 @pytest.mark.reftypes
 @pytest.mark.core
 def test_reftypes_jwst_load_raw_specs(default_shared_state):

--- a/test/misc/test_check_archive.py
+++ b/test/misc/test_check_archive.py
@@ -18,28 +18,28 @@ log.THE_LOGGER.logger.propagate = True
 [sys.argv.remove(a) for a in sys.argv]
 
 @mark.misc
-def test_check_archive_file_api_true(default_shared_state):
+def test_check_archive_file_api_true(hst_shared_cache_state):
     chk = check_archive.file_available("hst.pmap")
-    default_shared_state.cleanup()
+    hst_shared_cache_state.cleanup()
     assert chk is True
 
 
 @mark.misc
-def test_check_archive_file_api_false(default_shared_state, caplog):
+def test_check_archive_file_api_false(hst_shared_cache_state, caplog):
     with caplog.at_level(logging.INFO, logger="CRDS"):
         chk = check_archive.file_available("foo.pmap")
         out = caplog.text
-    default_shared_state.cleanup()
+    hst_shared_cache_state.cleanup()
     assert chk is False
     assert "File 'foo.pmap' failed HTTP HEAD with code = 404 from 'https://hst-crds.stsci.edu/unchecked_get/mappings/hst/foo.pmap'" in out
 
 
 @mark.misc
-def test_check_archive_script(default_shared_state, caplog):
+def test_check_archive_script(hst_shared_cache_state, caplog):
     with caplog.at_level(logging.INFO, logger="CRDS"):
         check_archive.CheckArchiveScript("crds.misc.check_archive --files foo.map hst.pmap")()
         out = caplog.text
-    default_shared_state.cleanup()
+    hst_shared_cache_state.cleanup()
     expected = """Mapping URL: 'https://hst-crds.stsci.edu/unchecked_get/mappings/hst/'
 Reference URL: 'https://hst-crds.stsci.edu/unchecked_get/references/hst/'
 File 'foo.map' failed HTTP HEAD with code = 404 from 'https://hst-crds.stsci.edu/unchecked_get/references/hst/foo.map'

--- a/test/misc/test_check_archive.py
+++ b/test/misc/test_check_archive.py
@@ -1,0 +1,50 @@
+"""
+Tests for crds.misc.check_archive which is nominally used to check the
+archive for file availability as an alternative to a true ACK from the
+archive when their processing is complete.  Also supplies a function API
+used by the server to determine and cache file availability status in the
+CRDS catalog.
+"""
+from pytest import mark
+import logging
+import sys
+from crds.core import log
+from crds.misc import check_archive
+
+# ensure CRDS logger propagates events to pytest log capture.
+log.THE_LOGGER.logger.propagate = True
+
+# prevent pytest args from being passed to CheckArchive script
+[sys.argv.remove(a) for a in sys.argv]
+
+@mark.misc
+def test_check_archive_file_api_true(default_shared_state):
+    chk = check_archive.file_available("hst.pmap")
+    default_shared_state.cleanup()
+    assert chk is True
+
+
+@mark.misc
+def test_check_archive_file_api_false(default_shared_state, caplog):
+    with caplog.at_level(logging.INFO, logger="CRDS"):
+        chk = check_archive.file_available("foo.pmap")
+        out = caplog.text
+    default_shared_state.cleanup()
+    assert chk is False
+    assert "File 'foo.pmap' failed HTTP HEAD with code = 404 from 'https://hst-crds.stsci.edu/unchecked_get/mappings/hst/foo.pmap'" in out
+
+
+@mark.misc
+def test_check_archive_script(default_shared_state, caplog):
+    with caplog.at_level(logging.INFO, logger="CRDS"):
+        check_archive.CheckArchiveScript("crds.misc.check_archive --files foo.map hst.pmap")()
+        out = caplog.text
+    default_shared_state.cleanup()
+    expected = """Mapping URL: 'https://hst-crds.stsci.edu/unchecked_get/mappings/hst/'
+Reference URL: 'https://hst-crds.stsci.edu/unchecked_get/references/hst/'
+File 'foo.map' failed HTTP HEAD with code = 404 from 'https://hst-crds.stsci.edu/unchecked_get/references/hst/foo.map'
+1 errors
+0 warnings
+3 infos"""
+    for line in expected.splitlines():
+        assert line in out

--- a/test/test_matches.py
+++ b/test/test_matches.py
@@ -41,6 +41,7 @@ def test_matches_datasets_minimize_headers_contexts_condition(capsys, default_sh
     MatchesScript(
         "crds.matches --datasets JBANJOF3Q --minimize-headers --contexts hst_0048.pmap hst_0044.pmap --condition-values")()
     out, _ = capsys.readouterr()
+    default_shared_state.cleanup()
     out_to_check = """JBANJOF3Q:JBANJOF3Q : hst_0044.pmap : APERTURE='WFC1-2K' ATODCORR='OMIT' BIASCORR='OMIT' \
 CCDAMP='B' CCDCHIP='1.0' CCDGAIN='2.0' CRCORR='OMIT' DARKCORR='OMIT' DATE-OBS='2010-01-31' DETECTOR='WFC' \
 DQICORR='PERFORM' DRIZCORR='OMIT' FILTER1='F502N' FILTER2='F660N' FLASHCUR='OFF' FLATCORR='OMIT' FLSHCORR='OMIT' \


### PR DESCRIPTION
- converted tests to pytest for crds.misc.check_archive
- removed extraneous and unregistered jwst marker from test_reftypes.py 
- added 'misc' to pytest markers