### PR TITLE
remove breakpoint when test fails

### DIFF
--- a/test/certify/test_certify.py
+++ b/test/certify/test_certify.py
@@ -1587,8 +1587,6 @@ File written with dev version of asdf library: 2.0.0.dev1213
 4 warnings
 5 infos"""
     for msg in expected_out.splitlines():
-        if msg.strip() not in out:
-            breakpoint()
         assert msg.strip() in out
 
 


### PR DESCRIPTION
@stscieisenhamer found a stray breakpoint in one of the certify test that triggers when the test fails. This PR removes the breakpoint.