### PR TITLE
use public import location for ValidationWarning

### DIFF
--- a/crds/io/abstract.py
+++ b/crds/io/abstract.py
@@ -46,7 +46,7 @@ def hijack_warnings(func):
             warnings.showwarning = hijacked_showwarning
             warnings.simplefilter("always", AstropyUserWarning)
             try:
-                from stdatamodels.validate import ValidationWarning
+                from stdatamodels.exceptions import ValidationWarning
             except:
                 log.verbose_warning(
                     "stdatamodels ValidationWarning import failed.  "

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -11,7 +11,7 @@ import re
 import warnings
 
 from asdf.tags.core import NDArrayType
-from stdatamodels.validate import ValidationWarning
+from stdatamodels.exceptions import ValidationWarning
 
 # =======================================================================
 


### PR DESCRIPTION
Change `ValidationWarning` import from stdatamodels from `stdatamodels.validate` (which is undocumented) to the documented and public `stdatamodels.exceptions`.

Let me know if you think this needs a changelog entry.

FWIW stdatamodels is working on clarifying some API (making private modules `_` prefixed). See https://github.com/spacetelescope/stdatamodels/issues/535
While search CRDS I found some tests that check for exact strings like the following:
https://github.com/spacetelescope/crds/blob/79f90eb6d483d2c604cd6a8642e47429d381c467/test/certify/test_certify.py#L619
These will fail when `util` is renamed to `_util` (one of the planned changes). That isn't addressed in this PR and given the test specificity can't be addressed until it starts to fail.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

