### PR TITLE
CCD-1743: pass in header parameters to determine instrument

### DIFF
--- a/changes/1200.general.rst
+++ b/changes/1200.general.rst
@@ -1,0 +1,1 @@
+Pass in header parameters to determine instrument.

--- a/crds/client/api.py
+++ b/crds/client/api.py
@@ -706,11 +706,12 @@ def file_progress(activity, name, path, bytes, bytes_so_far, total_bytes, nth_fi
 class FileCacher:
     """FileCacher gets remote files with simple names into a local cache."""
 
-    def __init__(self, pipeline_context, ignore_cache=False, raise_exceptions=True):
+    def __init__(self, pipeline_context, ignore_cache=False, raise_exceptions=True, parameters=None):
         self.pipeline_context = pipeline_context
         self.observatory = self.observatory_from_context()
         self.ignore_cache = ignore_cache
         self.raise_exceptions = raise_exceptions
+        self.parameters = parameters
         self.info_map = {}
 
     def get_local_files(self, names):
@@ -759,7 +760,7 @@ class FileCacher:
 
     def locate(self, name):
         """Return the standard CRDS cache location for file `name`."""
-        return config.locate_file(name, observatory=self.observatory)
+        return config.locate_file(name, observatory=self.observatory, parameters=self.parameters)
 
     def catalog_file_size(self, name):
         """Return the size of file `name` based on the server catalog."""
@@ -999,7 +1000,7 @@ def cache_best_references(pipeline_context, header, ignore_cache=False, reftypes
     return local_paths
 
 
-def cache_references(pipeline_context, bestrefs, ignore_cache=False):
+def cache_references(pipeline_context, bestrefs, ignore_cache=False, parameters=None):
     """Given a CRDS context `pipeline_context` and `bestrefs` dictionary, download missing
     reference files and cache them on the local file system.
 
@@ -1012,7 +1013,7 @@ def cache_references(pipeline_context, bestrefs, ignore_cache=False):
     if config.S3_RETURN_URI:
         localrefs = {name: get_flex_uri(name) for name in wanted}
     else:
-        localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False).get_local_files(wanted)[0]
+        localrefs = FileCacher(pipeline_context, ignore_cache, raise_exceptions=False, parameters=parameters).get_local_files(wanted)[0]
 
     refs = _squash_unicode_in_bestrefs(bestrefs, localrefs)
 

--- a/crds/core/config.py
+++ b/crds/core/config.py
@@ -954,7 +954,7 @@ def get_path(filename, observatory):
     fullpath = locate_file(filename, observatory)
     return os.path.dirname(fullpath)
 
-def locate_file(filepath, observatory):
+def locate_file(filepath, observatory, parameters=None):
     """Returns CRDS cache path if `filepath` has no directory, otherwise `filepath` as-is.
 
    Cannot always determine CRDS cache location for hypothetical files if not
@@ -966,7 +966,7 @@ def locate_file(filepath, observatory):
     """
     if os.path.dirname(filepath):
         return filepath
-    return relocate_file(filepath, observatory)
+    return relocate_file(filepath, observatory, parameters=parameters)
 
 def pop_crds_uri(filepath):
     """Pop off crds:// from a filepath,  yielding a pathless filename."""
@@ -975,7 +975,7 @@ def pop_crds_uri(filepath):
         assert not os.path.dirname(filepath), "crds:// must prefix a filename with no path."
     return filepath
 
-def relocate_file(filepath, observatory):
+def relocate_file(filepath, observatory, parameters=None):
     """Returns path in CRDS cache where `filepath` would be relocated if it were
     copied into the CRDS cache.
 
@@ -989,7 +989,7 @@ def relocate_file(filepath, observatory):
     if is_mapping(filepath):
         return relocate_mapping(filepath, observatory)
     else:
-        return relocate_reference(filepath, observatory)
+        return relocate_reference(filepath, observatory, parameters=parameters)
 
 # ===========================================================================
 
@@ -1001,7 +1001,7 @@ def locate_reference(ref, observatory):
         return ref
     return relocate_reference(ref, observatory)
 
-def relocate_reference(ref, observatory):
+def relocate_reference(ref, observatory, parameters=None):
     """Returns CRDS cache location where `ref` would be copied if it
     was copied into the CRDS cache.  When `ref` specifies a path to an
     existing file, the contents of `ref` can be exploited to determine
@@ -1016,7 +1016,7 @@ def relocate_reference(ref, observatory):
         return os.path.join(get_crds_refpath(observatory), os.path.basename(ref))
     else:
         from crds.core import utils
-        return utils.get_locator_module(observatory).locate_file(ref)
+        return utils.get_locator_module(observatory).locate_file(ref, parameters=parameters)
 
 # ===========================================================================
 if os.path.exists("/tmp"):

--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -125,7 +125,7 @@ def getreferences(parameters, reftypes=None, context=None, ignore_cache=False,
     # Attempt to cache the recommended references,  which unlike dump_mappings
     # should work without network access if files are already cached.
     best_refs_paths = api.cache_references(
-        final_context, bestrefs, ignore_cache=ignore_cache)
+        final_context, bestrefs, ignore_cache=ignore_cache, parameters=parameters)
 
     return best_refs_paths
 

--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -595,15 +595,25 @@ def filekind_to_keyword(filekind):
     return filekind.upper()
 
 
-def locate_file(refname, mode=None):
+def locate_file(refname, mode=None, parameters=None):
     """Given a valid reffilename in CDBS or CRDS format,  return a cache path for the file.
     The aspect of this which is complicated is determining instrument and an instrument
     specific sub-directory for it based on the filename alone,  not the file contents.
     """
+    if parameters is None:
+        parameters = dict()
+    instrument = None
     try:
         instrument = instrument_from_refname(refname)
     except Exception:
-        instrument = get_reference_properties(refname)[1]
+        pass
+    if instrument is None:
+        try:
+            instrument = get_reference_properties(refname)[1]
+        except Exception:
+            pass
+    if instrument is None:
+        instrument = parameters.get('instrume', None)
     rootdir = locate_dir(instrument, mode)
     return  os.path.join(rootdir, os.path.basename(refname))
 

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -458,7 +458,7 @@ def filekind_to_keyword(filekind):
 def warn_filekind_once(filekind):
     log.warning("No apparent JWST cal code data models schema support for", log.srepr(filekind))
 
-def locate_file(refname, mode=None):
+def locate_file(refname, mode=None, parameters=None):
     """Given a valid reffilename in CDBS or CRDS format,  return a cache path for the file.
     The aspect of this which is complicated is determining instrument and an instrument
     specific sub-directory for it based on the filename alone,  not the file contents.
@@ -466,7 +466,9 @@ def locate_file(refname, mode=None):
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="jwst")
     if mode == "instrument":
-        instrument = utils.file_to_instrument(refname)
+        instrument = parameters.get('meta.instrument.name', None)
+        if instrument is None:
+            instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)
     elif mode == "flat":
         rootdir = config.get_crds_refpath("jwst")

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -633,7 +633,7 @@ def filekind_to_keyword(filekind):
     """
     raise NotImplementedError("filekind_to_keyword not implemented for Roman")
 
-def locate_file(refname, mode=None):
+def locate_file(refname, mode=None, parameters=None):
     """Given a valid reffilename in CDBS or CRDS format,  return a cache path for the file.
     The aspect of this which is complicated is determining instrument and an instrument
     specific sub-directory for it based on the filename alone,  not the file contents.
@@ -665,10 +665,14 @@ def locate_file(refname, mode=None):
     ValueError: Unhandled reference file location mode 'other'
 
     """
+    if parameters is None:
+        parameters = dict()
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="roman")
     if mode == "instrument":
-        instrument = utils.file_to_instrument(refname)
+        instrument = parameters.get('roman.meta.instrument.name', None)
+        if instrument is None:
+            instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)
     elif mode == "flat":
         rootdir = config.get_crds_refpath("roman")

