### PR TITLE
remove maker_utils usage from mkdata test script

### DIFF
--- a/test/data/roman/mkdata.py
+++ b/test/data/roman/mkdata.py
@@ -10,18 +10,15 @@ Execute with
 import os
 
 import roman_datamodels as rdm
-import roman_datamodels.maker_utils as mu
 
 
 def mkdata():
     """Create FlatRefModels with various bad settings"""
 
     # Good model
-    flatref = mu.mk_datamodel(rdm.datamodels.FlatRefModel, shape=(2, 2),
-                              meta={'instrument': {'name': 'WFI', 'detector': 'WFI16', 'optical_element': 'F158'}})
+    flatref = rdm.datamodels.FlatRefModel.create_fake_data(shape=(2, 2), defaults={'meta': {'instrument': {'name': 'WFI', 'detector': 'WFI16', 'optical_element': 'F158'}}})
     flatref.save('roman_wfi16_f158_flat_small.asdf')
-    flatrefgrism = mu.mk_datamodel(rdm.datamodels.FlatRefModel, shape=(2, 2),
-                              meta={'instrument': {'name': 'WFI', 'detector': 'WFI16', 'optical_element': 'GRISM'}})
+    flatrefgrism = rdm.datamodels.FlatRefModel.create_fake_data(shape=(2, 2), defaults={'meta': {'instrument': {'name': 'WFI', 'detector': 'WFI16', 'optical_element': 'GRISM'}}})
     flatrefgrism.save('roman_wfi16_grism_flat_small.asdf')
 
     # Turn off validations so we can make bad decisions


### PR DESCRIPTION
roman_datamodels is deprecating maker_utils: https://github.com/spacetelescope/roman_datamodels/issues/525

This PR updates the test file generation script `test/data/roman/mkdata.py` to use the new `create_fake_data` API (added in roman_datamodels [0.26.0](https://github.com/spacetelescope/roman_datamodels/releases/tag/0.26.0)).

I don't believe this script is run as part of any CI tests. I manually ran the updated script and it succeeded. Let me know if further testing is helpful.

Given the changes in this PR I'd like to add a "no-changelog" label but am unable to do so.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

