### PR TITLE
roman/fix-parameter-refs-certify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,15 +3,25 @@
 
 ROMAN
 -----
+- Resolves CCD-1482, github issue 1053. Running certify on a Roman reference file now checks the correct set of header keywords depending on whether the file is a parameter reference type (prefix "META") or regular reference type (prefix "ROMAN.META"). [#1054]
+
+
+11.17.26 (2024-07-09)
+=====================
+
+ROMAN
+-----
 
 - Removed all redundant tpn files for roman datamodel-represented references. Certify parameter reference files [#1050]
 
-11.17.24 (20204-06-10)
+11.17.25 (2024-06-12)
 =====================
 
 JWST
 ----
-- Added pars-darkcurrentstep rmaps for NIRISS, NIRCAM and NIRSPEC [#1045]
+
+- Fixed some issues with rmap file parkey selections for NIRISS, NIRCAM and NIRSPEC. [#1046]
+
 
 11.17.23 (2024-06-03)
 =====================

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -479,8 +479,8 @@ def reference_keys_to_dataset_keys(rmapping, header):
     crds.core.exceptions.InvalidUseAfterFormat: Bad USEAFTER time format = 'bad user after'
     """
     header = dict(header)
-    # parameter reference files and data models have dropped the "ROMAN" prefix
-    paramfile = True if len(str(os.path.basename(rmapping)).split("-")) > 1 else False
+    # if parameter reference file (contains "-"), there is no "ROMAN" prefix
+    paramfile = True if len(rmapping.name.split("-")) > 1 else False
     prefix = "META" if paramfile is True else "ROMAN.META"
     # Basic common pattern translations
     translations = {

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -479,14 +479,15 @@ def reference_keys_to_dataset_keys(rmapping, header):
     crds.core.exceptions.InvalidUseAfterFormat: Bad USEAFTER time format = 'bad user after'
     """
     header = dict(header)
-
+    # parameter reference files and data models have dropped the "ROMAN" prefix
+    paramfile = True if len(str(os.path.basename(rmapping)).split("-")) > 1 else False
+    prefix = "META" if paramfile is True else "ROMAN.META"
     # Basic common pattern translations
     translations = {
-        "ROMAN.META.EXPOSURE.P_EXPTYPE" : "ROMAN.META.EXPOSURE.TYPE",
-        "ROMAN.META.INSTRUMENT.P_DETECTOR"  : "ROMAN.META.INSTRUMENT.DETECTOR",
-        "ROMAN.META.INSTRUMENT.P_OPTICAL_ELEMENT": "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT",
+        f"{prefix}.EXPOSURE.P_EXPTYPE": f"{prefix}.EXPOSURE.TYPE",
+        f"{prefix}.INSTRUMENT.P_DETECTOR"  : f"{prefix}.INSTRUMENT.DETECTOR",
+        f"{prefix}.INSTRUMENT.P_OPTICAL_ELEMENT": f"{prefix}.INSTRUMENT.OPTICAL_ELEMENT",
     }
-
     # Rmap header reference_to_dataset field tranlations,  can override basic!
     try:
         translations.update(rmapping.reference_to_dataset)
@@ -522,22 +523,21 @@ def reference_keys_to_dataset_keys(rmapping, header):
                          "to value of", repr(rkey), "=", repr(rval))
                 header[dkey] = rval
 
-    if "ROMAN.META.SUBARRAY.NAME" not in header:
-        header["ROMAN.META.SUBARRAY.NAME"] = "UNDEFINED"
-
-    if "ROMAN.META.EXPOSURE.TYPE" not in header:
-        header["ROMAN.META.EXPOSURE.TYPE"] = "UNDEFINED"
+    if f"{prefix}.SUBARRAY.NAME" not in header:
+        header[f"{prefix}.SUBARRAY.NAME"] = "UNDEFINED"
+    if f"{prefix}.EXPOSURE.TYPE" not in header:
+        header[f"{prefix}.EXPOSURE.TYPE"] = "UNDEFINED"
 
     # If USEAFTER is defined,  or we're configured to fake it...
     #   don't invent one if its missing and we're not faking it.
-    if "ROMAN.META.USEAFTER" in header or config.ALLOW_BAD_USEAFTER:
+    if f"{prefix}.USEAFTER" in header or config.ALLOW_BAD_USEAFTER:
 
         # Identify this as best as possible,
-        filename = header.get("ROMAN.META.FILENAME", None) or rmapping.filename
+        filename = header.get(f"{prefix}.FILENAME", None) or rmapping.filename
 
         reformatted = timestamp.reformat_useafter(filename, header).split()
         dt_string = f"{reformatted[0]} {reformatted[1]}"
-        header["ROMAN.META.EXPOSURE.START_TIME"] = dt_string
+        header[f"{prefix}.EXPOSURE.START_TIME"] = dt_string
 
     log.verbose("reference_to_dataset output header:\n", log.PP(header), verbosity=80)
 

--- a/test/core/test_rmap.py
+++ b/test/core/test_rmap.py
@@ -449,9 +449,7 @@ def test_validate_mapping_ambiguous_roman(roman_serverless_state, roman_data, ca
     with caplog.at_level(logging.INFO, logger="CRDS"):
         r.validate_mapping()
         out = caplog.text
-    expected = """Match('ROMAN.META.INSTRUMENT.DETECTOR', 'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT') : ('WFI01', 'F158') :
-----------------------------------------
-Match case
+    expected = """Match case
 ('WFI01', 'F158') : UseAfter({
     '2020-01-01 00:00:00' : roman_wfi_flat_0002.asdf
 is an equal weight special case of


### PR DESCRIPTION
Resolves CCD-1482, [github issue 1053](https://github.com/spacetelescope/crds/issues/1053). Running certify on a Roman reference file now checks the correct set of header keywords depending on whether the file is a parameter reference type (prefix "META") or regular reference type (prefix "ROMAN.META").