### PR TITLE
Update pre_sm4 subarray date to reflect July 2022 ref file delivery

### DIFF
--- a/changes/1121.hst.rst
+++ b/changes/1121.hst.rst
@@ -1,0 +1,1 @@
+Push back the date for using subarray specific bias reference files for ACS

--- a/crds/hst/acs_common.py
+++ b/crds/hst/acs_common.py
@@ -21,4 +21,4 @@ SM4 = timestamp.reformat_date("2009-05-14 00:00:00.000000")
 
 # Date after which subarray references were added to the
 # BIASFILE rmap so header preconditioning is no longer needed.
-PRE_SM4_SUBARRAY = timestamp.reformat_date("2002-08-01 00:00:00.000000")
+PRE_SM4_SUBARRAY = timestamp.reformat_date("2002-03-30 00:00:00.000000")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1210](https://jira.stsci.edu/browse/CCD-1210)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR pushes back the date for using subarray specific bias reference files for ACS

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

