### PR TITLE
revert release action version to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           git push origin ${{ github.event.inputs.version }}
 
       - name: Create GitHub release (triggers publish-to-pypi workflow)
-        uses: zendesk/action-create-release@746afbc52c1d78025a1a55b59ccd4f89208d4474  # master
+        uses: zendesk/action-create-release@v1  # master
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         with:


### PR DESCRIPTION
Using the new hash format for github actions changed the create-release-action to v2 which fails. Changing this back to v1 so that we can avoid failures when deploying the release action.
