### PR TITLE
add separate workflow to download CRDS test cache

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,6 +6,12 @@ on:
     # Weekly Monday 9AM
     - cron: "0 9 * * 1"
   pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
 
 defaults:
   run:
@@ -56,6 +62,7 @@ jobs:
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
   cache:
+    if: (github.repository == 'spacetelescope/crds' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'update CRDS cache')))
     needs: [ contexts ]
     name: run tests to build cache of CRDS reference files
     runs-on: ubuntu-latest
@@ -65,7 +72,7 @@ jobs:
         with:
           environment-name: crds-testing
           create-args: >-
-            python=3
+            python=3.11
             fitsverify
           init-shell: bash
           cache-environment: true

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -61,6 +61,7 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
+      - run: echo "${{ steps.hst_crds_context.outputs.pmap }} ${{ steps.jwst_crds_context.outputs.pmap }} ${{ steps.roman_crds_context.outputs.pmap }}"
   cache:
     if: (github.repository == 'spacetelescope/crds' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'update CRDS cache')))
     needs: [ contexts ]

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,4 @@
-name: cache
+name: test cache
 
 on:
   workflow_call:
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CRDS_PATH: /tmp/crds-cache-default-test/
+  CRDS_PATH: /tmp/crds-cache-default-test
   CRDS_TEST_ROOT: /tmp
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
@@ -58,15 +58,15 @@ jobs:
       - name: restore cached HST files
         uses: actions/cache@v3
         with:
-          path: ${{ env.CRDS_PATH }}/mappings/hst/
-          key: ${{ needs.contexts.outputs.hst }}
+          path: ${{ env.CRDS_PATH }}/**/hst*
+          key: test-cache-${{ needs.contexts.outputs.hst }}
       - name: restore cached JWST files
         uses: actions/cache@v3
         with:
-          path: ${{ env.CRDS_PATH }}/mappings/jwst
-          key: ${{ needs.contexts.outputs.jwst }}
+          path: ${{ env.CRDS_PATH }}/**/jwst*
+          key: test-cache-${{ needs.contexts.outputs.jwst }}
       - id: key
-        run: echo "key=crds-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
+        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
       - name: combine caches
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: key
-        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
+        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
       - id: cache
         name: restore entire CRDS cache
         uses: actions/cache@v3
@@ -62,13 +62,6 @@ jobs:
           path: ${{ env.CRDS_PATH }}/**/jwst*
           key: test-cache-${{ needs.contexts.outputs.jwst }}
       - if: steps.cache.outputs.cache-hit == 'false'
-        id: cache_roman
-        name: restore cached Roman files
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}/**/roman*
-          key: test-cache-${{ needs.contexts.outputs.roman }}
-      - if: steps.cache.outputs.cache-hit == 'false'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: crds-testing
@@ -89,4 +82,4 @@ jobs:
       - if: steps.cache.outputs.cache-hit == 'false'
         run: pip uninstall --yes crds && ./install && pip install .
       - if: steps.cache.outputs.cache-hit == 'false'
-        run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true' || steps.cache_roman.outputs.cache-hit == 'true') && 'u' || 'c' }}
+        run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -36,7 +36,6 @@ jobs:
       crds_path: ${{ env.CRDS_PATH }}
       hst: ${{ steps.hst_crds_context.outputs.pmap }}
       jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
-      roman: ${{ steps.roman_crds_context.outputs.pmap }}
     steps:
       - id: hst_crds_context
         env:
@@ -56,20 +55,11 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - id: roman_crds_context
-        env:
-          OBSERVATORY: roman
-          CRDS_SERVER_URL: https://roman-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - run: echo "${{ steps.hst_crds_context.outputs.pmap }} ${{ steps.jwst_crds_context.outputs.pmap }} ${{ steps.roman_crds_context.outputs.pmap }}"
+      - run: echo ${{ steps.hst_crds_context.outputs.pmap }} ${{ steps.jwst_crds_context.outputs.pmap }}
   cache:
     if: (github.repository == 'spacetelescope/crds' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'update CRDS cache')))
     needs: [ contexts ]
