### PR TITLE
sync/allow-latest

### DIFF
--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -36,7 +36,7 @@ jobs:
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         run: >
           echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", null], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -36,7 +36,7 @@ jobs:
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
         run: >
           echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
           python -c "import sys, json; print(json.load(sys.stdin)['result'])"
           )" >> $GITHUB_OUTPUT
       - run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,15 @@
-12.0.1 (unreleased)
+12.0.2 (2024-10-07)
+===================
+
+Documentation
+-------------
+
+- Fixed changelog version [#1083]
+
+- Updated image names [#1084]
+
+
+12.0.1 (2024-10-07)
 ===================
 
 Documentation

--- a/changes/1088.general.rst
+++ b/changes/1088.general.rst
@@ -1,0 +1,1 @@
+latest is a valid file state, context spec includes build and latest

--- a/crds/core/cmdline.py
+++ b/crds/core/cmdline.py
@@ -343,8 +343,7 @@ class Script:
     @property
     def default_context(self):
         """Return the default latest .pmap defined by the CRDS server or cache."""
-        default = self.server_info.get("latest_context", "operational_context")
-        return self.server_info[default]
+        return self.server_info.get("latest_context", self.server_info["operational_context"])
 
     def get_words(self, word_list):
         """Process a file list,  expanding @-files into corresponding lists of

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -661,7 +661,7 @@ def get_crds_env_context():
     context = os.environ.get("CRDS_CONTEXT", None)
     if context:
         assert is_context_spec(context), \
-            "Only set CRDS_CONTEXT to a literal or symbolic context (.pmap), e.g. jwst_0042.pmap,  jwst-2014-10-15T00:15:21, jwst-operational,  not " + repr(context)
+            "Only set CRDS_CONTEXT to a literal or symbolic context (.pmap), e.g. jwst_0042.pmap,  jwst-2014-10-15T00:15:21, jwst-latest,  not " + repr(context)
     return context
 
 CRDS_IGNORE_MAPPING_CHECKSUM = BooleanConfigItem("CRDS_IGNORE_MAPPING_CHECKSUM", False,
@@ -1400,6 +1400,8 @@ def is_context_spec(mapping):
     >>> is_context_spec("hst-acs-2040-01-29T12:00:00")
     False
     """
+    if mapping in ["latest", "build"]:
+        return True
     return is_context(mapping) or (isinstance(mapping, str) and bool(PIPELINE_CONTEXT_RE.match(mapping)))
 
 def is_date_based_mapping_spec(mapping):

--- a/crds/sync.py
+++ b/crds/sync.py
@@ -633,7 +633,7 @@ class SyncScript(cmdline.ContextsScript):
                 self.error_and_repair(path, "File", repr(base), "checksum mismatch CRDS=" + repr(info["sha1sum"]),
                                       "LOCAL=" + repr(sha1sum))
 
-        if info["state"] not in ["archived", "operational", "delivered"]:
+        if info["state"] not in ["archived", "operational", "delivered", "latest"]:
             log.warning("File", repr(base), "has an unusual CRDS file state", repr(info["state"]))
 
         if info["rejected"] != "false":


### PR DESCRIPTION
Resolves #1087

<!-- describe the changes comprising this PR here -->
Allow "latest" as a CRDS file state in `crds sync` so that it doesn't issue a warning message for all the files it finds in this state.

There's no test for `crds sync` with JWST.  Only HST.  And the testing infrastructure here is so specialized, I'm not sure how to test this.  But some pseudocode would be:

```python
def test_sync_jwst_file_state():
    with pytest.warns() as record:
        errors = SyncScript("crds.sync some low-resource-command that reproduces warning")()
    assert errors is None
    assert len(record) is 0, record.pop().message
```

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

