### PR TITLE
CCD-1464: Fix error when submitting acs imphttab ref files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ HST
 ---
 
 - Added RMAP and TPN files for new COS HVDSTAB reference file [#1042]
+- Fix for acs imphttab ref file submission failures [#1044]
 
 JWST
 ----

--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -201,6 +201,7 @@ class ReferenceCertifier(Certifier):
                 "Checking reference modes for", repr(self.filename)):
             if self.mode_columns:
                 self.certify_reference_modes()
+
         with self.error_on_exception(
                 "Dumping provenance for", repr(self.filename)):
             if self._dump_provenance_flag:
@@ -471,7 +472,11 @@ class ReferenceCertifier(Certifier):
                 different += 1
             old_value = handle_nan(old_value)
             new_value = handle_nan(new_value)
-            if np.any(old_value != new_value):
+            try:
+                if np.any(old_value != new_value):
+                    different += 1
+            except ValueError:
+                log.warning(f"Cannot compare arrays in column {old_key} for mode {mode}")
                 different += 1
         return different
 


### PR DESCRIPTION
ACS imphttab ref file submission was failing with the error:

2024-04-24 13:46:38,326 - CRDS - ERROR - In '20240423_acs_sbc_imp.fits' : Checking tables modes in segment 0 of #file_location : operands could not be broadcast together with shapes (52,) (54,)  

Error arises in the crds certify code when trying to compare table elements against the current reference file: the omparison errors when the array sizes are different, which can happen for these reference file types where the table cells contain variable length arrays