--- a/crds/tobs/locate.py
+++ b/crds/tobs/locate.py
@@ -256,12 +256,17 @@ def filekind_to_keyword(filekind):
     """Return the FITS keyword at which a reference should be recorded."""
     return filekind.upper()
 
-def locate_file(refname, mode=None):
+def locate_file(refname, mode=None, parameters=None):
     """Given a valid reffilename in CDBS or CRDS format,  return a cache path for the file.
     The aspect of this which is complicated is determining instrument and an instrument
     specific sub-directory for it based on the filename alone,  not the file contents.
     """
-    _path,  _observatory, instrument, _filekind, _serial, _ext = get_reference_properties(refname)
+    try:
+        _path,  _observatory, instrument, _filekind, _serial, _ext = get_reference_properties(refname)
+    except Exception:
+        instrument = None
+        if parameters is not None:
+            instrument = parameters.get('instrume', None)
     rootdir = locate_dir(instrument, mode)
     return  os.path.join(rootdir, os.path.basename(refname))
 


### PR DESCRIPTION
This PR addresses an issue with how the `locate` function works. Currently, to determine a path to a reference file, at least for roman, the algorithm relies on the reference filename itself. This forces a file naming convention that, in principle, CRDS is not supposed to require. Failing that, there is an attempt made to open the reference file. This is odd in that the point of locate is that one does not know where the reference file is.

Design-wise, there is a major disconnect between determination of reference files, using the bestrefs functionality, and then determine where in the pmap/imap/rmap tree that reference file actually exists. The basic design flaw appears to be that bestrefs should return that whole mapping path, as opposed to just the reference file name. Resolving this issue appears at first site to require significant work. A new issue will be opened to deal with that.

In the meantime, as a straight-forward stopgap, the parameters used to determine the reference file are now passed in to the locate and its utility functions and is implemented in the Roman version. This gives access to the necessary information of how to recreate the mapping path to determine reference file location.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

