### PR TITLE
Created new rmap for miri_mask.

### DIFF
--- a/crds/jwst/specs/miri_mask.rmap
+++ b/crds/jwst/specs/miri_mask.rmap
@@ -1,0 +1,21 @@
+header = {
+    'classes' : ('Match', 'UseAfter'),
+    'derived_from' : 'jwst_miri_mask_new.rmap',
+    'file_ext' : '.fits',
+    'filekind' : 'MASK',
+    'filetype' : 'MASK',
+    'instrument' : 'MIRI',
+    'mapping' : 'REFERENCE',
+    'name' : 'miri_mask.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.INSTRUMENT.DETECTOR', 'META.SUBARRAY.NAME', 'META.EXPOSURE.READPATT', 'META.EXPOSURE.NGROUPS'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '62525b89da8312e457d0368534911eea944fad5a',
+    'substitutions' : {
+        'META.SUBARRAY.NAME' : {
+            'GENERIC' : 'N/A',
+        },
+    },
+}
+
+selector = Match({
+})


### PR DESCRIPTION
A new rmap was needed for references with bad pixel maps, miri_mask was created for it and derived from an rmap provided by redcat.