### PR TITLE
Added pars-darkcurrentstep rmaps for NIRISS, NIRCAM and NIRSPEC.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+11.17.24 (20204-06-10)
+=====================
+
+JWST
+----
+- Added pars-darkcurrentstep rmaps for NIRISS, NIRCAM and NIRSPEC [#1044]
+
 11.17.23 (2024-06-03)
 =====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 
 JWST
 ----
-- Added pars-darkcurrentstep rmaps for NIRISS, NIRCAM and NIRSPEC [#1044]
+- Added pars-darkcurrentstep rmaps for NIRISS, NIRCAM and NIRSPEC [#1045]
 
 11.17.23 (2024-06-03)
 =====================

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -4285,6 +4285,32 @@
             "tpn":"nircam_mask.tpn",
             "unique_rowkeys":null
         },
+        "pars-darkcurrentstep":{
+            "derived_from":"Created by Hunter Brown 2024-06-10",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-darkcurrentstep",
+            "filetype":"pars-darkcurrentstep",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_pars-darkcurrentstep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_pars-darkcurrentstep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"d9fe7ab309b949ea4db0662e8e4df8b0bf5a9ef8",
+            "suffix":"pars-darkcurrentstep",
+            "text_descr":"DarkCurrentStep runtime parameters for nircam",
+            "tpn":"nircam_pars-darkcurrentstep.tpn",
+            "unique_rowkeys":null
+        },
         "pars-darkpipeline":{
             "classes":[
                 "Match",
@@ -5366,6 +5392,32 @@
             "suffix":"pars-chargemigrationstep",
             "text_descr":"Parameters to correct charge migration and the jump detection step interaction.",
             "tpn":"niriss_pars-chargemigrationstep.tpn",
+            "unique_rowkeys":null
+        },
+        "pars-darkcurrentstep":{
+            "derived_from":"Created by Hunter Brown 2024-06-10",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-darkcurrentstep",
+            "filetype":"pars-darkcurrentstep",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_pars-darkcurrentstep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_pars-darkcurrentstep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"4f3c8d6c8bc1dca3ce2a73c8913f9df85ec23a42",
+            "suffix":"pars-darkcurrentstep",
+            "text_descr":"DarkCurrentStep runtime parameters for niriss",
+            "tpn":"niriss_pars-darkcurrentstep.tpn",
             "unique_rowkeys":null
         },
         "pars-darkpipeline":{
@@ -6937,6 +6989,32 @@
             "suffix":"ote",
             "text_descr":"Transform through the Optical Telescope Element",
             "tpn":"nirspec_ote.tpn",
+            "unique_rowkeys":null
+        },
+        "pars-darkcurrentstep":{
+            "derived_from":"Created by Hunter Brown 2024-06-10",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-darkcurrentstep",
+            "filetype":"pars-darkcurrentstep",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_pars-darkcurrentstep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_pars-darkcurrentstep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"041b2b67e68467067eef9728adbc8266648fdd2c",
+            "suffix":"pars-darkcurrentstep",
+            "text_descr":"DarkCurrentStep runtime parameters for nirspec",
+            "tpn":"nirspec_pars-darkcurrentstep.tpn",
             "unique_rowkeys":null
         },
         "pars-darkpipeline":{

--- a/crds/jwst/specs/nircam_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/nircam_pars-darkcurrentstep.rmap
@@ -8,7 +8,7 @@ header = {
     'name' : 'jwst_nircam_pars-darkcurrentstep.rmap',
     'observatory' : 'JWST',
     'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'sha1sum' : 'd9fe7ab309b949ea4db0662e8e4df8b0bf5a9ef8',
     'suffix' : 'pars-darkcurrentstep',
     'text_descr' : 'DarkCurrentStep runtime parameters for nircam',
 }

--- a/crds/jwst/specs/nircam_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/nircam_pars-darkcurrentstep.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'Created by Hunter Brown 2024-06-10',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-darkcurrentstep',
+    'filetype' : 'pars-darkcurrentstep',
+    'instrument' : 'NIRCAM',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_nircam_pars-darkcurrentstep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'suffix' : 'pars-darkcurrentstep',
+    'text_descr' : 'DarkCurrentStep runtime parameters for nircam',
+}
+
+selector = Match({
+})

--- a/crds/jwst/specs/niriss_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/niriss_pars-darkcurrentstep.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'Created by Hunter Brown 2024-06-10',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-darkcurrentstep',
+    'filetype' : 'pars-darkcurrentstep',
+    'instrument' : 'NIRISS',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_niriss_pars-darkcurrentstep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'suffix' : 'pars-darkcurrentstep',
+    'text_descr' : 'DarkCurrentStep runtime parameters for niriss',
+}
+
+selector = Match({
+})

--- a/crds/jwst/specs/niriss_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/niriss_pars-darkcurrentstep.rmap
@@ -8,7 +8,7 @@ header = {
     'name' : 'jwst_niriss_pars-darkcurrentstep.rmap',
     'observatory' : 'JWST',
     'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'sha1sum' : '4f3c8d6c8bc1dca3ce2a73c8913f9df85ec23a42',
     'suffix' : 'pars-darkcurrentstep',
     'text_descr' : 'DarkCurrentStep runtime parameters for niriss',
 }

--- a/crds/jwst/specs/nirspec_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/nirspec_pars-darkcurrentstep.rmap
@@ -8,7 +8,7 @@ header = {
     'name' : 'jwst_nirspec_pars-darkcurrentstep.rmap',
     'observatory' : 'JWST',
     'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'sha1sum' : '041b2b67e68467067eef9728adbc8266648fdd2c',
     'suffix' : 'pars-darkcurrentstep',
     'text_descr' : 'DarkCurrentStep runtime parameters for nirspec',
 }

--- a/crds/jwst/specs/nirspec_pars-darkcurrentstep.rmap
+++ b/crds/jwst/specs/nirspec_pars-darkcurrentstep.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'Created by Hunter Brown 2024-06-10',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-darkcurrentstep',
+    'filetype' : 'pars-darkcurrentstep',
+    'instrument' : 'NIRSPEC',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_nirspec_pars-darkcurrentstep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE',), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '1e250dfe1717c5acf08a42f326bb17ee62eeb54f',
+    'suffix' : 'pars-darkcurrentstep',
+    'text_descr' : 'DarkCurrentStep runtime parameters for nirspec',
+}
+
+selector = Match({
+})

--- a/test/core/test_reftypes.py
+++ b/test/core/test_reftypes.py
@@ -212,7 +212,7 @@ def test_reftypes_hst_get_filekinds(default_shared_state):
 def test_reftypes_jwst_get_filekinds(default_shared_state):
     types = reftypes.get_types_object("jwst")
     niriss_types = types.get_filekinds("niriss")
-    expected_types = ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'nrm', 'pars-chargemigrationstep', 'pars-darkpipeline', 'pars-detector1pipeline', 'pars-image2pipeline', 'pars-jumpstep', 'pars-outlierdetectionstep', 'pars-rampfitstep', 'pars-resamplestep', 'pars-sourcecatalogstep', 'pars-spec2pipeline', 'pars-tweakregstep', 'pars-undersamplecorrectionstep', 'pars-whitelightstep', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'speckernel', 'specprofile', 'spectrace', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wavemap', 'wcsregions', 'wfssbkg']
+    expected_types = ['abvegaoffset', 'all', 'amplifier', 'apcorr', 'area', 'dark', 'distortion', 'drizpars', 'extract1d', 'filteroffset', 'flat', 'gain', 'ipc', 'linearity', 'mask', 'nrm', 'pars-chargemigrationstep', 'pars-darkcurrentstep', 'pars-darkpipeline', 'pars-detector1pipeline', 'pars-image2pipeline', 'pars-jumpstep', 'pars-outlierdetectionstep', 'pars-rampfitstep', 'pars-resamplestep', 'pars-sourcecatalogstep', 'pars-spec2pipeline', 'pars-tweakregstep', 'pars-undersamplecorrectionstep', 'pars-whitelightstep', 'pathloss', 'persat', 'photom', 'readnoise', 'regions', 'saturation', 'speckernel', 'specprofile', 'spectrace', 'specwcs', 'superbias', 'throughput', 'trapdensity', 'trappars', 'wavelengthrange', 'wavemap', 'wcsregions', 'wfssbkg']
     assert sorted(niriss_types) == sorted(expected_types)
 
 


### PR DESCRIPTION
This PR handles CCD-1467 which added 3 rmaps for the pars-darkcurrentstep reference type.