### PR TITLE
Added rmap and tpn for pixel replace step.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 JWST
 ----
 - Added new rmap for miri_mask [#1020]
+- Added new rmap for miri_pars-pixelreplacestep [#1025]
 
 General
 -------

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -2648,6 +2648,32 @@
             "tpn":"miri_pars-photomstep.tpn",
             "unique_rowkeys":null
         },
+        "pars-pixelreplacestep":{
+            "derived_from":"miri_pars-photomstep.rmap",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-pixelreplacestep",
+            "filetype":"pars-pixelreplacestep",
+            "instrument":"MIRI",
+            "ld_tpn":"miri_pars-pixelreplacestep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_miri_pars-pixelreplacestep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"8f28960f8d179bbbba015e596932ff16622151df",
+            "suffix":"pars-pixelreplacestep",
+            "text_descr":"Pixel Replacement Step runtime parameters",
+            "tpn":"miri_pars-pixelreplacestep.tpn",
+            "unique_rowkeys":null
+        },
         "pars-rampfitstep":{
             "classes":[
                 "Match",

--- a/crds/jwst/specs/miri_pars-pixelreplacestep.rmap
+++ b/crds/jwst/specs/miri_pars-pixelreplacestep.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'miri_pars-photomstep.rmap',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-pixelreplacestep',
+    'filetype' : 'pars-pixelreplacestep',
+    'instrument' : 'MIRI',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_miri_pars-pixelreplacestep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '8f28960f8d179bbbba015e596932ff16622151df',
+    'suffix' : 'pars-pixelreplacestep',
+    'text_descr' : 'Pixel Replacement Step runtime parameters',
+}
+
+selector = Match({
+})

--- a/crds/jwst/tpns/miri_pixelreplacestep.tpn
+++ b/crds/jwst/tpns/miri_pixelreplacestep.tpn
@@ -1,0 +1,2 @@
+# Commented out until INS is ready for strict model type validation:
+# META.MODEL_TYPE  H  S  R  PixelReplaceStepModel


### PR DESCRIPTION
Deliveries have been made for pixel replace step yet we do not have existing specs or base rmaps for that reference type. This merge attempts to solve that.