### PR TITLE
[build] remove maintainer password from PyPI publish workflow in lieu of trusted publisher attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,5 +11,3 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@924441154cf3053034c6513d5e06c69d262fb9a6  # v1.13.0
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') }}
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-199](https://jira.stsci.edu/browse/SCSB-199)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
- [ ] add a Trusted Publisher configuration to the PyPI project by visiting https://pypi.org/manage/project/crds/settings/publishing/?provider=github&owner=spacetelescope&repository=crds&workflow_filename=build.yml
- [x] remove `pypi_token` (STScI PyPI maintainer password) from build workflow
- [ ] wait for issue with reusable workflows to be resolved in `pypa/warehouse`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

