### PR TITLE
Remove list of allowed values for LIFE_ADJ in COS tpns (CCD-1624)

### DIFF
--- a/changes/1146.hst.rst
+++ b/changes/1146.hst.rst
@@ -1,0 +1,1 @@
+Remove list of allowed values for COS tpns

--- a/crds/hst/tpns/cos_1dx.tpn
+++ b/crds/hst/tpns/cos_1dx.tpn
@@ -23,7 +23,7 @@ VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 DESCRIP             H        C         R
 PEDIGREE            H        C         R    &PEDIGREE
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
+LIFE_ADJ            H        I         R
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_1dx_ld.tpn
+++ b/crds/hst/tpns/cos_1dx_ld.tpn
@@ -35,7 +35,7 @@ CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,13
           2952,2979,2996,3018,3035,3057,3074,3094,\
           2635,2950,3000,3360
 APERTURE            C        C         R    PSA,BOA,WCA,FCA
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
+LIFE_ADJ            H        I         R
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_2zx.tpn
+++ b/crds/hst/tpns/cos_2zx.tpn
@@ -17,7 +17,7 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "TWO-ZONE SPECTRAL EXTRACTION PARAMETERS TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_2zx_ld.tpn
+++ b/crds/hst/tpns/cos_2zx_ld.tpn
@@ -27,7 +27,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 APERTURE            C        C         R    PSA,BOA
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_disp.tpn
+++ b/crds/hst/tpns/cos_disp.tpn
@@ -14,7 +14,7 @@
 INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "DISPERSION RELATION REFERENCE TABLE"
 DETECTOR            H        C         R    FUV,NUV
-LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,5,6,N/A
+LIFE_ADJ            H        C         R
 OBSTYPE             H        C         R    SPECTROSCOPIC
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE

--- a/crds/hst/tpns/cos_disp_ld.tpn
+++ b/crds/hst/tpns/cos_disp_ld.tpn
@@ -18,7 +18,7 @@ COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    DISP
 DETECTOR            C        C         R    FUV,NUV
-LIFE_ADJ            H        C         R    0,1,-1,-11,2,-2,3,4,5,6,N/A
+LIFE_ADJ            H        C         R
 OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE        C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC

--- a/crds/hst/tpns/cos_flat.tpn
+++ b/crds/hst/tpns/cos_flat.tpn
@@ -21,4 +21,4 @@ DESCRIP             H        C         R
 OPT_ELEM            H        C         O    G130M,G160M,G140L,\
                                             G185M,G225M,G285M,G230L, \
                                             MIRRORA,MIRRORB,ANY
-LIFE_ADJ            H        I         R    -1,0,1,2,3,4,5,6,-11
+LIFE_ADJ            H        I         R

--- a/crds/hst/tpns/cos_flat_ld.tpn
+++ b/crds/hst/tpns/cos_flat_ld.tpn
@@ -21,7 +21,7 @@ DETECTOR            C        C         R    FUV,NUV
 OPT_ELEM            C        C         O    G130M,G160M,G140L,\
                                             G185M,G225M,G285M,G230L,\
                                             MIRRORA,MIRRORB
-LIFE_ADJ            C        I         R    -1,0,1,2,3,4,5,6,-11
+LIFE_ADJ            C        I         R
 PEDIGREE            C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_lamp.tpn
+++ b/crds/hst/tpns/cos_lamp.tpn
@@ -19,7 +19,7 @@ VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
+LIFE_ADJ            H        I         R
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_lamp_ld.tpn
+++ b/crds/hst/tpns/cos_lamp_ld.tpn
@@ -17,7 +17,7 @@ COMPARISON_FILE     H        C         R
 COMMENT             H        C         R
 INSTRUMENT      H        C         R    COS
 REFERENCE_FILE_TYPE H        C         R    LAMP
-LIFE_ADJ            H        I         R    0,1,-1,-11,2,-2,3,4,5,6
+LIFE_ADJ            H        I         R
 DETECTOR            C        C         R    FUV,NUV
 OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE        C        C         R    INFLIGHT,GROUND,MODEL,DUMMY

--- a/crds/hst/tpns/cos_phot.tpn
+++ b/crds/hst/tpns/cos_phot.tpn
@@ -21,7 +21,7 @@ VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 SEGMENT             C        C         R    FUVA,FUVB,NUVA,NUVB,NUVC
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L

--- a/crds/hst/tpns/cos_phot_ld.tpn
+++ b/crds/hst/tpns/cos_phot_ld.tpn
@@ -35,7 +35,7 @@ CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,13
           2952,2979,2996,3018,3035,3057,3074,3094,\
           2635,2950,3000,3360
 APERTURE            C        C         R    PSA,BOA,WCA
-LIFE_ADJ            C        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            C        I         R
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_profile.tpn
+++ b/crds/hst/tpns/cos_profile.tpn
@@ -17,7 +17,7 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "2D SPECTRUM PROFILE TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_profile_ld.tpn
+++ b/crds/hst/tpns/cos_profile_ld.tpn
@@ -26,7 +26,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 APERTURE            C        C         R    PSA,BOA,ANY
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_trace.tpn
+++ b/crds/hst/tpns/cos_trace.tpn
@@ -16,7 +16,7 @@ INSTRUME            H        C         R    COS
 FILETYPE            H        C         R    "1D SPECTRAL TRACE TABLE"
 DETECTOR            H        C         R    FUV
 OBSTYPE             H        C         R    SPECTROSCOPIC
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 VCALCOS             H        C         R
 USEAFTER            H        C         R    &SYBDATE
 PEDIGREE            H        C         R    &PEDIGREE

--- a/crds/hst/tpns/cos_trace_ld.tpn
+++ b/crds/hst/tpns/cos_trace_ld.tpn
@@ -25,7 +25,7 @@ OPT_ELEM            C        C         R    G130M,G160M,G140L
 CENWAVE             C        I         R    800,1222,1223,1291,1300,1309,1318,1327,\
                                             1533,1577,1589,1600,1611,1623,\
                                             1105,1230,1280,1055,1096
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 APERTURE            C        C         R    PSA,BOA
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE
 OBSERVATION_END_DATE    C    C         O    &SYBDATE

--- a/crds/hst/tpns/cos_wcp.tpn
+++ b/crds/hst/tpns/cos_wcp.tpn
@@ -17,5 +17,5 @@ PEDIGREE            H        C         R    &PEDIGREE
 DESCRIP             H        C         R
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 N_SIGMA             C        R         O

--- a/crds/hst/tpns/cos_wcp_ld.tpn
+++ b/crds/hst/tpns/cos_wcp_ld.tpn
@@ -18,7 +18,7 @@ OBSTYPE             C        C         R    SPECTROSCOPIC
 PEDIGREE            C        C         R    INFLIGHT,GROUND,MODEL,DUMMY
 OPT_ELEM            C        C         R    G130M,G160M,G140L,\
           G185M,G225M,G285M,G230L
-LIFE_ADJ            H        I         R    -1,0,1,-11,2,3,4,5,6
+LIFE_ADJ            H        I         R
 N_SIGMA             C        R         O
 CHANGE_LEVEL        C        C         R    TRIVIAL,MODERATE,SEVERE
 OBSERVATION_BEGIN_DATE  C    C         O    &SYBDATE


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1624](https://jira.stsci.edu/browse/CCD-1624)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR updates the COS tpn files to remove the list of allowed values for the LIFE_ADJ keyword.  This means there is no need to update these files every time the COS team introduces a new lifetime position.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

