### PR TITLE
Enable python 3.12 testing in the CI, enable dependabot for CI workflow version checking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "zacharyburnett"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python-version:
-          - 3.9
+          - '3.9'
           - '3.10'
-          - 3.11
+          - '3.11'
+          - '3.12'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: mamba-org/setup-micromamba@v1


### PR DESCRIPTION
This PR adds python 3.12 tests to the CI.

While updating the workflow I noticed an out-of-date workflow version. I updated the version and added a dependabot configuration file to this PR that should enable dependabot to automatically open PRs that will update the workflow versions when a new one is available.