-    name: run tests to build cache of CRDS reference files
+    name: setup CRDS test cache
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -77,20 +67,16 @@ jobs:
         with:
           environment-name: crds-testing
           create-args: >-
-            python=3.11
-            fitsverify
+            python=3
           init-shell: bash
           cache-environment: true
           cache-downloads: true
       - run: |
-          pip install roman-datamodels git+https://github.com/spacetelescope/jwst
-          pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]
       - uses: actions/cache@v3
         if: always()
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}-${{ needs.data.outputs.roman }}
+          key: crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}
       - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}
-      - run: ./runtests

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -9,8 +9,8 @@ on:
         value: ${{ jobs.cache.outputs.key }}
   workflow_dispatch:
   schedule:
-    # Weekly Monday 9AM
-    - cron: "0 9 * * 1"
+    # Weekly Monday midnight
+    - cron: "0 0 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -16,10 +16,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash -leo pipefail {0} {0}
-
 env:
   CRDS_PATH: /tmp/crds-cache-default-test/
   CRDS_TEST_ROOT: /tmp
@@ -29,31 +25,7 @@ env:
 
 jobs:
   contexts:
-    name: retrieve latest CRDS contexts
-    runs-on: ubuntu-latest
-    outputs:
-      hst: ${{ steps.hst_crds_context.outputs.pmap }}
-      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
-    steps:
-      - id: hst_crds_context
-        env:
-          OBSERVATORY: hst
-          CRDS_SERVER_URL: https://hst-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - id: jwst_crds_context
-        env:
-          OBSERVATORY: jwst
-          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - run: echo ${{ steps.hst_crds_context.outputs.pmap }} ${{ steps.jwst_crds_context.outputs.pmap }}
+    uses: ./.github/workflows/contexts.yml
   cache:
     needs: [ contexts ]
     name: download and cache CRDS test files
@@ -73,7 +45,7 @@ jobs:
           cache-downloads: true
       - run: ./install && pip install .
       - id: key
-        run: echo "key=crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}" >> $GITHUB_OUTPUT
+        run: echo "key=crds-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         if: always()
         with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,4 @@
-name: build cache
+name: cache
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           environment-name: crds-testing
           create-args: >-
-            python=3
+            python=3.11
             asdf
             astropy
             filelock

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -47,9 +47,9 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - id: jst_crds_context
+      - id: jwst_crds_context
         env:
-          OBSERVATORY: jst
+          OBSERVATORY: jwst
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         run: >
           echo "pmap=$(

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -5,6 +5,7 @@ on:
   schedule:
     # Weekly Monday 9AM
     - cron: "0 9 * * 1"
+  pull_request:
 
 defaults:
   run:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -72,4 +72,4 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} u

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -5,6 +5,8 @@ on:
     outputs:
       path:
         value: ${{ jobs.cache.outputs.path }}
+      testing_cache:
+        value: ${{ jobs.cache.outputs.testing_cache }}
       key:
         value: ${{ jobs.cache.outputs.key }}
   workflow_dispatch:
@@ -17,8 +19,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CRDS_PATH: /tmp/crds-cache-default-test
   CRDS_TEST_ROOT: /tmp
+  CRDS_PATH: /tmp/crds-cache-default-test
+  CRDS_TESTING_CACHE: /tmp/crds-cache-test
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
   LD_LIBRARY_PATH: /usr/local/lib
@@ -36,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       path: ${{ env.CRDS_PATH }}
+      testing_cache: ${{ env.CRDS_TESTING_CACHE }}
       key: ${{ steps.key.outputs.key }}
     steps:
       - uses: actions/checkout@v3
@@ -45,8 +49,15 @@ jobs:
         name: restore entire CRDS cache
         uses: actions/cache@v3
         with:
