### PR TITLE
Created new reftype for niriss_bkg based on niriss_wfssbkg.

### DIFF
--- a/changes/1114.jwst.1.rst
+++ b/changes/1114.jwst.1.rst
@@ -1,0 +1,1 @@
+Added DHS subarray values to nircam_all.tpn

--- a/changes/1114.jwst.rst
+++ b/changes/1114.jwst.rst
@@ -1,0 +1,1 @@
+Created new reftype for niriss_bkg based on niriss_wfssbkg

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -5154,6 +5154,39 @@
             "tpn":"niriss_area.tpn",
             "unique_rowkeys":null
         },
+        "bkg":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"niriss_wfssbkg.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"BKG",
+            "filetype":"BKG",
+            "instrument":"NIRISS",
+            "ld_tpn":"niriss_bkg_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_niriss_bkg.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE",
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.INSTRUMENT.PUPIL"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"83e633f2b5dc74ee8694cb3e6a7e403af9cea192",
+            "suffix":"bkg",
+            "text_descr":"WFSS master background reference images",
+            "tpn":"niriss_bkg.tpn",
+            "unique_rowkeys":null
+        },
         "dark":{
             "derived_from":"jwst_niriss_dark_0002.rmap",
             "extra_keys":null,

--- a/crds/jwst/specs/niriss_bkg.rmap
+++ b/crds/jwst/specs/niriss_bkg.rmap
@@ -1,0 +1,19 @@
+header = {
+    'classes' : ('Match', 'UseAfter'),
+    'derived_from' : 'niriss_wfssbkg.rmap',
+    'file_ext' : '.fits',
+    'filekind' : 'BKG',
+    'filetype' : 'BKG',
+    'instrument' : 'NIRISS',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_niriss_bkg.rmap',
+    'observatory' : 'JWST',
+    'parkey' : (('META.EXPOSURE.TYPE', 'META.INSTRUMENT.DETECTOR', 'META.INSTRUMENT.FILTER', 'META.INSTRUMENT.PUPIL'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '83e633f2b5dc74ee8694cb3e6a7e403af9cea192',
+    'suffix' : 'bkg',
+    'text_descr' : 'WFSS master background reference images',
+}
+
+selector = Match({
+    ('NOT NIS_WFSS', 'ANY', 'ANY', 'ANY') : 'N/A',
+})

--- a/crds/jwst/tpns/nircam_all.tpn
+++ b/crds/jwst/tpns/nircam_all.tpn
@@ -34,12 +34,16 @@ META.INSTRUMENT.CHANNEL     H   C   O   SHORT,LONG,ANY,N/A
 META.SUBARRAY.NAME          H   C   O   SUB128,\
                                         SUB160,SUB160P,\
                                         SUB320,SUB320A335R,SUB320A430R,SUB320ALWB,SUB320B335R,SUB320B430R,SUB320BLWB,\
-                                        SUB32TATS,SUB32TATSGRISM,\
+                                        SUB32TA_DHS,SUB32TATS,SUB32TATSGRISM,\
                                         SUB400P,SUB400X256ALWB,\
+                                        SUB41STRIPE1_DHS,\
                                         SUB640,SUB640A210R,SUB640ASWB,SUB640B210R,SUB640BSWB,\
                                         SUB64FP1A,SUB64FP1B,SUB64FP6A,SUB64P,\
                                         SUB8FP1A,SUB8FP1B,SUB8FP6A, \
+                                        SUB82STRIPE2_DHS,\
                                         SUB96DHSPILA,SUB96DHSPILB,\
+                                        SUB164STRIPE4_DHS,\
+                                        SUB260STRIPE4_DHS,\
                                         SUBFSA210R,SUBFSA335R,SUBFSA430R,SUBFSALWB,SUBFSASWB,\
                                         SUBGRISM128,SUBGRISM256,SUBGRISM64,\
                                         \


### PR DESCRIPTION
Resolves [CCD-1566](https://jira.stsci.edu/browse/CCD-1566)
Resolves [CCD-1564](https://jira.stsci.edu/browse/CCD-1566)

<details><summary>news fragment change types...</summary>

- ``changes/1114.jwst.rst``: Created new reftype for niriss_bkg based on niriss_wfssbkg
- ``changes/1114.jwst.1.rst``: Added DHS subarray values to nircam_all.tpn
</details>

