### PR TITLE
raise error if context is empty

### DIFF
--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -26,7 +26,7 @@ jobs:
           CRDS_SERVER_URL: https://hst-crds.stsci.edu
         run: >
           echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.hst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.hst_crds_context.outputs.pmap }}; else exit 1; fi
@@ -36,7 +36,7 @@ jobs:
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         run: >
           echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
@@ -46,7 +46,7 @@ jobs:
           CRDS_SERVER_URL: https://roman-crds.stsci.edu
         run: >
           echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -29,7 +29,7 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: if [[ !-z "${{ steps.hst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.hst_crds_context.outputs.pmap }}; else exit 1; fi
+      - run: if [[ ! -z "${{ steps.hst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.hst_crds_context.outputs.pmap }}; else exit 1; fi
       - id: jwst_crds_context
         env:
           OBSERVATORY: jwst
@@ -39,7 +39,7 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: if [[ !-z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
+      - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
       - id: roman_crds_context
         env:
           OBSERVATORY: roman
@@ -49,4 +49,4 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: if [[ !-z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi
+      - run: if [[ ! -z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -29,7 +29,7 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: echo ${{ steps.hst_crds_context.outputs.pmap }}
+      - run: if [[ !-z "${{ steps.hst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.hst_crds_context.outputs.pmap }}; else exit 1; fi
       - id: jwst_crds_context
         env:
           OBSERVATORY: jwst
@@ -39,7 +39,7 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: echo ${{ steps.jwst_crds_context.outputs.pmap }}
+      - run: if [[ !-z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
       - id: roman_crds_context
         env:
           OBSERVATORY: roman
@@ -49,4 +49,4 @@ jobs:
           curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
-      - run: echo ${{ steps.roman_crds_context.outputs.pmap }}
+      - run: if [[ !-z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi


### PR DESCRIPTION
there is the possibility that, when `contexts.yml` requests a context, the CRDS server returns an incorrect response. 

For instance, this happened yesterday:
https://github.com/spacetelescope/crds/actions/runs/7643167120/job/20824529761#step:2:8
```shell
echo "pmap=$( curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["hst"], "id": 1}' https://hst-crds.stsci.edu/json/ | python -c "import sys, json; print(json.load(sys.stdin)['result'])" )" >> $GITHUB_OUTPUT
```
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.10/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
It failed silently and propagated an empty context string that then messed up the test caching (you can see here the HST files are missing from the cache, both from the file size and from the name):
<img width="783" alt="image" src="https://github.com/spacetelescope/crds/assets/16024299/bddfd579-174b-4ec5-8c90-aaa9d6139c65">
I reran `cache.yml` manually and it created the correct cache:
<img width="783" alt="image" src="https://github.com/spacetelescope/crds/assets/16024299/8aec75c3-512e-4f2e-8522-4bc0df7c656d">

This PR seeks to raise an error immediately if the context can't be retrieved, so the user knows something went wrong and can rerun the contexts job to fix it.