### PR TITLE
roman/epsf-hook

### DIFF
--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -51,7 +51,7 @@ HERE = os.path.dirname(__file__) or "."
 
 # Stub like HST for now
 
-def header_to_reftypes(header, context="roman-operational"):
+def header_to_reftypes(header, context="roman-latest"):
     """Based on `header` return the default list of appropriate reference type names.
 
     >>> ref_types = header_to_reftypes(None)
@@ -61,7 +61,7 @@ def header_to_reftypes(header, context="roman-operational"):
     """
     return []  # translates to "all types" for instrument defined by header.
 
-def header_to_pipelines(header, context="roman-operational"):
+def header_to_pipelines(header, context="roman-latest"):
     """Based on `header` return the default list of appropriate reference type names.
 
     >>> header_to_pipelines(None)

--- a/crds/roman/wfi.py
+++ b/crds/roman/wfi.py
@@ -1,0 +1,37 @@
+"""The epsf reftype will be used for both Level 2 (ImageModel, RampModel) and Level 3 (MosaicModel) data. For level 2, the keyword for the time specification is META.EXPOSURE.START_TIME. For Level 3 the keyword is META.BASIC.TIME_MEAN_MJD.
+
+There is no apparent way in the rmaps themselves to equivalence two different source keywords to the same parkey matching parameter. Assuming there is not, a different method will need to be used.
+
+An option is to use the "precondition_header" feature. This allows arbitrary modifications of the input header prior to any selections. At this point, if META.EXPOSURE.START_TIME does not exist and META.BASIC.TIME_MEAN_MJD does, META.EXPOSURE.START_TIME can be created and assigned the value of META.BASIC.TIME_MEAN_MJD.
+"""
+from crds.core import log
+from astropy.time import Time 
+
+def precondition_header_wfi_epsf_v1(rmap, header_in):
+    """Preconditions Level 3 EPSF data model header time specification by replacing MJD Mean Time keyword with standard META.EXPOSURE.START_TIME used by Level 2 files."""
+    header = dict(header_in)
+    l2_key = 'ROMAN.META.EXPOSURE.START_TIME'
+    l3_keys = ['ROMAN.META.BASIC.TIME_FIRST_MJD', 'ROMAN.META.BASIC.TIME_MEAN_MJD', 'ROMAN.META.COADD_INFO.TIME_MEAN']
+    dtstring = header.get(l2_key)
+    if not dtstring:
+        mjd = header.get(l3_keys[0], header.get(l3_keys[1], header.get(l3_keys[2])))
+        if mjd:
+            dtstring = Time(mjd, format="mjd").isot
+            header['ROMAN.META.EXPOSURE.START_TIME'] = dtstring
+            log.verbose(f"Replaced MJD L3 header keyword with CRDS equivalent {l2_key}")
+        else:
+            log.error("No available Useafter (time-based) relevant keywords found in header")
+    instr_params = header.get('ROMAN.META.INSTRUMENT')
+    if not instr_params:
+        instr_params = dict(name=header.get('ROMAN.META.BASIC.INSTRUMENT'), detector='WFI02', optical_element=header.get('ROMAN.META.BASIC.OPTICAL_ELEMENT'))
+        header['ROMAN.META.INSTRUMENT'] = instr_params
+    return header
+
+def wfi_epsf_filter(rmap):
+    """Adds precondition_header() hook to rmap header"""
+    header_additions = {
+        "hooks": {
+            "precondition_header": "precondition_header_wfi_epsf_v1"
+        }
+    }
+    return rmap, header_additions

--- a/test/roman/test_roman.py
+++ b/test/roman/test_roman.py
@@ -101,20 +101,17 @@ def test_wfi_epsf_level3_header_conversions(roman_test_cache_state):
     roman_test_cache_state.mode = 'local'
     roman_test_cache_state.config_setup()
     header_dict = {
-            "ROMAN.META.BASIC.INSTRUMENT": "WFI",
-            "ROMAN.META.BASIC.OPTICAL_ELEMENT": "F158",
+            "ROMAN.META.INSTRUMENT.NAME": "WFI",
+            "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT": "F158",
+            "ROMAN.META.COADD_INFO.TIME_MEAN": "2020-02-01T00:00:00"
     }
-    test_keys = ['BASIC.TIME_FIRST_MJD', 'BASIC.TIME_MEAN_MJD', 'COADD_INFO.TIME_MEAN']
-    for t in test_keys:
-        header_dict.update({'ROMAN.META.'+t:60857})
-        result = heavy_client.getreferences(
-            header_dict,
-            observatory="roman",
-            context="roman_0007.pmap",
-            reftypes=["epsf"]
-        )
-        assert os.path.basename(result['epsf']) == 'roman_wfi_epsf_0001.asdf'
-        del header_dict['ROMAN.META.'+t]
+    result = heavy_client.getreferences(
+        header_dict,
+        observatory="roman",
+        context="roman_0007.pmap",
+        reftypes=["epsf"]
+    )
+    assert os.path.basename(result['epsf']) == 'roman_wfi_epsf_0001.asdf'
 
 
 @mark.roman

--- a/test/roman/test_roman.py
+++ b/test/roman/test_roman.py
@@ -96,6 +96,29 @@ def test_getreferences_with_invalid_header(roman_test_cache_state):
         assert True
 
 
+def test_wfi_epsf_precondition_hook(roman_test_cache_state):
+    """Tests retrieving Useafter-relevant keyword from L3 dataset headers and converting to ISOT via precondition hook in the empirical point spread function rmap."""
+    roman_test_cache_state.mode = 'local'
+    roman_test_cache_state.config_setup()
+    header_dict = {
+            "ROMAN.META.INSTRUMENT.NAME": "WFI",
+            "ROMAN.META.INSTRUMENT.DETECTOR": "WFI02",
+            "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT": "F158",
+    }
+    test_keys = ['BASIC.TIME_FIRST_MJD', 'BASIC.TIME_MEAN_MJD', 'COADD_INFO.TIME_MEAN']
+    for t in test_keys:
+        header_dict.update({'ROMAN.META.'+t:60857})
+        result = heavy_client.getreferences(
+            header_dict,
+            observatory="roman",
+            context="roman_0007.pmap",
+            reftypes=["epsf"]
+        )
+        del header_dict[t]
+    # test from file
+
+
+
 @mark.roman
 def test_list_references(roman_test_cache_state):
     """ test_list_references: test satisfies Roman 303.2 and 628.2
