### PR TITLE
hotfix/drc-backwards-compatibility-fix

### DIFF
--- a/changes/1078.general.rst
+++ b/changes/1078.general.rst
@@ -1,0 +1,1 @@
+client.api.get_default_context falls back to observatory as only argument to maintain compatibility with crds_server < 13.0.0

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -372,7 +372,7 @@ def get_build_context(observatory=None):
         try:
             return str(S.get_build_context(observatory, calver))
         except ServiceError:
-            log.debug("Server build context could not be identified. Using 'latest' instead.")
+            log.info("Server build context could not be identified. Using 'latest' instead.")
     return get_default_context(observatory=observatory, state="latest")
 
 

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -355,8 +355,22 @@ def get_aui_best_references(date, dataset_ids):
 
 @utils.cached
 def get_default_context(observatory=None, state=None):
-    """Return the name of the latest pipeline mapping in use for processing
-    files for `observatory`.
+    """Return the name of the pipeline mapping ('.pmap') in use for processing
+    files for `observatory`. If `state` is None, for JWST this defaults to the build context
+    associated with the locally installed calibration software (cal_ver). For other missions
+    this defaults to `latest` (formerly `operational`).
+
+    Parameters
+    ----------
+    observatory : str, optional
+        observatory being used by current configuration, by default None
+    state : str, optional
+        context state ("latest", "build", "edit"), by default None
+
+    Returns
+    -------
+    str
+        name of the pipeline mapping ('.pmap') used to process files for `observatory`
     """
     observatory = get_default_observatory() if observatory is None else observatory
     if state == "build" or (observatory == "jwst" and state not in ["edit", "latest"]):
@@ -373,6 +387,17 @@ def get_build_context(observatory=None):
     calibration pipeline sw is included as a template. If exact match is not found, an attempt to
     find next closest (previous) patch version is made. Ultimate fallback is to the latest
     (formerly 'operational') context.
+
+    Parameters
+    ----------
+    observatory : str, optional
+        observatory being used by current configuration, by default None
+
+    Returns
+    -------
+    str
+        name of the pipeline mapping ('.pmap') used to process files for `observatory` according to 
+        locally installed calibration software version.
     """
     observatory = get_default_observatory() if observatory is None else observatory
     calver = get_cal_version(observatory)

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -240,6 +240,13 @@ def _get_file_info_map(observatory, files, fields):
     return infos
 
 
+def get_cal_dist_path(cal):
+    try:
+        return f' ({str(importlib.metadata.distribution(cal)._path)})'
+    except Exception:
+        return ''
+
+
 def get_cal_version(observatory):
     """Return the version of observatory calibration software."""
     cal_version = ''
@@ -248,7 +255,8 @@ def get_cal_version(observatory):
         try:
             cal_version = importlib.metadata.version(cal)
             cal_version = config.simplify_version(cal_version)
-            log.info(f"Calibration SW Found: {cal} {cal_version}")
+            dist_path = get_cal_dist_path(cal)
+            log.info(f"Calibration SW Found: {cal} {cal_version}{dist_path}")
         except importlib.metadata.PackageNotFoundError:
             log.warning("Calibration SW not found, defaulting to latest.")
     return cal_version

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -353,7 +353,10 @@ def get_default_context(observatory=None, state=None):
     observatory = get_default_observatory() if observatory is None else observatory
     if state == "build" or (observatory == "jwst" and state not in ["edit", "latest"]):
         return get_build_context(observatory=observatory)
-    return str(S.get_default_context(observatory, state))
+    try:
+        return str(S.get_default_context(observatory, state))
+    except ServiceError: # backwards-compatibility for crds_server < 13.0.0
+        return str(S.get_default_context(observatory))
 
 
 def get_build_context(observatory=None):
@@ -369,8 +372,8 @@ def get_build_context(observatory=None):
         try:
             return str(S.get_build_context(observatory, calver))
         except ServiceError:
-            log.warning("Server build context could not be identified. Using 'latest' instead.")
-    return get_default_context(observatory, "latest")
+            log.debug("Server build context could not be identified. Using 'latest' instead.")
+    return get_default_context(observatory=observatory, state="latest")
 
 
 @utils.cached


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1514](https://jira.stsci.edu/browse/CCD-1514)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Adds compatibility with CRDS server < 13.0.0 so that users running calibration pipeline code are able to get the default CRDS context from the Ops servers whether or not those servers have been updated to use the new data release style contexts.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

