### PR TITLE
docs/revert-back-to-display-version

### DIFF
--- a/documentation/crds_users_guide/source/conf.py
+++ b/documentation/crds_users_guide/source/conf.py
@@ -122,7 +122,7 @@ html_theme_options = {
     'canonical_url': '',
     # 'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
     'logo_only': False,
-    'version_selector': True,
+    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     'vcs_pageview_mode': '',


### PR DESCRIPTION
Temporary reversion in docs config to eliminate or identify CI errors