### PR TITLE
(CCD 1385) Added PIXAR headers to MIRI PHOTOM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.17.9 (unreleased)
+====================
+
+JWST
+----
+- Added PIXAR_SR and PIXAR_A2 to miri photom tpn. [#1013]
+
+
 11.17.8 (2023-11-07)
 ====================
 

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -1196,6 +1196,35 @@
             "tpn":"miri_fringefreq.tpn",
             "unique_rowkeys":null
         },
+        "gain":{
+            "derived_from":"cloning tool 0.05b (2013-04-12) used on 2013-10-04",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"GAIN",
+            "filetype":"GAIN",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_gain_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"miri_gain.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.INSTRUMENT.BAND",
+                    "META.SUBARRAY.NAME"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"39dfd6a132931f669d99443d334555677ff0c011",
+            "suffix":"gain",
+            "text_descr":"Gain",
+            "tpn":"miri_gain.tpn",
+            "unique_rowkeys":null
+        },
         "ipc":{
             "derived_from":"generated as stub rmap on 2014-03-24 15:03:30.015471",
             "extra_keys":null,

--- a/crds/jwst/tpns/miri_photom.tpn
+++ b/crds/jwst/tpns/miri_photom.tpn
@@ -1,2 +1,9 @@
 # Commented out until INS is ready for strict model type validation:
 # META.MODEL_TYPE  H  S  R  MirImgPhotomModel,MirLrsPhotomModel,MirMrsPhotomModel
+
+
+# PIXAR_SR = FLOAT / (sr) Nominal pixel area for this detector
+# PIXAR_A2 = FLOAT / (arcsec2) Nominal pixel area for this detector
+
+PIXAR_SR     H      R        R
+PIXAR_A2     H      R        R


### PR DESCRIPTION
Missing keywords in delivered miri photom reference files did not trigger an error with crds certify. This change should fix that. 