### PR TITLE
ga/main-replaces-master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "master"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     reviewers:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,14 @@
 name: CI
 
 on:
-  ## uncomment before merging to master once test suite is finalized
   push:
     branches:
-    - master
+    - main
     tags:
       - '*'
   pull_request:
     branches:
-    - master
+    - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           git push origin ${{ github.event.inputs.version }}
 
       - name: Create GitHub release (triggers publish-to-pypi workflow)
-        uses: zendesk/action-create-release@v1  # master
+        uses: zendesk/action-create-release@v1  # main
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
         with:


### PR DESCRIPTION
Replaces "master" with "main" in github actions. 

