### PR TITLE
remove jwst pub and add roman tvac to submission list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+11.17.14 (unreleased)
+=====================
+
+General
+-------
+
+- Remove jwst pub and add roman tvac to submission list. [#1018]
+
 11.17.13 (2023-12-01)
 ====================
 

--- a/crds/submit/rc_submit.py
+++ b/crds/submit/rc_submit.py
@@ -41,14 +41,14 @@ BASE_URLS = {
         'jwst': 'https://jwst-crds.stsci.edu/',
         'roman': 'https://roman-crds.stsci.edu/',
     },
-    'pub': {
-        'jwst': 'https://jwst-crds-pub.stsci.edu/',
-    },
     'test': {
         'hst':  'https://hst-crds-test.stsci.edu/',
         'jwst': 'https://jwst-crds-test.stsci.edu/',
         'roman': 'https://roman-crds-test.stsci.edu/',
     },
+    'tvac': {
+        'roman': 'https://roman-crds-tvac.stsci.edu/',
+    }
 }
 
 URL_DESCRIPTION = 'submission_form/redcat_description.yml'


### PR DESCRIPTION
Related to [CCD-1387](https://jira.stsci.edu/browse/CCD-1387)

The submission activity requires knowledge of the servers that are acceptable for submission. This PR replace JWST PUB with ROMAN TVAC.