### PR TITLE
fix-changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,33 +1,3 @@
-12.1.0 (2025-02-26)
-===================
-
-No significant changes.
-
-
-12.1.0 (2025-02-25)
-===================
-
-HST
----
-
-- Fixed typo in STIS HALOTAB spec (`#1105
-  <https://github.com/spacetelescope/crds/issues/1105>`_)
-
-
-ROMAN
------
-
-- Adds new rmap template for roman skycells reftype (`#1108
-  <https://github.com/spacetelescope/crds/issues/1108>`_)
-
-
-Testing / Automation
---------------------
-
-- Declare conflicting optional dependencies for uv builds (`#1110
-  <https://github.com/spacetelescope/crds/issues/1110>`_)
-
-
 12.0.9 (2024-12-27)
 ===================
 

--- a/changes/1108.roman.rst
+++ b/changes/1108.roman.rst
@@ -1,0 +1,1 @@
+Adds new rmap template for roman skycells reftype

--- a/changes/1110.testing.rst
+++ b/changes/1110.testing.rst
@@ -1,0 +1,1 @@
+Declare conflicting optional dependencies for uv builds


### PR DESCRIPTION
Adding news fragments back in so that release action for 12.1.0 doesn't throw an error