### PR TITLE
Ccd 1604

### DIFF
--- a/changes/1135.jwst.rst
+++ b/changes/1135.jwst.rst
@@ -1,0 +1,1 @@
+Added READPATT and SUBARRAY to selectors for nirspec_pars-refpixstep.rmap

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -7438,34 +7438,6 @@
             "tpn":"nirspec_pars-rampfitstep.tpn",
             "unique_rowkeys":null
         },
-        "pars-refpixstep":{
-            "classes":[
-                "Match",
-                "UseAfter"
-            ],
-            "derived_from":"Derived from nirspec_pars-rampfitstep.rmap",
-            "extra_keys":null,
-            "file_ext":".asdf",
-            "filekind":"pars-refpixstep",
-            "filetype":"pars-refpixstep",
-            "instrument":"NIRSPEC",
-            "ld_tpn":"nirspec_pars-refpixstep_ld.tpn",
-            "mapping":"REFERENCE",
-            "name":"jwst_nirspec_pars-refpixstep.rmap",
-            "observatory":"JWST",
-            "parkey":[
-                [],
-                [
-                    "META.OBSERVATION.DATE",
-                    "META.OBSERVATION.TIME"
-                ]
-            ],
-            "sha1sum":"4d44394814b8b4bb0452f843e9945d5e5abe0afe",
-            "suffix":"pars-refpixstep",
-            "text_descr":"NIRSpec NRS FULL reference pixel correction step parameters.",
-            "tpn":"nirspec_pars-refpixstep.tpn",
-            "unique_rowkeys":null
-        },
         "pars-resamplespecstep":{
             "derived_from":"nirspec-pars-jumpstep.rmap",
             "extra_keys":null,

--- a/crds/jwst/specs/nirspec_pars-refpixstep.rmap
+++ b/crds/jwst/specs/nirspec_pars-refpixstep.rmap
@@ -8,8 +8,8 @@ header = {
     'mapping' : 'REFERENCE',
     'name' : 'jwst_nirspec_pars-refpixstep.rmap',
     'observatory' : 'JWST',
-    'parkey' : ((), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
-    'sha1sum' : '4d44394814b8b4bb0452f843e9945d5e5abe0afe',
+    'parkey' : (('META.EXPOSURE.READPATT', 'META.SUBARRAY.NAME'), ('META.OBSERVATION.DATE', 'META.OBSERVATION.TIME')),
+    'sha1sum' : 'ca2ea7711861247cd71703c2399cb2a4cc17dec5',
     'suffix' : 'pars-refpixstep',
     'text_descr' : 'NIRSpec NRS FULL reference pixel correction step parameters.',
 }


### PR DESCRIPTION
Resolves [CCD-1604](https://jira.stsci.edu/browse/CCD-1604)

This PR addresses adding SUBARRAY and READPATT  as selectors in the base rmap for nirspec_pars-refpixstep.rmap


<details><summary>news fragment change types...</summary>

- ``changes/1135.jwst.rst``: JWST reference files
</details>

