### PR TITLE
simplify reusable contexts workflow to a GitHub Action for usage in downstream CI

### DIFF
--- a/.github/actions/contexts/action.yml
+++ b/.github/actions/contexts/action.yml
@@ -1,0 +1,73 @@
+name: crds-latest-contexts
+description: Retrieve latest context filenames for observatories using the Calibration Reference Data System (CRDS)
+branding:
+  icon: book-open
+  color: black
+
+inputs:
+  require_hst:
+    description: require response from Hubble Space Telescope CRDS server
+    required: false
+    default: "false"
+  require_jwst:
+    description: require response from James Webb Space Telescope CRDS server
+    required: false
+    default: "false"
+  require_roman:
+    description: require response from Nancy Grace Roman Space Telescope CRDS server
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - id: hst_crds
+      env:
+        OBSERVATORY: hst
+        CRDS_SERVER_URL: https://hst-crds.stsci.edu
+      run: >
+        echo "context=$(
+        curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+        python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+        )" >> $GITHUB_OUTPUT
+      shell: bash
+    - if: inputs.require_hst
+      run: if [[ ! -z "${{ steps.hst_crds.outputs.context }}" ]]; then echo ${{ steps.hst_crds.outputs.context }}; else exit 1; fi
+      shell: bash
+    - id: jwst_crds
+      env:
+        OBSERVATORY: jwst
+        CRDS_SERVER_URL: https://jwst-crds.stsci.edu
+      run: >
+        echo "context=$(
+        curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
+        python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+        )" >> $GITHUB_OUTPUT
+      shell: bash
+    - if: inputs.require_jwst
+      run: if [[ ! -z "${{ steps.jwst_crds.outputs.context }}" ]]; then echo ${{ steps.jwst_crds.outputs.context }}; else exit 1; fi
+      shell: bash
+    - id: roman_crds
+      env:
+        OBSERVATORY: roman
+        CRDS_SERVER_URL: https://roman-crds.stsci.edu
+      run: >
+        echo "context=$(
+        curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 |
+        python -c "import sys, json; print(json.load(sys.stdin)['result'])"
+        )" >> $GITHUB_OUTPUT
+      shell: bash
+    - if: inputs.require_roman
+      run: if [[ ! -z "${{ steps.roman_crds.outputs.context }}" ]]; then echo ${{ steps.roman_crds.outputs.context }}; else exit 1; fi
+      shell: bash
+
+outputs:
+  hst:
+    description: latest CRDS context for the Hubble Space Telescope
+    value: ${{ steps.hst_crds.outputs.context }}
+  jwst:
+    description: latest CRDS context for the James Webb Space Telescope
+    value: ${{ steps.jwst_crds.outputs.context }}
+  roman:
+    description: latest CRDS context for the Nancy Grace Roman Space Telescope
+    value: ${{ steps.roman_crds.outputs.context }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,10 +27,7 @@ defaults:
     shell: bash -leo pipefail {0} {0}
 
 jobs:
-  contexts:
-    uses: ./.github/workflows/contexts.yml
   cache:
-    needs: [ contexts ]
     name: download and cache CRDS test files
     runs-on: ubuntu-latest
     outputs:
@@ -41,8 +38,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: spacetelescope/crds
+      - id: contexts
+        uses: ./.github/actions/contexts
       - id: key
-        run: echo "key=test-cache-${{ needs.contexts.outputs.hst }}-${{ needs.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
+        run: echo "key=test-cache-${{ steps.contexts.outputs.hst }}-${{ steps.contexts.outputs.jwst }}" >> $GITHUB_OUTPUT
       - id: lookup-cache
         name: check for existence of combined CRDS cache (`${{ steps.key.outputs.key }}`)
         uses: actions/cache/restore@v5  # v4.0.2
@@ -69,18 +68,18 @@ jobs:
           mv crds-cache-test ${{ env.CRDS_TEST_ROOT }}
       - if: steps.lookup-combined-cache.outputs.cache-hit != 'true'
         id: retrieve-hst-cache
-        name: retrieve HST CRDS cache (`test-cache-${{ needs.contexts.outputs.hst }}`)
+        name: retrieve HST CRDS cache (`test-cache-${{ steps.contexts.outputs.hst }}`)
         uses: actions/cache@v5  # v4.0.2
         with:
           path: ${{ env.CRDS_PATH }}/**/hst*
-          key: test-cache-${{ needs.contexts.outputs.hst }}
+          key: test-cache-${{ steps.contexts.outputs.hst }}
       - if: steps.lookup-combined-cache.outputs.cache-hit != 'true'
         id: retrieve-jwst-cache
-        name: retrieve JWST CRDS cache (`test-cache-${{ needs.contexts.outputs.jwst }}`)
+        name: retrieve JWST CRDS cache (`test-cache-${{ steps.contexts.outputs.jwst }}`)
         uses: actions/cache@v5  # v4.0.2
         with:
           path: ${{ env.CRDS_PATH }}/**/jwst*
-          key: test-cache-${{ needs.contexts.outputs.jwst }}
+          key: test-cache-${{ steps.contexts.outputs.jwst }}
       - if: steps.lookup-cache.outputs.cache-hit != 'true'
         uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462  # v2.0.7
         with:

--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -1,3 +1,4 @@
+# TODO: deprecate this reusable workflow in favor of using the action
 name: contexts
 
 on:
@@ -20,44 +21,17 @@ jobs:
   contexts:
     name: retrieve latest CRDS contexts
     runs-on: ubuntu-latest
-    outputs:
-      hst: ${{ steps.hst_crds_context.outputs.pmap }}
-      jwst: ${{ steps.jwst_crds_context.outputs.pmap }}
-      roman: ${{ steps.roman_crds_context.outputs.pmap }}
     steps:
-      - id: hst_crds_context
-        if: ${{ contains(inputs.observatory, 'hst') }}
-        env:
-          OBSERVATORY: hst
-          CRDS_SERVER_URL: https://hst-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - if: ${{ contains(inputs.observatory, 'hst') }}
-        run: if [[ ! -z "${{ steps.hst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.hst_crds_context.outputs.pmap }}; else exit 1; fi
-      - id: jwst_crds_context
-        if: ${{ contains(inputs.observatory, 'jwst') }}
-        env:
-          OBSERVATORY: jwst
-          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 --connect-timeout 10 |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - if: ${{ contains(inputs.observatory, 'jwst') }}
-        run: if [[ ! -z "${{ steps.jwst_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.jwst_crds_context.outputs.pmap }}; else exit 1; fi
-      - id: roman_crds_context
-        if: ${{ contains(inputs.observatory, 'roman') }}
-        env:
-          OBSERVATORY: roman
-          CRDS_SERVER_URL: https://roman-crds.stsci.edu
-        run: >
-          echo "pmap=$(
-          curl -s -X POST -d '{"jsonrpc": "1.0", "method": "get_default_context", "params": ["${{ env.OBSERVATORY }}", "latest"], "id": 1}' ${{ env.CRDS_SERVER_URL }}/json/ --retry 8 |
-          python -c "import sys, json; print(json.load(sys.stdin)['result'])"
-          )" >> $GITHUB_OUTPUT
-      - if: ${{ contains(inputs.observatory, 'roman') }}
-        run: if [[ ! -z "${{ steps.roman_crds_context.outputs.pmap }}" ]]; then echo ${{ steps.roman_crds_context.outputs.pmap }}; else exit 1; fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: spacetelescope/crds
+      - id: contexts
+        uses: ./
+        with:
+          require_hst: ${{ contains(inputs.observatory, 'hst') }}
+          require_jwst: ${{ contains(inputs.observatory, 'jwst') }}
+          require_roman: ${{ contains(inputs.observatory, 'roman') }}
+    outputs:
+      hst: ${{ steps.contexts.outputs.hst }}
+      jwst: ${{ steps.contexts.outputs.jwst }}
+      roman: ${{ steps.contexts.outputs.roman }}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
getting the contexts probably should have been a simple action in the first place, instead of a reusable workflow. This change moves the context-grabbing stuff from `.github/workflows/contexts.yml` to `.github/actions/contexts/action.yml` (but keeps the reusable workflow so that downstream usage isn't affected until we can update it to the simpler method)

To migrate from using the reusable workflow to using the action (using `romancal` as an example):
https://github.com/spacetelescope/romancal/blob/26409040b8e777a633ae345281509397bdf22184/.github/workflows/tests.yml#L40-L51
```diff
-  latest_crds_contexts:
-    uses: spacetelescope/crds/.github/workflows/contexts.yml@main
-    with:
-      observatory: roman
   crds_context:
-    needs: [ latest_crds_contexts ]
     runs-on: ubuntu-latest
     steps:
+      - if: inputs.crds_context == ''
+        id: latest_context
+        uses: spacetelescope/crds/.github/actions/contexts@main
+        with:
+          require_roman: true
       - id: context
-        run: echo context=${{ github.event_name == 'workflow_dispatch' && (inputs.crds_context != '' && inputs.crds_context || needs.latest_crds_contexts.outputs.roman) || needs.latest_crds_contexts.outputs.roman }} >> $GITHUB_OUTPUT
+        run: echo context=${{ inputs.crds_context || steps.latest_context.outputs.roman }} >> $GITHUB_OUTPUT
   outputs:
     context: ${{ steps.context.outputs.context }}
```

Current downstream usages that point to `.github/workflows/contexts.yml`:
https://github.com/search?q=org%3Aspacetelescope%20uses%3A%20spacetelescope%2Fcrds%2F.github%2Fworkflows%2Fcontexts.yml&type=code
- `drizzlepac`
- `gwcs`
- `bench`
- `hubble_advanced_products`
- `romancal`
- `romanisim`
- `stenv`
- `roman_datamodels`
- `RegressionTests`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

