### PR TITLE
fix issue where environment was not using requested python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           environment-name: crds-testing
           create-args: >-
-            python=3.11
+            python=${{ matrix.python-version }}
             asdf
             astropy
             filelock


### PR DESCRIPTION
the Conda environment was hardcoded to `python=3.11` instead of `python=${{ matrix.python-version }}`