-          path: ${{ env.CRDS_PATH }}
+          path: |
+            ${{ env.CRDS_PATH }}
+            ${{ env.CRDS_TESTING_CACHE }}
           key: ${{ steps.key.outputs.key }}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        id: crds-cache-test
+        run: |
+          git clone https://github.com/spacetelescope/crds-cache-test.git
+          mv crds-cache-test ${{ env.CRDS_TEST_ROOT }}
       - if: steps.cache.outputs.cache-hit != 'true'
         id: cache_hst
         name: restore cached HST files
@@ -78,7 +89,7 @@ jobs:
           cache-environment: true
           cache-downloads: true
       - if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
+        run: pip install git+https://github.com/spacetelescope/jwst roman-datamodels
       - if: steps.cache.outputs.cache-hit != 'true'
         run: pip uninstall --yes crds && ./install && pip install .
       - if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -39,7 +39,37 @@ jobs:
       key: ${{ steps.key.outputs.key }}
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@v1
+      - id: key
+        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
+      - id: cache
+        name: restore entire CRDS cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: ${{ steps.key.outputs.key }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        id: cache_hst
+        name: restore cached HST files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/**/hst*
+          key: test-cache-${{ needs.contexts.outputs.hst }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        id: cache_jwst
+        name: restore cached JWST files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/**/jwst*
+          key: test-cache-${{ needs.contexts.outputs.jwst }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        id: cache_roman
+        name: restore cached Roman files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/**/roman*
+          key: test-cache-${{ needs.contexts.outputs.roman }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: crds-testing
           create-args: >-
@@ -54,33 +84,9 @@ jobs:
           init-shell: bash
           cache-environment: true
           cache-downloads: true
-      - run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
-      - run: pip uninstall --yes crds && ./install && pip install .
-      - id: cache_hst
-        name: restore cached HST files
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}/**/hst*
-          key: test-cache-${{ needs.contexts.outputs.hst }}
-      - id: cache_jwst
-        name: restore cached JWST files
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}/**/jwst*
-          key: test-cache-${{ needs.contexts.outputs.jwst }}
-      - id: cache_roman
-        name: restore cached Roman files
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}/**/roman*
-          key: test-cache-${{ needs.contexts.outputs.roman }}
-      - id: key
-        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
-      - id: cache
-        name: restore entire CRDS cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CRDS_PATH }}
-          key: ${{ steps.key.outputs.key }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
+      - if: steps.cache.outputs.cache-hit == 'false'
+        run: pip uninstall --yes crds && ./install && pip install .
       - if: steps.cache.outputs.cache-hit == 'false'
         run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true' || steps.cache_roman.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -13,6 +13,10 @@ on:
       - unlabeled
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash -leo pipefail {0} {0}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -47,6 +47,7 @@ jobs:
             asdf
             astropy
             filelock
+            fitsverify
             numpy
             parsley
             requests

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -83,8 +83,7 @@ jobs:
           cache-environment: true
           cache-downloads: true
       - run: |
-          pip install roman-datamodels
-          pip install git+https://github.com/spacetelescope/jwst
+          pip install roman-datamodels git+https://github.com/spacetelescope/jwst
           pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -55,12 +55,14 @@ jobs:
           cache-downloads: true
       - run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
       - run: pip uninstall --yes crds && ./install && pip install .
-      - name: restore cached HST files
+      - id: cache_hst
+        name: restore cached HST files
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}/**/hst*
           key: test-cache-${{ needs.contexts.outputs.hst }}
-      - name: restore cached JWST files
+      - id: cache_jwst
+        name: restore cached JWST files
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}/**/jwst*
@@ -73,4 +75,4 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ steps.cache.outputs.cache-hit == 'true' && 'u' || 'c' }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache.outputs.cache-hit == 'true' || steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -47,21 +47,21 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         id: cache_hst
         name: restore cached HST files
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}/**/hst*
           key: test-cache-${{ needs.contexts.outputs.hst }}
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         id: cache_jwst
         name: restore cached JWST files
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}/**/jwst*
           key: test-cache-${{ needs.contexts.outputs.jwst }}
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: crds-testing
@@ -77,9 +77,9 @@ jobs:
           init-shell: bash
           cache-environment: true
           cache-downloads: true
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         run: pip uninstall --yes crds && ./install && pip install .
-      - if: steps.cache.outputs.cache-hit == 'false'
+      - if: steps.cache.outputs.cache-hit != 'true'
         run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -53,11 +53,22 @@ jobs:
           init-shell: bash
           cache-environment: true
           cache-downloads: true
