### PR TITLE
certify/fix-deprecated-numpy-product

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+11.17.7 (unreleased)
+====================
+
+General
+-------
+
+- Replaced deprecated np.product with np.prod in crds.certify.validators.core [#975]
+
+
 11.17.6 (2023-09-08)
 =====================
 

--- a/crds/certify/validators/core.py
+++ b/crds/certify/validators/core.py
@@ -687,7 +687,7 @@ class KernelunityValidator(Validator):
         # super(KernelunityValidator, self).check_header(filename, header)
         array_name = self.complex_name
         all_data = header[array_name].DATA.transpose()
-        images = int(np.product(all_data.shape[:-2]))
+        images = int(np.prod(all_data.shape[:-2]))
         images_shape = (images,) + all_data.shape[-2:]
         images_data = np.reshape(all_data, images_shape)
         log.verbose("File=" + repr(os.path.basename(filename)),


### PR DESCRIPTION
- Replace deprecated np.product with np.prod in crds.certify.validators.core. `product` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0