### PR TITLE
use GitHub Actions cache to cache test cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           ./install
           pip install .[submission,test,docs,synphot]
       - uses: actions/cache@v3
+        if: always()
         with:
           path: ${{ needs.data.outputs.crds_path }}
           key: ${{ needs.data.outputs.crds_context }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,36 @@ on:
     - pytest-migration #temp
 
 jobs:
+  data:
+    name: retrieve current CRDS context
+    runs-on: ubuntu-latest
+    env:
+      OBSERVATORY: hst
+      CRDS_SERVER_URL: https://hst-crds.stsci.edu
+      CRDS_PATH: /tmp/crds-cache-default-test
+    outputs:
+      crds_path: ${{ steps.crds_path.outputs.path }}
+      crds_context: ${{ steps.crds_context.outputs.pmap }}
+      crds_server: ${{ steps.crds_server.outputs.url }}
+    steps:
+      - id: crds_context
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+        # Get default CRDS_CONTEXT without installing crds client
+        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
+      - id: crds_path
+        run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
+      - id: crds_server
+        run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
   pytest:
     name: ${{ matrix.runs-on }} Python ${{ matrix.python-version }}
+    needs: [ data ]
     runs-on: ${{ matrix.runs-on }}
     env:
-      CRDS_SERVER_URL: https://hst-crds.stsci.edu
+      CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
       CRDS_TEST_ROOT: /tmp
       LD_LIBRARY_PATH: /usr/local/lib
     strategy:
@@ -56,6 +81,9 @@ jobs:
           pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]
-          ./setup_test_cache $CRDS_TEST_ROOT
-      - name: Run tests
-        run: ./runtests --cover
+      - uses: actions/cache@v3
+        with:
+          path: ${{ needs.data.outputs.crds_path }}
+          key: ${{ needs.data.outputs.crds_context }}
+      - run: ./setup_test_cache $CRDS_TEST_ROOT
+      - run: ./runtests --cover


### PR DESCRIPTION
It appears the that Pytest CI downloads the same test cache every time; perhaps this can be sped up by caching it per-context