### PR TITLE
New pars-refpixstep rmap for nircam.  

### DIFF
--- a/changes/1134.jwst.rst
+++ b/changes/1134.jwst.rst
@@ -1,0 +1,1 @@
+CCD-1602 new pars-pixrefstep.rmap for nircam.

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -4055,6 +4055,39 @@
             "tpn":"nircam_area.tpn",
             "unique_rowkeys":null
         },
+        "bkg":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"jwst_niriss_bkg_0001.rmap",
+            "extra_keys":null,
+            "file_ext":".fits",
+            "filekind":"BKG",
+            "filetype":"BKG",
+            "instrument":"NIRCAM",
+            "ld_tpn":"nircam_bkg_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nircam_bkg.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [
+                    "META.EXPOSURE.TYPE",
+                    "META.INSTRUMENT.DETECTOR",
+                    "META.INSTRUMENT.FILTER",
+                    "META.INSTRUMENT.PUPIL"
+                ],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"bd997e7ea80376ed74bf771d9d498bb7c78b4492",
+            "suffix":"bkg",
+            "text_descr":"Background Reference Images",
+            "tpn":"nircam_bkg.tpn",
+            "unique_rowkeys":null
+        },
         "dark":{
             "classes":[
                 "Match",
@@ -7403,6 +7436,34 @@
             "suffix":"pars-rampfitstep",
             "text_descr":"RampFitStep runtime parameters",
             "tpn":"nirspec_pars-rampfitstep.tpn",
+            "unique_rowkeys":null
+        },
+        "pars-refpixstep":{
+            "classes":[
+                "Match",
+                "UseAfter"
+            ],
+            "derived_from":"Derived from nirspec_pars-rampfitstep.rmap",
+            "extra_keys":null,
+            "file_ext":".asdf",
+            "filekind":"pars-refpixstep",
+            "filetype":"pars-refpixstep",
+            "instrument":"NIRSPEC",
+            "ld_tpn":"nirspec_pars-refpixstep_ld.tpn",
+            "mapping":"REFERENCE",
+            "name":"jwst_nirspec_pars-refpixstep.rmap",
+            "observatory":"JWST",
+            "parkey":[
+                [],
+                [
+                    "META.OBSERVATION.DATE",
+                    "META.OBSERVATION.TIME"
+                ]
+            ],
+            "sha1sum":"4d44394814b8b4bb0452f843e9945d5e5abe0afe",
+            "suffix":"pars-refpixstep",
+            "text_descr":"NIRSpec NRS FULL reference pixel correction step parameters.",
+            "tpn":"nirspec_pars-refpixstep.tpn",
             "unique_rowkeys":null
         },
         "pars-resamplespecstep":{

--- a/crds/jwst/specs/nirspec_pars-refpixstep.rmap
+++ b/crds/jwst/specs/nirspec_pars-refpixstep.rmap
@@ -1,0 +1,18 @@
+header = {
+    'classes' : ('Match', 'UseAfter'),
+    'derived_from' : 'Derived from nirspec_pars-rampfitstep.rmap',
+    'file_ext' : '.asdf',
+    'filekind' : 'pars-refpixstep',
+    'filetype' : 'pars-refpixstep',
+    'instrument' : 'NIRSPEC',
+    'mapping' : 'REFERENCE',
+    'name' : 'jwst_nirspec_pars-refpixstep.rmap',
+    'observatory' : 'JWST',
+    'parkey' : ((), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : '4d44394814b8b4bb0452f843e9945d5e5abe0afe',
+    'suffix' : 'pars-refpixstep',
+    'text_descr' : 'NIRSpec NRS FULL reference pixel correction step parameters.',
+}
+
+selector = Match({
+})


### PR DESCRIPTION
Resolves [CCD-1602](https://jira.stsci.edu/browse/CCD-1602)

This PR addresses the creation of a new rmap for nircam titled pars-refpixstep.


<details><summary>news fragment change types...</summary>
- ``changes/<PR#>1134.jwst.rst``: JWST reference files
</details>

