### PR TITLE
(Crds 754) Removed constraints for nirspec_pathloss.tpn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+11.17.13 (Unreleased)
+====================
+
+JWST
+----
+-Removed vonstraints in nirspec_pathloss.tpn. [#1017]
+
 11.17.12 (2023-11-29)
 ====================
 

--- a/crds/jwst/tpns/nirspec_pathloss.tpn
+++ b/crds/jwst/tpns/nirspec_pathloss.tpn
@@ -1,23 +1,4 @@
 # Commented out until INS is ready for strict model type validation:
 # META.MODEL_TYPE  H  S  R  PathlossModel
 
-# Technically part of PS HDU and required for all ver with different values
-# this latter aspect is not checked.
-APERTURE  H    C   R
-
-PS      A   X   R (ndim(PS_ARRAY,3))
-PS      A   X   R (has_type(PS_ARRAY,'FLOAT'))
-PS      A   X   R  &IsomorphicFitsVer
-
-PSVAR   A   X   R (ndim(PS_ARRAY,3))
-PSVAR   A   X   R (has_type(PS_ARRAY,'FLOAT'))
-PSVAR   A   X   R  &IsomorphicFitsVer
-
-UNI     A   X   R (ndim(UNI_ARRAY,1))
-UNI     A   X   R (has_type(UNI_ARRAY,'FLOAT'))
-UNI     A   X   R  &IsomorphicFitsVer
-
-UNIVAR  A   X   R (ndim(UNIVAR_ARRAY,1))
-UNIVAR  A   X   R (has_type(UNIVAR_ARRAY,'FLOAT'))
-UNIVAR  A   X   R  &IsomorphicFitsVer
 


### PR DESCRIPTION
Nirspec wanted some constraints removed from the pathloss.tpn.