### PR TITLE
roman/s3-script-updates

### DIFF
--- a/changes/1152.aws.rst
+++ b/changes/1152.aws.rst
@@ -1,1 +1,0 @@
-Raise import error if aws deps not installed

--- a/changes/1152.aws.rst
+++ b/changes/1152.aws.rst
@@ -1,0 +1,1 @@
+Raise import error if aws deps not installed

--- a/changes/1154.roman.rst
+++ b/changes/1154.roman.rst
@@ -1,0 +1,1 @@
+improved crds_s3_get script for roman pipeline

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -1573,6 +1573,8 @@ OBSERVATORY = StrConfigItem("CRDS_OBSERVATORY", None,
     lower=True
 )
 
+S3_BUCKET = StrConfigItem("CRDS_S3_BUCKET", None, "S3 bucket from which to download CRDS references and mappings.", lower=True)
+
 # -------------------------------------------------------------------------------------
 def get_uri(filename):
     """Return an appropriate s3:// or https:// URI for the specified filename based

--- a/documentation/crds_users_guide/source/environment.rst
+++ b/documentation/crds_users_guide/source/environment.rst
@@ -290,38 +290,60 @@ crds.getreferences() API function.
 AWS
 ---
 
-The CRDS client can be configured to read files from Amazon's S3 service.  The STScI AWS environment
-currently hosts files in the following buckets:
+The CRDS client can be configured to read files from Amazon's S3 service. **NOTE** Your compute environment must be configured with AWS credentials that have been granted access to the bucket. The STScI AWS environment currently hosts files in the following buckets:
 
-+-----------------+-----------------------+
-| Environment     | S3 Bucket Name        |
-+=================+=======================+
-| HST OPS         | hst-crds-cache-ops    |
-+-----------------+-----------------------+
-| HST TEST        | hst-crds-cache-test   |
-+-----------------+-----------------------+
-| ROMAN TEST†     | roman-crds-cache-test |
-+-----------------+-----------------------+
++-----------------+-----------------------+------------------+
+| Environment     | S3 Bucket Name        | S3 Prefix        |
++=================+=======================+==================+
+| HST OPS         | hst-crds-cache-ops    |                  |
++-----------------+-----------------------+------------------+
+| HST TEST        | hst-crds-cache-test   |                  |
++-----------------+-----------------------+------------------+
+| ROMAN OPS       | stpubdata             | /roman/crds      | ø
++-----------------+-----------------------+------------------+
+| ROMAN TEST      | stpubdata-tst         | /roman/crds      |
++-----------------+-----------------------+------------------+
 
-† As of this writing, Roman crds cache on AWS is not yet available.
+ø Roman Ops CRDS cache is hosted in the publicly-accessible AWS Open Data bucket so any valid AWS credentials can be used.
 
-The S3 buckets contain only recent contexts.  They also exclude mapping files, so the client must be
-configured to load the context's rules from a pickle file.  Here is an example configuration for the
-HST OPS bucket:
+.. tabs::
 
-  .. code-block:: bash
-      
-      $ export CRDS_CONFIG_URI=s3://hst-crds-cache-ops/config/hst/
-      $ export CRDS_DOWNLOAD_MODE=plugin
-      $ export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
-      $ export CRDS_PATH=/path/to/local/cache
-      $ export CRDS_PICKLE_URI=s3://hst-crds-cache-ops/pickles/hst/
-      $ export CRDS_REFERENCE_URI=s3://hst-crds-cache-ops/references/hst/
-      $ export CRDS_SERVER_URL=https://hst-crds-serverless.stsci.edu
-      $ export CRDS_USE_PICKLED_CONTEXTS=1
+   .. group-tab:: HST
 
-**NOTE** Your compute environment must be configured with AWS credentials that have been granted access
-to the bucket.
+    The S3 buckets for HST exclude mapping files, so the client must be configured to load the context's rules from a pickle file.  
+    Here is an example configuration for the HST OPS bucket:
+
+       .. code-block:: bash
+        
+        $ export CRDS_CONFIG_URI=s3://hst-crds-cache-ops/config/hst/
+        $ export CRDS_DOWNLOAD_MODE=plugin
+        $ export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} -d ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
+        $ export CRDS_PATH=/path/to/local/cache
+        $ export CRDS_PICKLE_URI=s3://hst-crds-cache-ops/pickles/hst/
+        $ export CRDS_REFERENCE_URI=s3://hst-crds-cache-ops/references/hst/
+        $ export CRDS_SERVER_URL=https://hst-crds-serverless.stsci.edu
+        $ export CRDS_USE_PICKLED_CONTEXTS=1
+
+   .. group-tab:: ROMAN
+
+    The s3 buckets for Roman only contain mappings and references from the last 5 contexts. The CRDS cache for Roman Ops is publicly accessible in the Open Data bucket
+
+       .. code-block:: bash
+
+           # Standard environment variables always required
+           $ export CRDS_SERVER_URL=https://roman-crds-serverless.stsci.edu
+           $ export CRDS_PATH=path/to/local/cache
+
+           # Extra vars needed for s3
+           $ export CRDS_S3_ENABLED=1
+           $ export CRDS_S3_BUCKET=stpubdata
+           $ export CRDS_DOWNLOAD_MODE=plugin
+           $ export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${FILENAME} -d ${OUTPUT_PATH} -s ${FILE_SIZE} -c ${FILE_SHA1SUM}'
+           
+           # Run the crds_s3_get script
+           $ crds_s3_get roman_0088.pmap
+
+
 
 Advanced Environment
 --------------------

--- a/envs/s3.sh
+++ b/envs/s3.sh
@@ -1,46 +1,13 @@
-#!/bin/bash
-observatory=${1:-"roman"}
-crds_cache=${2:-"${HOME}/crds_cache"}
-test=${3:-""}
-pickles=${4:-0}
-
-export CRDS_PATH=$crds_cache
-if [[ -z $CRDS_OBSERVATORY ]]; then
-    export CRDS_OBSERVATORY=$observatory
-fi
-export CRDS_SERVER_URL="https://${CRDS_OBSERVATORY}-crds-serverless.stsci.edu"
+export CRDS_SERVER_URL="https://roman-crds-serverless.stsci.edu"
+export CRDS_PATH=${HOME}/crds_cache
 export CRDS_S3_ENABLED=1
 export CRDS_S3_RETURN_URI=0
-
-if [[ "${CRDS_OBSERVATORY}" == "roman" ]]; then
-    export CRDS_S3_PREFIX=/roman/crds
-    s3_bucket=stpubdata
-    tsfx="-tst"
-    sfx=""
-else
-    export CRDS_S3_PREFIX=""
-    s3_bucket=hst-crds-cache
-    tsfx="-test"
-    sfx="-ops"
-fi
-
-if [[ -z $test ]]; then
-    export CRDS_S3_BUCKET="${s3_bucket}${sfx}"
-else
-    export CRDS_S3_BUCKET="${s3_bucket}${tsfx}"
-fi
-
-export CRDS_MAPPING_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/${CRDS_OBSERVATORY}
-export CRDS_REFERENCE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/${CRDS_OBSERVATORY}
-export CRDS_CONFIG_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/${CRDS_OBSERVATORY}
-
-# To use pickled contexts,  set CRDS_S3_ENABLED=0 and CRDS_USE_PICKLED_CONTEXTS=1
-if [[ $pickles -lt 0 ]]; then
-    export CRDS_USE_PICKLED_CONTEXTS=0
-    export CRDS_PICKLE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/pickles/${CRDS_OBSERVATORY}
-
-fi
-
+export CRDS_S3_BUCKET=stpubdata
+export CRDS_S3_PREFIX=/roman/crds
+export CRDS_MAPPING_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/roman
+export CRDS_REFERENCE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/roman
+export CRDS_CONFIG_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/roman
+export CRDS_USE_PICKLED_CONTEXTS=0
+export CRDS_PICKLE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/pickles/${CRDS_OBSERVATORY}
 export CRDS_DOWNLOAD_MODE=plugin
-# export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
 export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${FILENAME} -d ${OUTPUT_PATH} -s ${FILE_SIZE} -c ${FILE_SHA1SUM}'

--- a/envs/s3.sh
+++ b/envs/s3.sh
@@ -1,19 +1,46 @@
-# export CRDS_MAPPING_URL=https://s3.us-east-1.amazonaws.com/account/crds_cache/mappings/jwst
-# export CRDS_REFERENCE_URL=https://s3.us-east-1.amazonaws.com/account/crds_cache/references/jwst
+#!/bin/bash
+observatory=${1:-"roman"}
+crds_cache=${2:-"${HOME}/crds_cache"}
+test=${3:-""}
+pickles=${4:-0}
 
-export CRDS_SERVER_URL=https://jwst-serverless.stsci.edu
-export CRDS_PATH=$HOME/crds_cache
-
+export CRDS_PATH=$crds_cache
+if [[ -z $CRDS_OBSERVATORY ]]; then
+    export CRDS_OBSERVATORY=$observatory
+fi
+export CRDS_SERVER_URL="https://${CRDS_OBSERVATORY}-crds-serverless.stsci.edu"
 export CRDS_S3_ENABLED=1
 export CRDS_S3_RETURN_URI=0
-export CRDS_MAPPING_URI=s3://account/crds_cache/mappings/jwst
-export CRDS_REFERENCE_URI=s3://account/crds_cache/references/jwst
-# export CRDS_REFERENCE_URI=https://s3.us-east-1.amazonaws.com/account/crds_cache/references/jwst
-export CRDS_CONFIG_URI=s3://account/crds_cache/config/jwst
+
+if [[ "${CRDS_OBSERVATORY}" == "roman" ]]; then
+    export CRDS_S3_PREFIX=/roman/crds
+    s3_bucket=stpubdata
+    tsfx="-tst"
+    sfx=""
+else
+    export CRDS_S3_PREFIX=""
+    s3_bucket=hst-crds-cache
+    tsfx="-test"
+    sfx="-ops"
+fi
+
+if [[ -z $test ]]; then
+    export CRDS_S3_BUCKET="${s3_bucket}${sfx}"
+else
+    export CRDS_S3_BUCKET="${s3_bucket}${tsfx}"
+fi
+
+export CRDS_MAPPING_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/${CRDS_OBSERVATORY}
+export CRDS_REFERENCE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/${CRDS_OBSERVATORY}
+export CRDS_CONFIG_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/${CRDS_OBSERVATORY}
 
 # To use pickled contexts,  set CRDS_S3_ENABLED=0 and CRDS_USE_PICKLED_CONTEXTS=1
-export CRDS_USE_PICKLED_CONTEXTS=0
-export CRDS_PICKLE_URI=s3://account/crds_cache/pickles/jwst
+if [[ $pickles -lt 0 ]]; then
+    export CRDS_USE_PICKLED_CONTEXTS=0
+    export CRDS_PICKLE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/pickles/${CRDS_OBSERVATORY}
+
+fi
 
 export CRDS_DOWNLOAD_MODE=plugin
-export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
+# export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
+export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${FILENAME} -d ${OUTPUT_PATH} -s ${FILE_SIZE} -c ${FILE_SHA1SUM}'

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -20,7 +20,8 @@ import time
 import sys
 
 from crds.core.utils import checksum
-
+from crds.client.api import get_default_observatory
+from crds.core import config 
 
 BAD_SIZE_STATUS = 10
 BAD_CHECKSUM_STATUS = 11
@@ -35,15 +36,47 @@ except ImportError:
 def check_aws_imports():
     return boto3 is not None
 
+
+def create_s3_path(s3_prefix : str, kind : str, fname : str, obs: str) -> str:
+    """Creates an s3 object uri string starting with s3_prefix and following standard crds cache directory structure.
+    """
+    kind = f"/{kind}" if s3_prefix else kind
+    return f"{s3_prefix.rstrip('/')}{kind}/{obs}/{fname}"
+
+
+def format_uris(**kwargs):
+    source, destination = kwargs.pop("source"), kwargs.pop("destination")
+    fname = source.split("/")[-1]
+    kind = "mappings" if fname.endswith("map") else "references" # assumes only refs and mappings, not config files
+    if not source.startswith("s3"):
+        s3_bucket = os.environ.get("CRDS_S3_BUCKET")
+        if not s3_bucket:
+            print("Please set the CRDS_S3_BUCKET environment variable or pass the full S3 URI into `source` arg")
+            sys.exit(1)
+        obs = get_default_observatory()
+        s3_pfx = "/roman/crds" if obs == "roman" else ""
+        s3_key = create_s3_path(s3_pfx, kind, fname, obs)
+        s3_uri = f"s3://{s3_bucket}/{s3_key.lstrip('/')}"
+    else:
+        s3_uri = source
+
+    crds_path = os.environ.get("CRDS_PATH", config.get_crds_path())
+    if os.path.isdir(destination):
+        if config.get_crds_ref_subdir_mode(obs) != "flat":
+            config.set_crds_ref_subdir_mode("flat", obs)
+        dest = f"{crds_path}/{kind}/{obs}/{fname}" if destination == crds_path else f"{destination.rstrip('/')}/{fname}"
+    else:
+        dest = destination
+   
+    return s3_uri, dest
+
+
 def parse_args():
     parser = argparse.ArgumentParser("crds_s3_get", description="S3 download plugin for CRDS")
-
-    parser.add_argument("source", help="Source S3 URI")
-    parser.add_argument("destination", help="Destination path on local filesystem")
-    parser.add_argument("--file-size", help="Expected file size in bytes", type=int, default=None)
-    parser.add_argument("--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
-    parser.add_argument("--max-retries", help="Maximum number of retries on download failure", type=int, default=3)
-
+    parser.add_argument("source", help="filename to download or full S3 URI to the file")
+    parser.add_argument("-d", "--destination", help="Destination path on local filesystem", default=os.environ.get("CRDS_PATH"))
+    parser.add_argument("-s", "--file-size", help="Expected file size in bytes", type=int, default=None)
+    parser.add_argument("-c", "--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
     return parser.parse_args()
 
 
@@ -53,12 +86,15 @@ def main():
             "You must install awscli and boto3 for the crds_s3_get script to work. "
             "AWS dependencies for CRDS can be installed via `pip install crds[aws]`"
         )
+
     args = parse_args()
+    kwargs = {**vars(args)}
+    src, dest = format_uris(**kwargs)
 
     result = subprocess.run([
         "aws", "s3", "cp", "--no-progress",
-        args.source,
-        args.destination,
+        src,
+        dest,
     ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
 
     if result.returncode != 0:

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -42,6 +42,7 @@ def parse_args():
     parser.add_argument("destination", help="Destination path on local filesystem")
     parser.add_argument("--file-size", help="Expected file size in bytes", type=int, default=None)
     parser.add_argument("--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
+    parser.add_argument("--max-retries", help="Maximum number of retries on download failure", type=int, default=3)
 
     return parser.parse_args()
 

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -4,6 +4,7 @@ S3 download plugin for CRDS.
 
 Exit status:
 0 - success
+1 - Invalid arg or missing environment vars
 10 - failed file size verification
 11 - failed checksum verification
 other codes - aws-cli failure.  See https://docs.aws.amazon.com/cli/latest/topic/return-codes.html
@@ -36,7 +37,6 @@ except ImportError:
 def check_aws_imports():
     return boto3 is not None
 
-
 def create_s3_path(s3_prefix : str, kind : str, fname : str, obs: str) -> str:
     """Creates an s3 object uri string starting with s3_prefix and following standard crds cache directory structure.
     """
@@ -44,16 +44,33 @@ def create_s3_path(s3_prefix : str, kind : str, fname : str, obs: str) -> str:
     return f"{s3_prefix.rstrip('/')}{kind}/{obs}/{fname}"
 
 
+def get_file_attrs(fname):
+    pfx = fname.split("_")[0]
+    if fname.endswith("map"):
+        kind = "mappings"
+        obs = config.mapping_to_observatory(fname)
+        instr = ""
+    elif fname.split(".")[-1] in ["asdf", "fits"]:
+        kind = "references" # assumes only refs and mappings, not config files
+        obs = pfx if pfx in ["roman", "jwst"] else "hst"
+        instr = str(os.path.basename(os.path.dirname(config.locate_reference(fname, obs))))
+    else:
+        print(f"Unrecognized file type for `source`: {fname} - valid types are mappings (.pmap, .imap, .rmap) and references (.asdf, .fits)")
+        sys.exit(1)
+    return obs, instr, kind
+
+
 def format_uris(**kwargs):
     source, destination = kwargs.pop("source"), kwargs.pop("destination")
     fname = source.split("/")[-1]
-    kind = "mappings" if fname.endswith("map") else "references" # assumes only refs and mappings, not config files
+    obs, instr, kind = get_file_attrs(fname)
+    
     if not source.startswith("s3"):
         s3_bucket = os.environ.get("CRDS_S3_BUCKET")
         if not s3_bucket:
             print("Please set the CRDS_S3_BUCKET environment variable or pass the full S3 URI into `source` arg")
             sys.exit(1)
-        obs = get_default_observatory()
+        
         s3_pfx = "/roman/crds" if obs == "roman" else ""
         s3_key = create_s3_path(s3_pfx, kind, fname, obs)
         s3_uri = f"s3://{s3_bucket}/{s3_key.lstrip('/')}"
@@ -62,21 +79,25 @@ def format_uris(**kwargs):
 
     crds_path = os.environ.get("CRDS_PATH", config.get_crds_path())
     if os.path.isdir(destination):
-        if config.get_crds_ref_subdir_mode(obs) != "flat":
-            config.set_crds_ref_subdir_mode("flat", obs)
-        dest = f"{crds_path}/{kind}/{obs}/{fname}" if destination == crds_path else f"{destination.rstrip('/')}/{fname}"
+        if instr and config.get_crds_ref_subdir_mode(obs) == "instrument":
+            instr += "/"
+        else:
+            instr = ""
+        dest = f"{crds_path}/{kind}/{obs}/{instr}{fname}" if destination == crds_path else f"{destination.rstrip('/')}/{fname}"
     else:
         dest = destination
-   
+    
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
     return s3_uri, dest
 
 
 def parse_args():
     parser = argparse.ArgumentParser("crds_s3_get", description="S3 download plugin for CRDS")
     parser.add_argument("source", help="filename to download or full S3 URI to the file")
-    parser.add_argument("-d", "--destination", help="Destination path on local filesystem", default=os.environ.get("CRDS_PATH"))
+    parser.add_argument("-d", "--destination", help="Destination path on local filesystem", default=os.environ.get("CRDS_PATH", None))
     parser.add_argument("-s", "--file-size", help="Expected file size in bytes", type=int, default=None)
     parser.add_argument("-c", "--file-sha1sum", help="Expected file SHA-1 checksum", default=None)
+    parser.add_argument("-r", "--max-retries", help="Maximum number of retries on download failure", type=int, default=3)
     return parser.parse_args()
 
 
@@ -86,10 +107,16 @@ def main():
             "You must install awscli and boto3 for the crds_s3_get script to work. "
             "AWS dependencies for CRDS can be installed via `pip install crds[aws]`"
         )
-
     args = parse_args()
+    if args.destination is None:
+        print("Destination path defaults to CRDS_PATH but no value was set. \n" \
+        "Please set the CRDS_PATH variable e.g. `export CRDS_PATH=path/to/local/cache` \n" \
+        "or pass an absolute path on local disk where you want the file to be downloaded: \n" \
+        "`crds_s3_get myfile -d abs/path/to/download")
+        sys.exit(1)
     kwargs = {**vars(args)}
     src, dest = format_uris(**kwargs)
+    
 
     result = subprocess.run([
         "aws", "s3", "cp", "--no-progress",

--- a/scripts/crds_s3_set
+++ b/scripts/crds_s3_set
@@ -1,0 +1,57 @@
+#!/bin/bash
+###### examples: 
+# $source crds_s3_set roman path/to/local/cache
+# $source crds_s3_set $CRDS_PATH
+# use test bucket: $ source crds_s3_set roman $CRDS_PATH 1
+
+observatory=${1:-"roman"}
+crds_cache=${2:-"$HOME/crds_cache"}
+test=${3:-""}
+pickles=${4:-0}
+
+if [[ -z ${CRDS_PATH} ]]; then
+    export CRDS_PATH=$crds_cache
+fi
+if [[ ! -d $CRDS_PATH ]]; then
+    mkdir -p $CRDS_PATH
+fi
+
+if [[ -z $CRDS_OBSERVATORY ]]; then
+    export CRDS_OBSERVATORY=$observatory
+fi
+export CRDS_SERVER_URL="https://${CRDS_OBSERVATORY}-crds-serverless.stsci.edu"
+export CRDS_S3_ENABLED=1
+export CRDS_S3_RETURN_URI=0
+
+if [[ "${CRDS_OBSERVATORY}" == "roman" ]]; then
+    export CRDS_S3_PREFIX=/roman/crds
+    s3_bucket=stpubdata
+    tsfx="-tst"
+    sfx=""
+else
+    export CRDS_S3_PREFIX=""
+    s3_bucket=hst-crds-cache
+    tsfx="-test"
+    sfx="-ops"
+fi
+
+if [[ -z $test ]]; then
+    export CRDS_S3_BUCKET="${s3_bucket}${sfx}"
+else
+    export CRDS_S3_BUCKET="${s3_bucket}${tsfx}"
+fi
+
+export CRDS_MAPPING_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/${CRDS_OBSERVATORY}
+export CRDS_REFERENCE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/${CRDS_OBSERVATORY}
+export CRDS_CONFIG_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/${CRDS_OBSERVATORY}
+
+# To use pickled contexts,  set CRDS_S3_ENABLED=0 and CRDS_USE_PICKLED_CONTEXTS=1
+if [[ $pickles -lt 0 ]]; then
+    export CRDS_USE_PICKLED_CONTEXTS=0
+    export CRDS_PICKLE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/pickles/${CRDS_OBSERVATORY}
+
+fi
+
+export CRDS_DOWNLOAD_MODE=plugin
+# export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
+export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${FILENAME} -d ${OUTPUT_PATH} -s ${FILE_SIZE} -c ${FILE_SHA1SUM}'


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1636](https://jira.stsci.edu/browse/CCD-1636)

<!-- describe the changes comprising this PR here -->
This PR improves the crds_s3_get script by allowing the user to pass in just the filename (mapping or reference file). The script will determine the exact s3 URI based on the observatory and other environment variables. The destination arg is now an optional argument, and defaults to CRDS_PATH env var. It is still possible to pass in the full s3 uri and absolute path for download destination; these changes allow for a much simpler invocation, e.g. "crds_s3_get roman_0088.pmap". 

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

