### PR TITLE
roman/s3-mode

### DIFF
--- a/changes/1159.roman.rst
+++ b/changes/1159.roman.rst
@@ -1,0 +1,1 @@
+Updated prefixes and simplified cfg setup

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -486,7 +486,13 @@ def _get_server_info():
     """
     config_uri = config.get_uri("server_config")
     try:
-        if config_uri != "none":
+        if config_uri.startswith("s3://"):
+            log.verbose(f"Loading config from URI '{config_uri}'.")
+            content = utils.get_uri_content(config_uri)
+            info = ast.literal_eval(content)
+            info["status"] = "s3"
+            info["connected"] = True
+        elif config_uri != "none":
             log.verbose(f"Loading config from URI '{config_uri}'.")
             content = utils.get_uri_content(config_uri)
             info = ast.literal_eval(content)

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -625,7 +625,7 @@ def check_crds_ref_subdir_mode(mode):
 CRDS_MODE = StrConfigItem("CRDS_MODE", default="auto",
     comment="""Selects where bestrefs are performed, locally, remotely (on the CRDS server),
     or automatically chosen by comparing client version to server version.""",
-    valid_values=["local", "remote", "auto"])
+    valid_values=["local", "remote", "auto", "s3"])
 
 def get_crds_processing_mode():
     """Return the preferred location for computing best references when

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -518,7 +518,7 @@ class ConfigInfo(utils.Struct):
 
         returns 'local' or 'remote'
         """
-        mode = config.get_crds_processing_mode()  # local, remote, auto
+        mode = config.get_crds_processing_mode()  # local, remote, auto, s3
         if mode == "auto":
             eff_mode = "remote" if (self.connected and hasattr(self, "force_remote_mode") and self.force_remote_mode) else "local"
         else:
@@ -572,7 +572,7 @@ def update_config_info(observatory):
     if config.writable_cache_or_verbose("skipping config update."):
         info = get_config_info(observatory)
         if info.connected and info.effective_mode == "local":
-            log.verbose("Connected to server and computing locally, updating CRDS cache config and operational context.")
+            log.verbose("Connected to server and computing locally, updating CRDS cache config and latest context.")
             cache_server_info(info, observatory)  # save locally
         else:
             log.verbose("Not connected to CRDS server or operating in 'remote' mode,  skipping cache config update.", verbosity=65)

--- a/crds/core/utils.py
+++ b/crds/core/utils.py
@@ -699,6 +699,12 @@ def _get_s3_uri_content(s3_uri, mode):
     s3 = boto3.resource("s3")
     obj = s3.Object(bucket_name, key)
     binary = obj.get()["Body"].read()
+    if config.get_cache_readonly() is False:
+        try:
+            import subprocess
+            p = subprocess.run(["crds_s3_get", s3_uri], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+        except Exception as e:
+            print(p.stderr)
     if mode == "text":
         text = binary.decode("utf-8")
         return text

--- a/scripts/crds_s3_get
+++ b/scripts/crds_s3_get
@@ -37,46 +37,13 @@ except ImportError:
 def check_aws_imports():
     return boto3 is not None
 
-def create_s3_path(s3_prefix : str, kind : str, fname : str, obs: str) -> str:
-    """Creates an s3 object uri string starting with s3_prefix and following standard crds cache directory structure.
-    """
-    kind = f"/{kind}" if s3_prefix else kind
-    return f"{s3_prefix.rstrip('/')}{kind}/{obs}/{fname}"
-
-
-def get_file_attrs(fname):
-    pfx = fname.split("_")[0]
-    if fname.endswith("map"):
-        kind = "mappings"
-        obs = config.mapping_to_observatory(fname)
-        instr = ""
-    elif fname.split(".")[-1] in ["asdf", "fits"]:
-        kind = "references" # assumes only refs and mappings, not config files
-        obs = pfx if pfx in ["roman", "jwst"] else "hst"
-        instr = str(os.path.basename(os.path.dirname(config.locate_reference(fname, obs))))
-    else:
-        print(f"Unrecognized file type for `source`: {fname} - valid types are mappings (.pmap, .imap, .rmap) and references (.asdf, .fits)")
-        sys.exit(1)
-    return obs, instr, kind
-
 
 def format_uris(**kwargs):
     source, destination = kwargs.pop("source"), kwargs.pop("destination")
     fname = source.split("/")[-1]
-    obs, instr, kind = get_file_attrs(fname)
-    
-    if not source.startswith("s3"):
-        s3_bucket = os.environ.get("CRDS_S3_BUCKET")
-        if not s3_bucket:
-            print("Please set the CRDS_S3_BUCKET environment variable or pass the full S3 URI into `source` arg")
-            sys.exit(1)
-        
-        s3_pfx = "/roman/crds" if obs == "roman" else ""
-        s3_key = create_s3_path(s3_pfx, kind, fname, obs)
-        s3_uri = f"s3://{s3_bucket}/{s3_key.lstrip('/')}"
-    else:
-        s3_uri = source
-
+    s3_uri = source if source.startswith("s3") else config.get_uri(fname)
+    obs, kind = s3_uri.split('/')[-2], s3_uri.split('/')[-3]
+    instr = "" if kind != "references" else str(os.path.basename(os.path.dirname(config.locate_reference(fname, obs))))
     crds_path = os.environ.get("CRDS_PATH", config.get_crds_path())
     if os.path.isdir(destination):
         if instr and config.get_crds_ref_subdir_mode(obs) == "instrument":
@@ -86,7 +53,6 @@ def format_uris(**kwargs):
         dest = f"{crds_path}/{kind}/{obs}/{instr}{fname}" if destination == crds_path else f"{destination.rstrip('/')}/{fname}"
     else:
         dest = destination
-    
     os.makedirs(os.path.dirname(dest), exist_ok=True)
     return s3_uri, dest
 

--- a/scripts/crds_s3_set
+++ b/scripts/crds_s3_set
@@ -1,57 +1,50 @@
 #!/bin/bash
-###### examples: 
-# $source crds_s3_set roman path/to/local/cache
-# $source crds_s3_set $CRDS_PATH
-# use test bucket: $ source crds_s3_set roman $CRDS_PATH 1
-
+#####
+# Sets environment variables required for configuring CRDS to use S3
+# NOTE: Setting CRDS_PATH prior to sourcing this script is recommended: $ export CRDS_PATH=path/to/my/cache
+# Usage: $ source crds_s3_set [observatory] [ops|int|test|dev]
+# Examples:
+# Roman ops (public) bucket: $ source crds_s3_set
+# Roman test bucket: $ source crds_s3_set roman [dev|test|int]
+# HST: $ source crds_s3_set hst [ops (default)|test]
+#####
+# Accepted args with default values
 observatory=${1:-"roman"}
-crds_cache=${2:-"$HOME/crds_cache"}
-test=${3:-""}
-pickles=${4:-0}
+env_pfx=${2:-"ops"}
 
-if [[ -z ${CRDS_PATH} ]]; then
-    export CRDS_PATH=$crds_cache
-fi
-if [[ ! -d $CRDS_PATH ]]; then
-    mkdir -p $CRDS_PATH
-fi
+# Set CRDS_PATH only if not already set
+: "${CRDS_PATH:=$HOME/crds_cache}"
+# Create directory if it doesn't exist
+[ ! -d "$CRDS_PATH" ] && mkdir -p "$CRDS_PATH"
 
-if [[ -z $CRDS_OBSERVATORY ]]; then
-    export CRDS_OBSERVATORY=$observatory
-fi
+# Set common environment variables
+export CRDS_OBSERVATORY=$observatory
 export CRDS_SERVER_URL="https://${CRDS_OBSERVATORY}-crds-serverless.stsci.edu"
 export CRDS_S3_ENABLED=1
 export CRDS_S3_RETURN_URI=0
+export CRDS_MODE="s3"
 
-if [[ "${CRDS_OBSERVATORY}" == "roman" ]]; then
-    export CRDS_S3_PREFIX=/roman/crds
-    s3_bucket=stpubdata
-    tsfx="-tst"
-    sfx=""
-else
-    export CRDS_S3_PREFIX=""
-    s3_bucket=hst-crds-cache
-    tsfx="-test"
-    sfx="-ops"
+# Determine bucket and prefix based on observatory and environment prefix
+if [[ "$CRDS_OBSERVATORY" == "roman" ]]; then
+    bucket="stpubdata"
+    pfx="/roman/crds"
+    if [[ "$env_pfx" != "ops" ]]; then
+        bucket+="-tst"
+        pfx+="/${env_pfx}"
+    fi
+else  # hst
+    pfx=""
+    bucket="hst-crds-cache-${env_pfx}"
 fi
 
-if [[ -z $test ]]; then
-    export CRDS_S3_BUCKET="${s3_bucket}${sfx}"
-else
-    export CRDS_S3_BUCKET="${s3_bucket}${tsfx}"
-fi
-
-export CRDS_MAPPING_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/${CRDS_OBSERVATORY}
-export CRDS_REFERENCE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/${CRDS_OBSERVATORY}
-export CRDS_CONFIG_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/${CRDS_OBSERVATORY}
-
-# To use pickled contexts,  set CRDS_S3_ENABLED=0 and CRDS_USE_PICKLED_CONTEXTS=1
-if [[ $pickles -lt 0 ]]; then
-    export CRDS_USE_PICKLED_CONTEXTS=0
-    export CRDS_PICKLE_URI=s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/pickles/${CRDS_OBSERVATORY}
-
-fi
-
+# Export the values
+export CRDS_PATH
+export CRDS_S3_BUCKET="$bucket"
+export CRDS_S3_PREFIX="$pfx"
+export CRDS_MAPPING_URI="s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/mappings/${CRDS_OBSERVATORY}"
+export CRDS_REFERENCE_URI="s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/references/${CRDS_OBSERVATORY}"
+export CRDS_CONFIG_URI="s3://${CRDS_S3_BUCKET}${CRDS_S3_PREFIX}/config/${CRDS_OBSERVATORY}"
 export CRDS_DOWNLOAD_MODE=plugin
-# export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${SOURCE_URL} ${OUTPUT_PATH} --file-size ${FILE_SIZE} --file-sha1sum ${FILE_SHA1SUM}'
-export CRDS_DOWNLOAD_PLUGIN='crds_s3_get ${FILENAME} -d ${OUTPUT_PATH} -s ${FILE_SIZE} -c ${FILE_SHA1SUM}'
+export CRDS_DOWNLOAD_PLUGIN="crds_s3_get \${FILENAME} -d \${OUTPUT_PATH} -s \${FILE_SIZE} -c \${FILE_SHA1SUM}"
+
+printenv | grep "^CRDS_"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1653](https://jira.stsci.edu/browse/CCD-1653)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
- Adds "s3" as a valid CRDS_MODE for running sync with s3 (enables aws users to retrieve config and mappings from s3 buckets using standard CRDS sync commands)
- Simplifies crds_s3_get script src and dest url formatting
- Updates the crds_s3_set env config setter script to use the new s3 prefixes in the Roman test bucket along with some other minor improvements and updates

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