+      - run: pip install roman-datamodels stdatamodels
       - run: ./install && pip install .
+      - name: restore cached HST files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/mappings/hst/
+          key: ${{ needs.contexts.outputs.hst }}
+      - name: restore cached JWST files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/mappings/jwst
+          key: ${{ needs.contexts.outputs.jwst }}
       - id: key
         run: echo "key=crds-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        if: always()
+      - name: combine caches
+        uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -23,6 +23,10 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
   LD_LIBRARY_PATH: /usr/local/lib
 
+defaults:
+  run:
+    shell: bash -leo pipefail {0} {0}
+
 jobs:
   contexts:
     uses: ./.github/workflows/contexts.yml
@@ -40,6 +44,12 @@ jobs:
           environment-name: crds-testing
           create-args: >-
             python=3
+            asdf
+            astropy
+            filelock
+            numpy
+            parsley
+            requests
           init-shell: bash
           cache-environment: true
           cache-downloads: true

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -75,7 +75,7 @@ jobs:
           path: ${{ env.CRDS_PATH }}/**/roman*
           key: test-cache-${{ needs.contexts.outputs.roman }}
       - id: key
-        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
+        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
       - id: cache
         name: restore entire CRDS cache
         uses: actions/cache@v3

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -67,7 +67,7 @@ jobs:
           key: test-cache-${{ needs.contexts.outputs.jwst }}
       - id: key
         run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
-      - name: combine caches
+      - name: restore entire CRDS cache
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -67,12 +67,18 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}/**/jwst*
           key: test-cache-${{ needs.contexts.outputs.jwst }}
+      - id: cache_roman
+        name: restore cached Roman files
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CRDS_PATH }}/**/roman*
+          key: test-cache-${{ needs.contexts.outputs.roman }}
       - id: key
-        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
+        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.roman }}" >> $GITHUB_OUTPUT
       - id: cache
         name: restore entire CRDS cache
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache.outputs.cache-hit == 'true' || steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true') && 'u' || 'c' }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache.outputs.cache-hit == 'true' || steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true' || steps.cache_roman.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -67,9 +67,10 @@ jobs:
           key: test-cache-${{ needs.contexts.outputs.jwst }}
       - id: key
         run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
-      - name: restore entire CRDS cache
+      - id: cache
+        name: restore entire CRDS cache
         uses: actions/cache@v3
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} u
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ steps.cache.outputs.cache-hit == 'true' && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -53,8 +53,8 @@ jobs:
           init-shell: bash
           cache-environment: true
           cache-downloads: true
-      - run: pip install roman-datamodels stdatamodels
-      - run: ./install && pip install .
+      - run: pip install roman-datamodels git+https://github.com/spacetelescope/jwst
+      - run: pip uninstall --yes crds && ./install && pip install .
       - name: restore cached HST files
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,17 +1,16 @@
 name: cache
 
 on:
+  workflow_call:
+    outputs:
+      path:
+        value: ${{ jobs.cache.outputs.path }}
+      key:
+        value: ${{ jobs.cache.outputs.key }}
   workflow_dispatch:
   schedule:
     # Weekly Monday 9AM
     - cron: "0 9 * * 1"
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - labeled
-      - unlabeled
-      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,7 +32,6 @@ jobs:
     name: retrieve latest CRDS contexts
     runs-on: ubuntu-latest
     outputs:
-      crds_path: ${{ env.CRDS_PATH }}
       hst: ${{ steps.hst_crds_context.outputs.pmap }}
       jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
     steps:
