### PR TITLE
jwst/no-vars-fallback-to-latest

### DIFF
--- a/changes/1106.jwst.rst
+++ b/changes/1106.jwst.rst
@@ -1,0 +1,1 @@
+Default to latest context if no env variables set for internal local users

--- a/conftest.py
+++ b/conftest.py
@@ -154,8 +154,10 @@ class ConfigState:
         self.old_state = None
         self.new_state = None
 
-    def config_setup(self):
-        """Reset the CRDS configuration state to support testing given the supplied parameters."""
+    def config_setup(self, **kwargs):
+        """Reset the CRDS configuration state to support testing given the supplied parameters.
+        Optional argument `kwargs` accepts a dict of key-value pairs to allow further customization if needed.
+        """
         log.set_test_mode()
         self.old_state = crds_config.get_crds_state()
         self.old_state["CRDS_CWD"] = os.getcwd()
@@ -172,6 +174,7 @@ class ConfigState:
             self.new_state["CRDS_OBSERVATORY"] = self.observatory
         if self.mode is not None:
             self.new_state['CRDS_MODE'] = self.mode
+        self.new_state.update(**kwargs)
         crds_config.set_crds_state(self.new_state)
         utils.clear_function_caches()
 
@@ -353,9 +356,10 @@ def tobs_test_cache_state(test_cache):
 
 
 @fixture(scope='function')
-def jwst_local_ro_cache_state():
-    cfg = ConfigState(observatory='jwst')
-    cfg.config_setup()
+def jwst_local_cache_state(crds_shared_group_cache):
+    cfg = ConfigState(cache=crds_shared_group_cache, observatory='jwst', mode='local')
+    extra_kwargs = dict(CRDS_CONFIG_OFFSITE='0', CRDS_VERBOSITY=1)
+    cfg.config_setup(**extra_kwargs)
     yield cfg
     cfg.cleanup()
  

--- a/conftest.py
+++ b/conftest.py
@@ -351,6 +351,13 @@ def tobs_test_cache_state(test_cache):
     yield cfg
     cfg.cleanup()
 
+
+@fixture(scope='function')
+def jwst_local_ro_cache_state():
+    cfg = ConfigState(observatory='jwst')
+    cfg.config_setup()
+    yield cfg
+    cfg.cleanup()
  
 
 # ==============================================================================

--- a/documentation/crds_users_guide/source/web_services.rst
+++ b/documentation/crds_users_guide/source/web_services.rst
@@ -28,8 +28,8 @@ Centralized Default
 `get_default_context()` returns the name of the context which is
 currently in use by default in the archive pipeline, e.g. 'jwst_0001.pmap'.
 This value is set and maintained on the CRDS Server. The actual pipeline context 
-differs from this commanded valuer until the pipeline is synchronized with the CRDS
-server using cron_sync.   
+differs from this commanded value until the pipeline is synchronized with the CRDS
+server using cron_sync.
 
 The commanded default can be obtained using the CRDS client library as follows:
 
@@ -50,6 +50,15 @@ The commanded default can be obtained using the CRDS client library as follows:
            >>> from crds import client
            >>> client.get_default_context('jwst')
            'jwst_0101.pmap'
+        
+       .. note::
+
+        If using a local, read-only CRDS configuration on the internal STScI network - and in particular if you
+        do not have any CRDS environment variables set - the context used to retrieve references will default to
+        the "latest" context no matter what. This behavior is due to the fact that the build context is retrieved
+        via API from the server according to the version of JWST pipeline calibration code you have installed locally.
+        With no environment variables set, CRDS assumes a local configuration and falls back to the latest cached context.
+
 
    .. group-tab:: ROMAN
 

--- a/test/core/test_heavy_client.py
+++ b/test/core/test_heavy_client.py
@@ -289,8 +289,8 @@ def dt_get_context_parkeys(jwst_serverless_state):
 @mark.jwst
 @mark.core
 @mark.heavy_client
-def test_jwst_default_context_local_mode(jwst_local_ro_cache_state):
-    info = heavy_client.get_config_info(jwst_local_ro_cache_state.observatory)
+def test_jwst_default_context_local_mode(jwst_local_cache_state):
+    info = heavy_client.get_config_info(jwst_local_cache_state.observatory)
     assert info.effective_mode == 'local'
     context = heavy_client.get_final_context(info, None)
     assert context.startswith("jwst_")

--- a/test/core/test_heavy_client.py
+++ b/test/core/test_heavy_client.py
@@ -284,3 +284,13 @@ def dt_get_context_parkeys(jwst_serverless_state):
     assert parkeys2 == ['META.INSTRUMENT.LAMP_STATE', 'META.OBSERVATION.DATE', 'META.VISIT.TSOVISIT', 'REFTYPE']
     parkeys3 = heavy_client.get_context_parkeys("jwst_miri_flat.rmap","miri")
     assert parkeys3 == ['META.OBSERVATION.DATE', 'META.VISIT.TSOVISIT', 'META.INSTRUMENT.LAMP_STATE']
+
+
+@mark.jwst
+@mark.core
+@mark.heavy_client
+def test_jwst_default_context_local_mode(jwst_local_ro_cache_state):
+    info = heavy_client.get_config_info(jwst_local_ro_cache_state.observatory)
+    assert info.effective_mode == 'local'
+    context = heavy_client.get_final_context(info, None)
+    assert context.startswith("jwst_")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1540](https://jira.stsci.edu/browse/CCD-1540) and [JP-3838](https://jira.stsci.edu/browse/JP-3838)

<!-- describe the changes comprising this PR here -->
This PR addresses a bug introduced by the recent cal version-based context changes where users internal to the STScI network who have no CRDS environment variables configured are no longer able to retrieve the default context. The client will now fallback to the "latest" context if all else fails, and also default to latest if crds determines a local configuration (which occurs automatically when no server url is preset). A new test as well as a note in the relevant documentation has been added. Note - it is possible to retrieve the cached "build_context" variable but this is not necessarily reliable since the user may have updated their jwst cal version since the last crds sync took place.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

