### PR TITLE
Added a check for serverless in the CRDS_SERVER_URL.

### DIFF
--- a/changes/1198.hst.rst
+++ b/changes/1198.hst.rst
@@ -1,0 +1,1 @@
+Added logic to check if serverless

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -472,7 +472,7 @@ def get_server_info():
 
 @utils.cached
 def get_download_metadata():
-    "Defer and cache decoding of download_metadata field of server info."""
+    """Defer and cache decoding of download_metadata field of server info."""
     info = get_server_info()
     return proxy.crds_decode(info["download_metadata"])
 
@@ -491,7 +491,10 @@ def _get_server_info():
             content = utils.get_uri_content(config_uri)
             info = ast.literal_eval(content)
             info["status"] = "s3"
-            info["connected"] = True
+            if "serverless" in get_crds_server(get_default_observatory()):
+                info["connected"] = False
+            else:
+                info["connected"] = True
         elif config_uri != "none":
             log.verbose(f"Loading config from URI '{config_uri}'.")
             content = utils.get_uri_content(config_uri)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [CCD-nnnn](https://jira.stsci.edu/browse/CCD-1739)

<!-- describe the changes comprising this PR here -->
This PR addresses an error encountered in HST when trying to sync while using a cloud path (starting with s3) but configured with CRDS_SERVER_URL set to https://hst-crds-serverless.stsci.edu/.

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
</details>