@@ -57,10 +55,12 @@ jobs:
           )" >> $GITHUB_OUTPUT
       - run: echo ${{ steps.hst_crds_context.outputs.pmap }} ${{ steps.jwst_crds_context.outputs.pmap }}
   cache:
-    if: (github.repository == 'spacetelescope/crds' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'update CRDS cache')))
     needs: [ contexts ]
-    name: setup CRDS test cache
+    name: download and cache CRDS test files
     runs-on: ubuntu-latest
+    outputs:
+      path: ${{ env.CRDS_PATH }}
+      key: ${{ steps.key.outputs.key }}
     steps:
       - uses: actions/checkout@v3
       - uses: mamba-org/setup-micromamba@v1
@@ -71,12 +71,12 @@ jobs:
           init-shell: bash
           cache-environment: true
           cache-downloads: true
-      - run: |
-          ./install
-          pip install .[submission,test,docs,synphot]
+      - run: ./install && pip install .
+      - id: key
+        run: echo "key=crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         if: always()
         with:
           path: ${{ env.CRDS_PATH }}
-          key: crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}
+          key: ${{ steps.key.outputs.key }}
       - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -82,4 +82,5 @@ jobs:
         with:
           path: ${{ env.CRDS_PATH }}
           key: ${{ steps.key.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache.outputs.cache-hit == 'true' || steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true' || steps.cache_roman.outputs.cache-hit == 'true') && 'u' || 'c' }}
+      - if: steps.cache.outputs.cache-hit == 'false'
+        run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ (steps.cache_hst.outputs.cache-hit == 'true' || steps.cache_jwst.outputs.cache-hit == 'true' || steps.cache_roman.outputs.cache-hit == 'true') && 'u' || 'c' }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,84 @@
+name: build cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly Monday 9AM
+    - cron: "0 9 * * 1"
+
+defaults:
+  run:
+    shell: bash -leo pipefail {0} {0}
+
+env:
+  CRDS_PATH: /tmp/crds-cache-default-test/
+  CRDS_TEST_ROOT: /tmp
+  CRDS_CLIENT_RETRY_COUNT: 3
+  CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+  LD_LIBRARY_PATH: /usr/local/lib
+
+jobs:
+  contexts:
+    name: retrieve latest CRDS contexts
+    runs-on: ubuntu-latest
+    outputs:
+      crds_path: ${{ env.CRDS_PATH }}
+      hst: ${{ steps.hst_crds_context.outputs.pmap }}
+      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
+      roman: ${{ steps.roman_crds_context.outputs.pmap }}
+    steps:
+      - id: hst_crds_context
+        env:
+          OBSERVATORY: hst
+          CRDS_SERVER_URL: https://hst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - id: jst_crds_context
+        env:
+          OBSERVATORY: jst
+          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - id: roman_crds_context
+        env:
+          OBSERVATORY: roman
+          CRDS_SERVER_URL: https://roman-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+  cache:
+    needs: [ contexts ]
+    name: run tests to build cache of CRDS reference files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: crds-testing
+          create-args: >-
+            python=3
+            fitsverify
+          init-shell: bash
+          cache-environment: true
+          cache-downloads: true
+      - run: |
+          pip install roman-datamodels
+          pip install git+https://github.com/spacetelescope/jwst
+          pip uninstall --yes crds
+          ./install
+          pip install .[submission,test,docs,synphot]
+      - uses: actions/cache@v3
+        if: always()
+        with:
+          path: ${{ env.CRDS_PATH }}
+          key: crds-${{ needs.data.outputs.hst }}-${{ needs.data.outputs.jwst }}-${{ needs.data.outputs.roman }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}
+      - run: ./runtests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,10 @@ jobs:
           pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]
-      - uses: actions/cache@v3
+      - id: cache
+        uses: actions/cache@v3
         with:
           path: ${{ needs.cache.outputs.path }}
           key: ${{ needs.cache.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} u
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ steps.cache.outputs.cache-hit == 'true' && 'u' || 'c' }}
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,41 +12,20 @@ on:
     # - master
     - pytest-migration #temp
 
