### PR TITLE
Added SUBARRAY to nircam_photom.spec to remove duplicate warnings.

### DIFF
--- a/changes/1194.jwst.rst
+++ b/changes/1194.jwst.rst
@@ -1,0 +1,1 @@
+Added SUBARRAY to nircam_photom.spec

--- a/crds/jwst/specs/combined_specs.json
+++ b/crds/jwst/specs/combined_specs.json
@@ -4889,7 +4889,8 @@
             "unique_rowkeys":[
                 "FILTER",
                 "PUPIL",
-                "ORDER"
+                "ORDER",
+                "SUBARRAY"
             ]
         },
         "psfmask":{

--- a/crds/jwst/specs/nircam_photom.spec
+++ b/crds/jwst/specs/nircam_photom.spec
@@ -11,5 +11,5 @@
     'sha1sum' : '8b882aefccecf7de1ae321e78052f74cf84b164f',
     'suffix' : 'photom',
     'text_descr' : 'Absolute Calibration',
-    'unique_rowkeys': ('FILTER', 'PUPIL', 'ORDER'),
+    'unique_rowkeys': ('FILTER', 'PUPIL', 'ORDER', 'SUBARRAY'),
 }


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-1734](https://jira.stsci.edu/browse/CCD-1734)
<!-- describe the changes comprising this PR here -->
This PR addresses the fixing of some 100 or so warnings that would occur due to mismatching unique column identifiers. Certify now shows no errors.

<details><summary>news fragment change types...</summary>

- ``changes/1194.jwst.rst``: JWST reference files

</details>

