### PR TITLE
explicitly specify CRDS in `actions/checkout` to enable reuse of caching workflow in other repos

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -39,6 +39,8 @@ jobs:
       key: ${{ steps.key.outputs.key }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: spacetelescope/crds
       - id: key
         run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
       - id: cache

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ JWST
 ----
 - Added new rmap for miri_mask [#1020]
 
+General
+-------
+
+- for the test caching CI workflow (``.github/workflows/cache.yml``), explicitly checkout CRDS to enable reuse in other repositories' CI [#1022]
+
 11.17.14 (2023-12-14)
 =====================
 


### PR DESCRIPTION
If other repositories (such as `stenv`) wish to run CRDS tests, and want to cache this testing data, then they can reuse the `cache.yml` workflow by calling
```yaml
jobs:
  crds_test_cache:
    uses: spacetelescope/crds/.github/workflows/cache.yml@master
```

However, currently the `actions/checkout` action does not specify which repo to checkout, meaning that when `cache.yml` is called in another repo, it will checkout THAT repo instead of `spacetelescope/crds`. This can be fixed by adding
```yaml
jobs:
    - uses: actions/checkout@v3
      with:
        repository: spacetelescope/crds
```