+env:
+  CRDS_CLIENT_RETRY_COUNT: 3
+  CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+  LD_LIBRARY_PATH: /usr/local/lib
+
 jobs:
-  data:
-    name: retrieve current CRDS context
-    runs-on: ubuntu-latest
-    env:
-      OBSERVATORY: hst
-      CRDS_SERVER_URL: https://hst-crds.stsci.edu
-      CRDS_PATH: /tmp/crds-cache-default-test
-    outputs:
-      crds_path: ${{ steps.crds_path.outputs.path }}
-      crds_context: ${{ steps.crds_context.outputs.pmap }}
-      crds_server: ${{ steps.crds_server.outputs.url }}
-    steps:
-      - id: crds_context
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-        # Get default CRDS_CONTEXT without installing crds client
-        # See https://hst-crds.stsci.edu/static/users_guide/web_services.html#generic-request
-      - id: crds_path
-        run: echo "path=${{ env.CRDS_PATH }}" >> $GITHUB_OUTPUT
-      - id: crds_server
-        run: echo "url=${{ env.CRDS_SERVER_URL }}" >> $GITHUB_OUTPUT
+  cache:
+    uses: ./.github/workflows/cache.yml
   pytest:
     name: ${{ matrix.runs-on }} Python ${{ matrix.python-version }}
-    needs: [ data ]
+    needs: [ cache ]
     runs-on: ${{ matrix.runs-on }}
     env:
-      CRDS_SERVER_URL: ${{ needs.data.outputs.crds_server }}
       CRDS_TEST_ROOT: /tmp
-      CRDS_CLIENT_RETRY_COUNT: 3
-      CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-      LD_LIBRARY_PATH: /usr/local/lib
     strategy:
       fail-fast: false
       matrix:
@@ -78,15 +57,14 @@ jobs:
           sudo cp fitsverify /usr/local/bin
       - name: Install Python dependencies
         run: |
-          pip install roman-datamodels
-          pip install git+https://github.com/spacetelescope/jwst
+          pip install roman-datamodels git+https://github.com/spacetelescope/jwst
           pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]
       - uses: actions/cache@v3
         if: always()
         with:
-          path: ${{ needs.data.outputs.crds_path }}
-          key: ${{ needs.data.outputs.crds_context }}
-      - run: ./setup_test_cache $CRDS_TEST_ROOT
+          path: ${{ needs.cache.outputs.path }}
+          key: ${{ needs.cache.outputs.key }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           sudo cp fitsverify /usr/local/bin
       - name: Install Python dependencies
         run: |
-          pip install roman-datamodels git+https://github.com/spacetelescope/jwst
+          pip install roman-datamodels git+https://github.com/spacetelescope/jwst.git
           pip uninstall --yes crds
           ./install
           pip install .[submission,test,docs,synphot]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
     - pytest-migration #temp
 
 env:
+  CRDS_TEST_ROOT: /tmp
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
   LD_LIBRARY_PATH: /usr/local/lib
@@ -24,8 +25,6 @@ jobs:
     name: ${{ matrix.runs-on }} Python ${{ matrix.python-version }}
     needs: [ cache ]
     runs-on: ${{ matrix.runs-on }}
-    env:
-      CRDS_TEST_ROOT: /tmp
     strategy:
       fail-fast: false
       matrix:
@@ -66,4 +65,5 @@ jobs:
         with:
           path: ${{ needs.cache.outputs.path }}
           key: ${{ needs.cache.outputs.key }}
+      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} u
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,4 @@ jobs:
         with:
           path: ${{ needs.cache.outputs.path }}
           key: ${{ needs.cache.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }} ${{ steps.cache.outputs.cache-hit == 'true' && 'u' || 'c' }}
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,4 @@ jobs:
         with:
           path: ${{ needs.cache.outputs.path }}
           key: ${{ needs.cache.outputs.key }}
