### PR TITLE
CCD-1743 Fix jwst none-dict issue and use generic header utility

### DIFF
--- a/crds/core/heavy_client.py
+++ b/crds/core/heavy_client.py
@@ -125,7 +125,7 @@ def getreferences(parameters, reftypes=None, context=None, ignore_cache=False,
     # Attempt to cache the recommended references,  which unlike dump_mappings
     # should work without network access if files are already cached.
     best_refs_paths = api.cache_references(
-        final_context, bestrefs, ignore_cache=ignore_cache, parameters=parameters)
+        final_context, bestrefs, ignore_cache=ignore_cache, parameters=check_parameters(parameters))
 
     return best_refs_paths
 

--- a/crds/hst/locate.py
+++ b/crds/hst/locate.py
@@ -613,7 +613,7 @@ def locate_file(refname, mode=None, parameters=None):
         except Exception:
             pass
     if instrument is None:
-        instrument = parameters.get('instrume', None)
+        instrument = utils.header_to_instrument(parameters)
     rootdir = locate_dir(instrument, mode)
     return  os.path.join(rootdir, os.path.basename(refname))
 

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -463,10 +463,12 @@ def locate_file(refname, mode=None, parameters=None):
     The aspect of this which is complicated is determining instrument and an instrument
     specific sub-directory for it based on the filename alone,  not the file contents.
     """
+    if parameters is None:
+        parameters = dict()
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="jwst")
     if mode == "instrument":
-        instrument = parameters.get('meta.instrument.name', None)
+        instrument = utils.header_to_instrument(parameters)
         if instrument is None:
             instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -468,8 +468,9 @@ def locate_file(refname, mode=None, parameters=None):
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="jwst")
     if mode == "instrument":
-        instrument = utils.header_to_instrument(parameters)
-        if instrument is None:
+        try:
+            instrument = utils.header_to_instrument(parameters)
+        except KeyError:
             instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)
     elif mode == "flat":

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -670,7 +670,7 @@ def locate_file(refname, mode=None, parameters=None):
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="roman")
     if mode == "instrument":
-        instrument = parameters.get('roman.meta.instrument.name', None)
+        instrument = utils.header_to_instrument(parameters)
         if instrument is None:
             instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)

--- a/crds/tobs/locate.py
+++ b/crds/tobs/locate.py
@@ -266,7 +266,7 @@ def locate_file(refname, mode=None, parameters=None):
     except Exception:
         instrument = None
         if parameters is not None:
-            instrument = parameters.get('instrume', None)
+            instrument = utils.header_to_instrument(parameters)
     rootdir = locate_dir(instrument, mode)
     return  os.path.join(rootdir, os.path.basename(refname))
 


### PR DESCRIPTION
Resolves (again) [CCD-1743](https://jira.stsci.edu/browse/CCD-1743)

This PR addresses an issue found during jwst regression testing with a missed default dict specification. Fixed here. Also updated the header access code to use the crds generic utility to get instrument from header parameters.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

