### PR TITLE
CCD-

### DIFF
--- a/changes/1140.jwst.rst
+++ b/changes/1140.jwst.rst
@@ -1,0 +1,1 @@
+catch exceptions for serverless mode and fallback to latest

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -104,13 +104,19 @@ def set_crds_server(url):
     S = CheckingProxy(URL, version="1.0")
 
 
-def get_crds_server():
+def get_crds_server(obs=None):
     """Return the base URL for the CRDS JSON RPC server.
     """
-    url = URL[:-len(URL_SUFFIX)]
-    if not url.startswith("https://") and "localhost" not in url:
-        log.warning("CRDS_SERVER_URL does not start with https://  ::", url)
+    try:
+        url = URL[:-len(URL_SUFFIX)]
+        if not url.startswith("https://") and "localhost" not in url:
+            log.warning("CRDS_SERVER_URL does not start with https://  ::", url)
+    except NameError:
+        if obs is None:
+            obs = "jwst"
+        url = os.environ.get("CRDS_SERVER_URL", f"https://{obs}-serverless.stsci.edu")
     return url
+
 
 
 # =============================================================================
@@ -255,7 +261,7 @@ def get_cal_version(observatory):
         try:
             cal_version = importlib.metadata.version(cal)
             if 'dev' in cal_version:
-                log.info("DEV calibration SW identified. Defaulting to Edit Context.")
+                log.debug("DEV calibration SW identified. Defaulting to Edit Context.")
                 return 'dev'
             cal_version = config.simplify_version(cal_version)
             dist_path = get_cal_dist_path(cal)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1608](https://jira.stsci.edu/browse/CCD-1608)



<!-- describe the changes comprising this PR here -->
If no CRDS environment variables have been set, or if CRDS_SERVER_URL has "serverless" in it (e.g. 'https://jwst-serverless.stsci.edu'), acquire the default latest context from local CRDS cache. It's possible this fallback was not being triggered due to the exception type being raised - additional exceptions have been added to the try-catch condition to subvert an all out error and instead fallback to the local cache gracefully.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

