### PR TITLE
[CI] allow user to specify cache path in reusable workflow

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -15,9 +15,6 @@ on:
     - cron: "0 0 * * 1"
 
 env:
-  CRDS_TEST_ROOT: /tmp
-  CRDS_PATH: /tmp/crds-cache-default-test
-  CRDS_TESTING_CACHE: /tmp/crds-cache-test
   CRDS_CLIENT_RETRY_COUNT: 3
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
   LD_LIBRARY_PATH: /usr/local/lib
@@ -33,11 +30,11 @@ jobs:
     needs: [ contexts ]
     name: download and cache CRDS test files
     runs-on: ubuntu-latest
-    outputs:
-      path: ${{ env.CRDS_PATH }}
-      testing_cache: ${{ env.CRDS_TESTING_CACHE }}
-      key: ${{ steps.key.outputs.key }}
     steps:
+      - run: echo CRDS_TEST_ROOT=${{ runner.temp }}/crds >> $GITHUB_ENV
+      - run: |
+          echo CRDS_PATH=${{ env.CRDS_TEST_ROOT }}/crds-cache-default-test >> $GITHUB_ENV
+          echo CRDS_TESTING_CACHE=${{ env.CRDS_TEST_ROOT }}/crds-cache-test >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           repository: spacetelescope/crds
@@ -97,4 +94,7 @@ jobs:
             ${{ env.CRDS_PATH }}
             ${{ env.CRDS_TESTING_CACHE }}
           key: ${{ steps.key.outputs.key }}
-        
+    outputs:
+      path: ${{ env.CRDS_PATH }}
+      testing_cache: ${{ env.CRDS_TESTING_CACHE }}
+      key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,7 +3,7 @@ name: download CRDS test cache
 on:
   workflow_call:
     inputs:
-      path:
+      cache_path:
         description: path to download files to and cache
         type: string
         required: false
@@ -39,7 +39,7 @@ jobs:
     name: download and cache CRDS test files
     runs-on: ubuntu-latest
     steps:
-      - run: echo CRDS_TEST_ROOT=${{ inputs.path != '' && inputs.path || '/tmp/crds' }} >> $GITHUB_ENV
+      - run: echo CRDS_TEST_ROOT=${{ inputs.cache_path != '' && inputs.cache_path || '/tmp/crds' }} >> $GITHUB_ENV
       - run: |
           echo CRDS_PATH=${{ env.CRDS_TEST_ROOT }}/crds-cache-default-test >> $GITHUB_ENV
           echo CRDS_TESTING_CACHE=${{ env.CRDS_TEST_ROOT }}/crds-cache-test >> $GITHUB_ENV

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -39,7 +39,7 @@ jobs:
     name: download and cache CRDS test files
     runs-on: ubuntu-latest
     steps:
-      - run: echo CRDS_TEST_ROOT=${{ inputs.path != '' && inputs.path || runner.temp }} >> $GITHUB_ENV
+      - run: echo CRDS_TEST_ROOT=${{ inputs.path != '' && inputs.path || '/tmp/crds' }} >> $GITHUB_ENV
       - run: |
           echo CRDS_PATH=${{ env.CRDS_TEST_ROOT }}/crds-cache-default-test >> $GITHUB_ENV
           echo CRDS_TESTING_CACHE=${{ env.CRDS_TEST_ROOT }}/crds-cache-test >> $GITHUB_ENV

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       cache_path:
-        description: path to download files to and cache
+        description: path to test cache on runner
         type: string
         required: false
-        default: ''
+        default: '/tmp/crds'
     outputs:
       cache_path:
         value: ${{ jobs.cache.outputs.cache_path }}
@@ -18,6 +18,12 @@ on:
       testing_cache:
         value: ${{ jobs.cache.outputs.testing_cache }}
   workflow_dispatch:
+    inputs:
+      cache_path:
+        description: path to test cache on runner
+        type: string
+        required: false
+        default: '/tmp/crds'
   schedule:
     # Weekly Monday midnight
     - cron: "0 0 * * 1"

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -2,13 +2,21 @@ name: download CRDS test cache
 
 on:
   workflow_call:
-    outputs:
+    inputs:
       path:
-        value: ${{ jobs.cache.outputs.path }}
+        description: path to download files to and cache
+        type: string
+        required: false
+        default: ''
+    outputs:
+      cache_path:
+        value: ${{ jobs.cache.outputs.cache_path }}
+      key:
+        value: ${{ jobs.cache.outputs.cache_key }}
+      path:
+        value: ${{ jobs.cache.outputs.crds_path }}
       testing_cache:
         value: ${{ jobs.cache.outputs.testing_cache }}
-      key:
-        value: ${{ jobs.cache.outputs.key }}
   workflow_dispatch:
   schedule:
     # Weekly Monday midnight
@@ -31,7 +39,7 @@ jobs:
     name: download and cache CRDS test files
     runs-on: ubuntu-latest
     steps:
-      - run: echo CRDS_TEST_ROOT=${{ runner.temp }}/crds >> $GITHUB_ENV
+      - run: echo CRDS_TEST_ROOT=${{ inputs.path != '' && inputs.path || runner.temp }} >> $GITHUB_ENV
       - run: |
           echo CRDS_PATH=${{ env.CRDS_TEST_ROOT }}/crds-cache-default-test >> $GITHUB_ENV
           echo CRDS_TESTING_CACHE=${{ env.CRDS_TEST_ROOT }}/crds-cache-test >> $GITHUB_ENV
@@ -95,6 +103,7 @@ jobs:
             ${{ env.CRDS_TESTING_CACHE }}
           key: ${{ steps.key.outputs.key }}
     outputs:
-      path: ${{ env.CRDS_PATH }}
-      testing_cache: ${{ env.CRDS_TESTING_CACHE }}
-      key: ${{ steps.key.outputs.key }}
+      cache_path: ${{ env.CRDS_TEST_ROOT }}
+      cache_key: ${{ steps.key.outputs.key }}
+      crds_path: ${{ env.CRDS_PATH }}
+      crds_testing_cache: ${{ env.CRDS_TESTING_CACHE }}


### PR DESCRIPTION
allow user to specify cache path in `workflow_call` inputs for better flexibility in downstream usages (`stenv`, `RegressionTests`, etc.)