### PR TITLE
Fix re string type

### DIFF
--- a/changes/1077.general.rst
+++ b/changes/1077.general.rst
@@ -1,0 +1,1 @@
+replaces deprecated string literals with raw strings in regex pattern matching

--- a/crds/certify/certify.py
+++ b/crds/certify/certify.py
@@ -687,7 +687,7 @@ class UnknownCertifier(Certifier):
 class AsdfCertifier(ReferenceCertifier):
     """Certifier for ADSF type,  invoke data models checks."""
 
-    _VERSION_RE = re.compile(f"^[0-9]+\.[0-9]+\.[0-9]+$")
+    _VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
     def certify(self):
         """Certify an unknown format file."""

--- a/crds/certify/validators/synphot.py
+++ b/crds/certify/validators/synphot.py
@@ -179,7 +179,7 @@ def _check_component_filename(context, reftype, suffix, filename, header):
         log.error("Header missing COMPNAME, unable to certify filename")
         return False
 
-    pattern = re.compile(".*_([0-9]{3})_" + suffix + ".fits")
+    pattern = re.compile(r".*_([0-9]{3})_" + suffix + r".fits")
 
     match = pattern.match(os.path.basename(filename))
     if not match:

--- a/crds/core/timestamp.py
+++ b/crds/core/timestamp.py
@@ -291,7 +291,7 @@ def parse_numerical_date(dstr):
 class DateParser:
     """Abstract baseclass for defining date parsers."""
 
-    format = re.compile("^$")
+    format = re.compile(r"^$")
     should_be = "DATE FORMAT NOT DEFINED"
 
     @classmethod

--- a/crds/hst/siname.py
+++ b/crds/hst/siname.py
@@ -36,7 +36,7 @@ class UnknownCDBSPrefix(Exception):
   pass
 
 # global compiled regex for splitting filenames
-filesplit = re.compile("[_\.]")
+filesplit = re.compile(r"[_\.]")
 
 # post-SM2 instruments supported by CDBS
 CDBS_supports = ("ACS","STIS","NICMOS","WFPC2","WFC3","COS")

--- a/crds/submit/submit.py
+++ b/crds/submit/submit.py
@@ -360,7 +360,7 @@ this command line interface must be members of the CRDS operators group
         return rnew
     
     def get_renamed_rmaps(self, soup, fmap):
-        diffs = soup.find_all(string=re.compile("Logical Diff"))
+        diffs = soup.find_all(string=re.compile(r"Logical Diff"))
         if len(diffs) > 0:
             for diff in diffs:
                 d = diff.split('(')[-1].split(')')[0]


### PR DESCRIPTION
* Replaces string literal with a raw string
* https://docs.python.org/3/library/re.html#module-re states: [..] any invalid escape sequences in Python’s usage of the backslash in string literals now generate a SyntaxWarning and in the future this will become a SyntaxError. The solution is to use Python's raw string notation for regular expression patterns.

<!-- describe the changes comprising this PR here -->
This PR addresses ...

Under Python 3.10:

```
DeprecationWarning: invalid escape sequence '\.'
    _VERSION_RE = re.compile(f"^[0-9]+\.[0-9]+\.[0-9]+$")
```

Under 3.11:

```
    _VERSION_RE = re.compile(f"^[0-9]+\.[0-9]+\.[0-9]+$")
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid escape sequence '\.'
```

Under 3.12:

```
SyntaxWarning: invalid escape sequence '\.'
    _VERSION_RE = re.compile(f"^[0-9]+\.[0-9]+\.[0-9]+$")
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

