### PR TITLE
fix/resolve-float128-testerrs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ ROMAN
 
 - Added support for pars- reference files [#1036]
 
+General
+-------
+
+- Use try/except for np.float128 import [#1037]
+
 
 11.17.20 (2024-04-18)
 =====================

--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -564,7 +564,12 @@ def table_mode_dictionary(generic_name, tab, mode_keys):
 
 def handle_nan(var):
     """Map nan values to 'nan' so that 'nan' == 'nan'."""
-    if isinstance(var, (np.float32, np.float64, np.float128)) and np.isnan(var):
+    try:
+        from numpy import float128
+        floats = (np.float32, np.float64, np.float128)
+    except ImportError:
+        floats = (np.float32, np.float64)
+    if isinstance(var, floats) and np.isnan(var):
         return 'nan'
     elif isinstance(var, np.ndarray) and var.shape == () and np.any(np.isnan(var)):
         return 'nan'


### PR DESCRIPTION
- use try-except to import numpy float128 which is not available/compatible with certain systems. Resolves errors in hst synphot tests on Mac OS.