### PR TITLE
add dependabot for tracking github actions workflow version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "zacharyburnett"


### PR DESCRIPTION
After this is merged, we should expect a PR from dependabot requesting to update at least the `actions/checkout` usage:
https://github.com/spacetelescope/crds/blob/d5d92a1c937d13f4a80360b9de71935e835e0d40/.github/workflows/ci.yml#L48
to version 4. Something like the following:
https://github.com/asdf-format/asdf/pull/1639