@@ -125,3 +148,4 @@ def test_list_references(roman_test_cache_state):
     results = results.decode('ascii').split("\n")
 
     assert {item for item in results if item} == expected_result
+    

--- a/test/roman/test_roman.py
+++ b/test/roman/test_roman.py
@@ -96,14 +96,13 @@ def test_getreferences_with_invalid_header(roman_test_cache_state):
         assert True
 
 
-def test_wfi_epsf_precondition_hook(roman_test_cache_state):
+def test_wfi_epsf_level3_header_conversions(roman_test_cache_state):
     """Tests retrieving Useafter-relevant keyword from L3 dataset headers and converting to ISOT via precondition hook in the empirical point spread function rmap."""
     roman_test_cache_state.mode = 'local'
     roman_test_cache_state.config_setup()
     header_dict = {
-            "ROMAN.META.INSTRUMENT.NAME": "WFI",
-            "ROMAN.META.INSTRUMENT.DETECTOR": "WFI02",
-            "ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT": "F158",
+            "ROMAN.META.BASIC.INSTRUMENT": "WFI",
+            "ROMAN.META.BASIC.OPTICAL_ELEMENT": "F158",
     }
     test_keys = ['BASIC.TIME_FIRST_MJD', 'BASIC.TIME_MEAN_MJD', 'COADD_INFO.TIME_MEAN']
     for t in test_keys:
@@ -114,9 +113,8 @@ def test_wfi_epsf_precondition_hook(roman_test_cache_state):
             context="roman_0007.pmap",
             reftypes=["epsf"]
         )
-        del header_dict[t]
-    # test from file
-
+        assert os.path.basename(result['epsf']) == 'roman_wfi_epsf_0001.asdf'
+        del header_dict['ROMAN.META.'+t]
 
 
 @mark.roman


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1614](https://jira.stsci.edu/browse/CCD-1614)



<!-- describe the changes comprising this PR here -->
This PR adds a precondition header hook for Level 3 data model header time specifications not recognized by CRDS. The hook replaces MJD Mean Time keyword (looping over list of possible keys) with standard ROMAN.META.EXPOSURE.START_TIME used by Level 2 files.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

