### PR TITLE
CCD-1754 Update logic for reference file location to include full local cache exploration and server queries

### DIFF
--- a/changes/1202.general.rst
+++ b/changes/1202.general.rst
@@ -1,0 +1,6 @@
+Bug fix to the jwst and roman reference file locate facility
+
+Note: Originating PR#1200 is a feature addition and
+should have bumped the minor version. Since this PR will
+actually generate a new minor version, a release note
+is required though this is just a bug fix.

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -15,6 +15,7 @@ from stdatamodels.exceptions import ValidationWarning
 
 # =======================================================================
 
+from crds import api
 from crds.core import rmap, config, utils, timestamp, log, exceptions
 from crds.certify import generic_tpn
 from crds import data_file
@@ -467,12 +468,35 @@ def locate_file(refname, mode=None, parameters=None):
         parameters = dict()
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="jwst")
+
     if mode == "instrument":
-        try:
-            instrument = utils.header_to_instrument(parameters)
-        except KeyError:
-            instrument = utils.file_to_instrument(refname)
-        rootdir = locate_dir(instrument, mode)
+
+        # Check if the file is already in the local cache
+        for instrument in INSTRUMENTS:
+            if instrument != 'all':
+                rootdir = locate_dir(instrument, mode)
+                if os.path.exists(os.path.join(rootdir, os.path.basename(refname))):
+                    break
+        else:
+            rootdir = None
+
+        # Not in local cache. Try various other methods.
+        if rootdir is None:
+            try:
+                instrument = utils.header_to_instrument(parameters)
+            except KeyError:
+                log.verbose('Cannot find instrument in header. Trying from file itself...', verbosity=80)
+                try:
+                    instrument = utils.file_to_instrument(refname)
+                except FileNotFoundError:
+                    log.verbose('Cannot find instrument from non-existent file.', verbosity=80)
+                    log.verbose('Attempt to contact server for meta information', verbosity=80)
+
+                    # If there is a server, get the instrument from there.
+                    instrument = api.get_file_info(api.get_default_context(observatory='roman'), os.path.basename(refname))['instrument']
+
+            rootdir = locate_dir(instrument, mode)
+
     elif mode == "flat":
         rootdir = config.get_crds_refpath("jwst")
     else:

--- a/crds/jwst/locate.py
+++ b/crds/jwst/locate.py
@@ -493,7 +493,7 @@ def locate_file(refname, mode=None, parameters=None):
                     log.verbose('Attempt to contact server for meta information', verbosity=80)
 
                     # If there is a server, get the instrument from there.
-                    instrument = api.get_file_info(api.get_default_context(observatory='roman'), os.path.basename(refname))['instrument']
+                    instrument = api.get_file_info(api.get_default_context(observatory='jwst'), os.path.basename(refname))['instrument']
 
             rootdir = locate_dir(instrument, mode)
 

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -670,8 +670,10 @@ def locate_file(refname, mode=None, parameters=None):
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="roman")
     if mode == "instrument":
-        instrument = utils.header_to_instrument(parameters)
-        if instrument is None:
+        try:
+            instrument = utils.header_to_instrument(parameters)
+        except KeyError:
+            log.verbose('Cannot find instrument in header. Trying from file itself...', verbosity=80)
             instrument = utils.file_to_instrument(refname)
         rootdir = locate_dir(instrument, mode)
     elif mode == "flat":

--- a/crds/roman/locate.py
+++ b/crds/roman/locate.py
@@ -24,6 +24,7 @@ from asdf.tags.core import NDArrayType
 
 # =======================================================================
 
+from crds import api
 from crds.core import rmap, config, utils, timestamp, log, exceptions
 from crds.certify import generic_tpn
 from crds import data_file
@@ -669,17 +670,40 @@ def locate_file(refname, mode=None, parameters=None):
         parameters = dict()
     if mode is  None:
         mode = config.get_crds_ref_subdir_mode(observatory="roman")
+
     if mode == "instrument":
-        try:
-            instrument = utils.header_to_instrument(parameters)
-        except KeyError:
-            log.verbose('Cannot find instrument in header. Trying from file itself...', verbosity=80)
-            instrument = utils.file_to_instrument(refname)
-        rootdir = locate_dir(instrument, mode)
+
+        # Check if the file is already in the local cache
+        for instrument in INSTRUMENTS:
+            if instrument != 'all':
+                rootdir = locate_dir(instrument, mode)
+                if os.path.exists(os.path.join(rootdir, os.path.basename(refname))):
+                    break
+        else:
+            rootdir = None
+
+        # Not in local cache. Try various other methods.
+        if rootdir is None:
+            try:
+                instrument = utils.header_to_instrument(parameters)
+            except KeyError:
+                log.verbose('Cannot find instrument in header. Trying from file itself...', verbosity=80)
+                try:
+                    instrument = utils.file_to_instrument(refname)
+                except FileNotFoundError:
+                    log.verbose('Cannot find instrument from non-existent file.', verbosity=80)
+                    log.verbose('Attempt to contact server for meta information', verbosity=80)
+
+                    # If there is a server, get the instrument from there.
+                    instrument = api.get_file_info(api.get_default_context(observatory='roman'), os.path.basename(refname))['instrument']
+
+            rootdir = locate_dir(instrument, mode)
+
     elif mode == "flat":
         rootdir = config.get_crds_refpath("roman")
     else:
         raise ValueError("Unhandled reference file location mode " + repr(mode))
+
     return  os.path.join(rootdir, os.path.basename(refname))
 
 def locate_dir(instrument, mode=None):


### PR DESCRIPTION
Resolves [CCD-1754](https://jira.stsci.edu/browse/CCD-1754)

This PR addresses a regression introduce by PR#1201, where syncing any references by name, i.e. the `--files` option, fails. The core issue is the disconnect between reference file retrieval, which can be just a file name, and where that file is in the CRDS database. The current logic was too simplistic and forced reference names into have a specific information in it.  This PR adds the ability to derive the needed information from potentially already-existing files in the local cache or a server if present.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

