### PR TITLE
MODEL was added to PEDIGREE verification for JWST.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 JWST
 ----
--Added MODEL to be a PEDIGREE option for JWST. [#1031]
+-Added MODEL to be a PEDIGREE option for JWST. [#1032]
 
 11.17.18 (2024-02-21)
 =====================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,16 @@
+11.17.19 (2024-02-22)
+=====================
+
+JWST
+----
+-Added MODEL to be a PEDIGREE option for JWST. [#1031]
+
 11.17.18 (2024-02-21)
 =====================
 
 JWST
 ----
--Added ner rmap for MIRI pars-emicorrstep. [#1030]
+-Added new rmap for MIRI pars-emicorrstep. [#1030]
 
 11.17.17 (2024-02-20)
 =====================

--- a/crds/certify/validators/core.py
+++ b/crds/certify/validators/core.py
@@ -517,9 +517,9 @@ class PedigreeValidator(PedigreeBaseValidator):
 class JwstpedigreeValidator(PedigreeBaseValidator):
     """Validates &JWSTPEDIGREE fields."""
 
-    _values = ["INFLIGHT", "GROUND", "DUMMY", "SIMULATION"]
-    _values_wo_date = ["GROUND", "DUMMY", "SIMULATION"]
-    _values_w_date = ["INFLIGHT"]
+    _values = ["INFLIGHT", "GROUND", "MODEL", "DUMMY", "SIMULATION"]
+    _values_wo_date = ["GROUND", "MODEL", "DUMMY", "SIMULATION"]
+    _values_w_date = ["INFLIGHT", "MODEL"]
     _dated_format = "INFLIGHT YYYY-MM-DD YYYY-MM-DD"
 
     def validate_date(self, date):


### PR DESCRIPTION
An rmap for NIRISS NRM needs to have MODEL available for META.PEDIGREE. This change should ideally allow that.