### PR TITLE
Added SUB8FP6A to nircam_all.tpn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+12.0.6 (2024-11-14)
+===================
+
+JWST
+----
+
+- Added SUB8FP6A to nircam_all.tpn. (`#1098
+  <https://github.com/spacetelescope/crds/issues/1098>`_)
+
+
 12.0.5 (2024-11-05)
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,3 @@
-12.0.6 (2024-11-14)
-===================
-
-JWST
-----
-
-- Added SUB8FP6A to nircam_all.tpn. (`#1098
-  <https://github.com/spacetelescope/crds/issues/1098>`_)
-
-
 12.0.5 (2024-11-05)
 ===================
 

--- a/changes/1098.jwst.rst
+++ b/changes/1098.jwst.rst
@@ -1,0 +1,1 @@
+Added SUB8FP6A to nircam_all.tpn.

--- a/crds/jwst/tpns/nircam_all.tpn
+++ b/crds/jwst/tpns/nircam_all.tpn
@@ -38,7 +38,7 @@ META.SUBARRAY.NAME          H   C   O   SUB128,\
                                         SUB400P,SUB400X256ALWB,\
                                         SUB640,SUB640A210R,SUB640ASWB,SUB640B210R,SUB640BSWB,\
                                         SUB64FP1A,SUB64FP1B,SUB64P,\
-                                        SUB8FP1A,SUB8FP1B,\
+                                        SUB8FP1A,SUB8FP1B,SUB8FP6A, \
                                         SUB96DHSPILA,SUB96DHSPILB,\
                                         SUBFSA210R,SUBFSA335R,SUBFSA430R,SUBFSALWB,SUBFSASWB,\
                                         SUBGRISM128,SUBGRISM256,SUBGRISM64,\

--- a/crds/jwst/tpns/nircam_all.tpn
+++ b/crds/jwst/tpns/nircam_all.tpn
@@ -37,7 +37,7 @@ META.SUBARRAY.NAME          H   C   O   SUB128,\
                                         SUB32TATS,SUB32TATSGRISM,\
                                         SUB400P,SUB400X256ALWB,\
                                         SUB640,SUB640A210R,SUB640ASWB,SUB640B210R,SUB640BSWB,\
-                                        SUB64FP1A,SUB64FP1B,SUB64P,\
+                                        SUB64FP1A,SUB64FP1B,SUB64FP6A,SUB64P,\
                                         SUB8FP1A,SUB8FP1B,SUB8FP6A, \
                                         SUB96DHSPILA,SUB96DHSPILB,\
                                         SUBFSA210R,SUBFSA335R,SUBFSA430R,SUBFSALWB,SUBFSASWB,\


### PR DESCRIPTION
Resolves [CCD-1527](https://jira.stsci.edu/browse/CCD-1527)

This PR addresses the lack of the new subarray SUB8FP6A added being delivered for NIRCAM.