-      - run: ./setup_test_cache ${{ env.CRDS_TEST_ROOT }}
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CRDS_TEST_ROOT: /tmp
+  CRDS_SERVER_URL: https://hst-crds.stsci.edu
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
   LD_LIBRARY_PATH: /usr/local/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
       - id: cache
         uses: actions/cache@v3
         with:
-          path: ${{ needs.cache.outputs.path }}
+          path: |
+            ${{ needs.cache.outputs.path }}
+            ${{ needs.cache.outputs.testing_cache }}
           key: ${{ needs.cache.outputs.key }}
       - run: ./runtests --cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
           ./install
           pip install .[submission,test,docs,synphot]
       - uses: actions/cache@v3
-        if: always()
         with:
           path: ${{ needs.cache.outputs.path }}
           key: ${{ needs.cache.outputs.key }}

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -11,10 +11,6 @@ on:
         value: ${{ jobs.contexts.outputs.roman }}
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   contexts:
     name: retrieve latest CRDS contexts

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,0 +1,56 @@
+name: contexts
+
+on:
+  workflow_call:
+    outputs:
+      hst:
+        value: ${{ jobs.contexts.outputs.hst }}
+      jwst:
+        value: ${{ jobs.contexts.outputs.jwst }}
+      roman:
+        value: ${{ jobs.contexts.outputs.roman }}
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contexts:
+    name: retrieve latest CRDS contexts
+    runs-on: ubuntu-latest
+    outputs:
+      hst: ${{ steps.hst_crds_context.outputs.pmap }}
+      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
+      roman: ${{ steps.roman_crds_context.outputs.pmap }}
+    steps:
+      - id: hst_crds_context
+        env:
+          OBSERVATORY: hst
+          CRDS_SERVER_URL: https://hst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.hst_crds_context.outputs.pmap }}
+      - id: jwst_crds_context
+        env:
+          OBSERVATORY: jwst
+          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.jwst_crds_context.outputs.pmap }}
+      - id: roman_crds_context
+        env:
+          OBSERVATORY: roman
+          CRDS_SERVER_URL: https://roman-crds.stsci.edu
+        run: >
+          echo "pmap=$(
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+          )" >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.roman_crds_context.outputs.pmap }}

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -19,3 +19,7 @@ python -m crds.sync --contexts hst_cos.imap --fetch-references --log-time --stat
 export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
 python -m crds.sync --files jwst_niriss_flat_0000.fits jwst_miri_flat_0006.fits --stats --log-time
+
+export CRDS_SERVER_URL=https://roman-crds.stsci.edu
+python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
+python -m crds.sync --files roman_wfi_dark_0001.asdf roman_wfi_distortion_0001.asdf roman_wfi_flat_0004.asdf --stats --log-time

--- a/setup_test_cache
+++ b/setup_test_cache
@@ -19,7 +19,3 @@ python -m crds.sync --contexts hst_cos.imap --fetch-references --log-time --stat
 export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
 python -m crds.sync --files jwst_niriss_flat_0000.fits jwst_miri_flat_0006.fits --stats --log-time
-
-export CRDS_SERVER_URL=https://roman-crds.stsci.edu
-python -m crds.sync --all --stats --log-time --check-sha1sum --repair-files --organize=flat
-python -m crds.sync --files roman_wfi_dark_0001.asdf roman_wfi_distortion_0001.asdf roman_wfi_flat_0004.asdf --stats --log-time


### PR DESCRIPTION
added a workflow specifically to cache CRDS reference files for subsequent testing, and have it run on a schedule every week so that the cache is ready upon a context change. This should force the cache to complete without having to run the tests first. Also, the caches are separated by observatory, so a change in one context should not necessitate redownloading the entire cache.

Additionally, set up a reusable workflow to retrieve the latest contexts of each server, that can potentially be used by other repositories.

<img width="277" alt="image" src="https://github.com/spacetelescope/crds/assets/16024299/a26fdd99-3aaa-4268-bcdf-dad7ebee204c">

