### PR TITLE
Added reftype for pars-cleanflickernoisestep and added doc.

### DIFF
--- a/changes/1102.jwst.rst
+++ b/changes/1102.jwst.rst
@@ -1,0 +1,1 @@
+Added reftype for pars-cleanflickernoisestep.

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -7097,6 +7097,30 @@
             "tpn":"nirspec_pars-badpixselfcalstep.tpn",
             "unique_rowkeys":null
         },
+        "pars-cleanflickernoisestep":{
+            "derived_from":"Created by Hunter Brown 2024-12-06",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-cleanflickernoisestep",
+            "filetype":"pars-cleanflickernoisestep",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_pars-cleanflickernoisestep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_pars-cleanflickernoisestep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"e92736107f6141b25b154484e47d72dad36290c3",
+            "suffix":"pars-cleanflickernoisestep",
+            "text_descr":"Base rmap for nirspec_pars-cleanflickernoisestep",
+            "tpn":"nirspec_pars-cleanflickernoisestep.tpn",
+            "unique_rowkeys":null
+        },
         "pars-darkcurrentstep":{
             "derived_from":"Created by Hunter Brown 2024-06-10",
             "extra_keys":null,

--- a/crds/jwst/specs/nirspec_pars-cleanflickernoisestep.rmap
+++ b/crds/jwst/specs/nirspec_pars-cleanflickernoisestep.rmap
@@ -1,0 +1,17 @@
+header = {
+    'derived_from' : 'Created by Hunter Brown 2024-12-06',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-cleanflickernoisestep',
+    'filetype' : 'pars-cleanflickernoisestep',
+    'instrument' : 'NIRSPEC',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_nirspec_pars-cleanflickernoisestep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : ((), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : 'e92736107f6141b25b154484e47d72dad36290c3',
+    'suffix' : 'pars-cleanflickernoisestep',
+    'text_descr' : 'Base rmap for nirspec_pars-cleanflickernoisestep',
+}
+
+selector = Match({
+})


### PR DESCRIPTION
Resolves [CRDS-884](https://jira.stsci.edu/browse/CRDS-884)

This PR addresses some errors for missing reftypes for pars-cleanflickernoisestep. A reftype for badpixselfstep was added in an earlier update.

<details><summary>news fragment change types...</summary>

- ``changes/1102.jwst.rst``: JWST reference files
</details>

