### PR TITLE
Declare conflicting optional dependencies for uv builds

### DIFF
--- a/changes/1110.testing.rst
+++ b/changes/1110.testing.rst
@@ -1,0 +1,1 @@
+Declare conflicting optional dependencies for uv builds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ synphot = ["stsynphot"]
 requires = ["setuptools>=61.2", "setuptools_scm[toml]>=3.4", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv]
+conflicts = [
+    [
+      { extra = "aws" },
+      { extra = "docs" },
+    ],
+]
+
 [tool.setuptools]
 platforms = ["Linux", "OS-X"]
 zip-safe = false


### PR DESCRIPTION
CRDS nightly Regtests have been failing due to dependency resolution by uv
UV is a fast Python package manager. It has a cache of built dependencies the same as pip.

This PR will resolve nightly regression test failures 
https://github.com/spacetelescope/RegressionTests/actions/workflows/crds_client.yml

Successful Regression Test: https://github.com/spacetelescope/RegressionTests/actions/runs/13507059096
Resolves https://jira.stsci.edu/browse/SPB-2406

The problem is an incompatibility with awscli and sphinx.
uv attempts resolves the whole project in cache including optional dependencies.
awscli is the real culprit - requiring docutils>=0.10, <0.17. The previous successfully solved environments downgraded awscli to 0.7.0 (circa Feb 2013) making it almost unrecognizable.

Why now?
The version of uv updated itself and started building packages more proactively.
uv tries to avoid package builds during resolution. It uses any wheel if exist for that version, then tries to find static metadata in the source distribution (mainly pyproject.toml with static `project.version`, `project.dependencies` and `project.optional-dependencies` or METADATA v2.2+). Only if all of that fails, it builds the package.
Builds fail for awscli packages that old and I think it wouldn't be worth the time to speculate why.

Solutions?
awscli and sphinx will not play nice with each other.

We dont want to downgrade uv because its used for all scsb regtests.
We can declare dependencies conflicts for the time being. 
It would probably be worth investigating awscli v2

AWS CLI v2 claims to fix this dependency conundrum but is not published to Pypi for somewhat dubious reasons... https://github.com/aws/aws-cli/issues/4947

There is a rehost of awscli2 on Pypi maintained by disgruntled community members
https://pypi.org/project/awscliv2/
Then there is the option to build from source
git+https://github.com/aws/aws-cli.git@v2

uv requires that all optional dependencies ("extras") declared by the project are compatible with each other and resolves all optional dependencies together when creating the lockfile

```
[tool.uv]
conflicts = [
    [
      { extra = "aws" },
      { extra = "docs" },
    ],
]
```