### PR TITLE
CRDS-781: Fix typo in STIS halotab text

### DIFF
--- a/changes/1105.hst.rst
+++ b/changes/1105.hst.rst
@@ -1,0 +1,1 @@
+Fixed typo in STIS HALOTAB spec

--- a/crds/hst/specs/combined_specs.json
+++ b/crds/hst/specs/combined_specs.json
@@ -1797,7 +1797,7 @@
             "reffile_switch":"none",
             "rmap_relevance":"(DETECTOR != \"CCD\" and OBSTYPE == \"SPECTROSCOPIC\")",
             "suffix":"hal",
-            "text_descr":"Detectore Halo Table",
+            "text_descr":"Detector Halo Table",
             "tpn":"stis_hal.tpn",
             "unique_rowkeys":[
                 "OPT_ELEM",

--- a/crds/hst/specs/stis_halotab.spec
+++ b/crds/hst/specs/stis_halotab.spec
@@ -10,7 +10,7 @@
     'reffile_switch': 'none',
     'rmap_relevance': '(DETECTOR != "CCD" and OBSTYPE == "SPECTROSCOPIC")',
     'suffix': 'hal',
-    'text_descr': 'Detectore Halo Table',
+    'text_descr': 'Detector Halo Table',
     'tpn': 'stis_hal.tpn',
     'unique_rowkeys': ('OPT_ELEM', 'HALOWAVE'),
 }


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CRDS-781](https://jira.stsci.edu/browse/CRDS-781)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR addresses a typo in the text description for the STIS HALOTAB reference file, where 'Detector' is mis-spelt as 'Detectore'

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

