### PR TITLE
fix for #1207

### DIFF
--- a/.github/workflows/contexts.yml
+++ b/.github/workflows/contexts.yml
@@ -22,11 +22,8 @@ jobs:
     name: retrieve latest CRDS contexts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: spacetelescope/crds
       - id: contexts
-        uses: ./
+        uses: spacetelescope/crds/.github/actions/contexts@main
         with:
           require_hst: ${{ contains(inputs.observatory, 'hst') }}
           require_jwst: ${{ contains(inputs.observatory, 'jwst') }}


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
fixes downstream issue from #1207

<!-- describe the changes comprising this PR here -->
> Looks like this broke romancal CI?
> https://github.com/spacetelescope/romancal/pull/2219 is blocked since the CI won't start
> Can we revert this and make this change in a way that doesn't break downstream usage?

_Originally posted by @braingram in https://github.com/spacetelescope/crds/issues/1207#issuecomment-4568846550_
            
tested downstream with https://github.com/spacetelescope/romancal/pull/2349

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.hst.rst``: HST reference files
- ``changes/<PR#>.jwst.rst``: JWST reference files
- ``changes/<PR#>.roman.rst``: Roman reference files
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.testing.rst``: change to tests or test automation
- ``changes/<PR#>.general.rst``: infrastructure or miscellaneous change
</details>

