### PR TITLE
CCD-1397: Add n/a to components of the cos badttab reftype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ General
 
 - Remove jwst pub and add roman tvac to submission list. [#1018]
 
+HST
+---
+
+- Add n/a to components of the cos badttab reftype [#1019]
+
 11.17.13 (2023-12-01)
 ====================
 

--- a/crds/hst/tpns/cos_badt.tpn
+++ b/crds/hst/tpns/cos_badt.tpn
@@ -9,10 +9,10 @@
 #----------------------------------------------------------
 INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "BAD TIME INTERVALS TABLE"
-DETECTOR            H        C         R    FUV
+DETECTOR            H        C         R    FUV,NUV,N/A
 OBSMODE             H        C         R    TIME-TAG
 VCALCOS             H        C         R    
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R    
-SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
+SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC,N/A


### PR DESCRIPTION
Resolves CCD-1397

Allows specification of "N/A" for COS BADTTAB reftype references and rmaps.